### PR TITLE
End wait if a prediction is canceled

### DIFF
--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -20,7 +20,7 @@ class Prediction(BaseModel):
 
     def wait(self):
         """Wait for prediction to finish."""
-        while self.status not in ["succeeded", "failed"]:
+        while self.status not in ["succeeded", "failed", "canceled"]:
             time.sleep(0.1)
             self.reload()
 


### PR DESCRIPTION
Signed-off-by: Mike Sheldon <mike@mikeasoft.com>

Currently, wait() will wait forever if a prediction is canceled by another thread/process. This PR simply adds "canceled" into the list of statuses that can end wait()