### PR TITLE
allow API host to be configured with an env var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
   - [Signing your work](#signing-your-work)
   - [How to sign off your commits](#how-to-sign-off-your-commits)
 - [Development](#development)
+    - [Environment variables](#environment-variables)
 - [Publishing a release](#publishing-a-release)
 
 ## Making a contribution
@@ -97,6 +98,11 @@ To install the package in development:
 ```sh
 pip install -e .
 ```
+
+### Environment variables
+
+- `REPLICATE_API_BASE_URL`: Defaults to `https://api.replicate.com` but can be overriden to point the client at a development host.
+- `REPLICATE_API_TOKEN`: Required. Find your token at https://replicate.com/#token
 
 ## Publishing a release
 

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 
 from replicate.model import ModelCollection
@@ -12,7 +13,9 @@ class Client:
         # Client is instantiated at import time, so do as little as possible.
         # This includes resolving environment variables -- they might be set programmatically.
         self.api_token = api_token
-        self.base_url = "https://api.replicate.com"
+        self.base_url = os.environ.get(
+            "REPLICATE_API_BASE_URL", "https://api.replicate.com"
+        )
 
         # TODO: make thread safe
         self.session = requests.Session()


### PR DESCRIPTION
This PR updates the client to look for the API's base URL in an environment variable, and default to the production host.

This will allow us to point clients at development hosts for testing.

This PR also documents the existing env vars the client supports.

Commits are significant.