### PR TITLE
First sketch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,23 @@ You can run a model and get its output:
 ```python
 >>> import replicate
 
->>> replicate.run("bfirsh/resnet", input=open("mystery.jpg"))
+>>> model = replicate.models.get("bfirsh/resnet")
+>>> model.predict(open("mystery.jpg"))
 [('n02123597', 'Siamese_cat', 0.88293666), ('n02123394', 'Persian_cat', 0.09810519), ('n02123045', 'tabby', 0.0057580653)]
 ```
 
 You can run a model and feed the output into another model:
 
 ```python
->>> image = replicate.run("afiaka87/clip-guided-diffusion", prompt="avocado armchair")
->>> upscaled_image = replicate.run("jingyunliang/swinir", image=image)
+>>> image = replicate.models.get("afiaka87/clip-guided-diffusion".predict(prompt="avocado armchair")
+>>> upscaled_image = replicate.models.get("jingyunliang/swinir").predict(image=image)
 ```
 
 Run a model and get its output while it's running:
 
 ```python
-for image in replicate.run("pixray/text2image", prompt="san francisco sunset"):
+model = replicate.models.get("pixray/text2image")
+for image in model.predict(prompt="san francisco sunset"):
     display(image)
 ```
 
@@ -29,7 +31,9 @@ for image in replicate.run("pixray/text2image", prompt="san francisco sunset"):
 You can start a model and run it in the background:
 
 ```python
->>> prediction = replicate.predictions.create("kvfrans/clipdraw", prompt="Watercolor painting of an underwater submarine")
+>>> prediction = replicate.predictions.create(
+...    version="kvfrans/clipdraw",
+...    input={"prompt":"Watercolor painting of an underwater submarine"})
 
 >>> prediction
 <Prediction 38a73e57ddb9 on kvfrans/clipdraw:8b0ba5ab4d85>


### PR DESCRIPTION
[View the rendered markdown](https://github.com/replicate/replicate-python/tree/first-sketch)

🍐 @zeke 

An implementation of this: https://github.com/replicate/replicate-web/issues/1303

This is the process we're using to design this thing:

1. Build some things and come up with some needs
2. Sketch a readme, based on needs (readme driven design!)
3. Weave in architectural considerations: building Cog concepts/abstractions/objects, building on OpenAPI definitions in Cog and/or Replicate, polling, progressive output...
4. Build a prototype

These are the things we've built:
- https://github.com/replicate/replicate-discord-command
- https://github.com/replicate/clipdraw-interactive

The needs we extracted from this:
- Run a model and get its output
- Run a model and get its output while it's running
- Run a model and feed the output into another model
- Start a model and run it in the background
- List predictions you've run

This PR is part (2).

Some things @zeke and I talked about:

1. The tension between a high-level and low-level API. If we just had an API that mapped 1-1 with the REST API, that would be laborious and verbose to use. If we just had an API that let you run containers, then that would stop you from doing useful things (like running models in the background). We need several levels of abstraction to solve this, and there is some art to drawing the right line.
2. We might want a third level of API that maps 1-1 to the OpenAPI schema.
3. A lot of these problems are similar to Docker's Python library and this has been heavily inspired by https://docker-py.readthedocs.io/en/stable/
4. We need a verb for the "create a prediction and wait until its finished then return the output" function. We debated between the "predict" and "run". 
    - "Predict" is machine learning jargon and isn't particularly concrete. For somebody using Replicate who doesn't know much about machine learning it doesn't make much sense. But, it is the verb we use in Cog for both `cog predict` and `predict()`, and something we use internally.
    - "Run" is what we already use on the website, and is immediately understandable to somebody who doesn't know machine learning. Unfortunately, it is overloaded with `cog run`. If we were to have a symmetrical API in Cog, then we couldn't use `cog.run()`.
   