### PR TITLE
Support list output

### DIFF
--- a/replicate/schema.py
+++ b/replicate/schema.py
@@ -1,0 +1,18 @@
+from packaging import version
+
+# TODO: this code is shared with replicate's backend. Maybe we should put it in the Cog Python package as the source of truth?
+
+
+def version_has_no_array_type(cog_version):
+    """Iterators have x-cog-array-type=iterator in the schema from 0.3.9 onward"""
+    return version.parse(cog_version) < version.parse("0.3.9")
+
+
+def make_schema_backwards_compatible(schema, version):
+    """A place to add backwards compatibility logic for our openapi schema"""
+    # If the top-level output is an array, assume it is an iterator in old versions which didn't have an array type
+    if version_has_no_array_type(version):
+        output = schema["components"]["schemas"]["Output"]
+        if output.get("type") == "array":
+            output["x-cog-array-type"] = "iterator"
+    return schema

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -9,13 +9,13 @@ def create_client():
     return client
 
 
-def create_version(client=None, openapi_schema=None):
+def create_version(client=None, openapi_schema=None, cog_version="0.3.0"):
     if client is None:
         client = create_client()
     version = Version(
         id="v1",
         created_at=datetime.datetime.now(),
-        cog_version="0.3.0",
+        cog_version=cog_version,
         openapi_schema=openapi_schema
         or {
             "info": {"title": "Cog", "version": "0.1.0"},
@@ -156,138 +156,31 @@ def create_version(client=None, openapi_schema=None):
 
 
 def create_version_with_iterator_output():
-    return create_version(
-        openapi_schema={
-            "info": {"title": "Cog", "version": "0.1.0"},
-            "paths": {
-                "/": {
-                    "get": {
-                        "summary": "Root",
-                        "responses": {
-                            "200": {
-                                "content": {"application/json": {"schema": {}}},
-                                "description": "Successful Response",
-                            }
-                        },
-                        "operationId": "root__get",
-                    }
-                },
-                "/predictions": {
-                    "post": {
-                        "summary": "Predict",
-                        "responses": {
-                            "200": {
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "$ref": "#/components/schemas/Response"
-                                        }
-                                    }
-                                },
-                                "description": "Successful Response",
-                            },
-                            "422": {
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "$ref": "#/components/schemas/HTTPValidationError"
-                                        }
-                                    }
-                                },
-                                "description": "Validation Error",
-                            },
-                        },
-                        "description": "Run a single prediction on the model.",
-                        "operationId": "predict_predictions_post",
-                        "requestBody": {
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/Request"}
-                                }
-                            }
-                        },
-                    }
-                },
-            },
-            "openapi": "3.0.2",
-            "components": {
-                "schemas": {
-                    "Input": {
-                        "type": "object",
-                        "title": "Input",
-                        "properties": {
-                            "prompts": {
-                                "type": "string",
-                                "title": "Prompts",
-                                "default": "Cairo skyline at sunset.",
-                                "x-order": 0,
-                                "description": "text prompt",
-                            },
-                        },
-                    },
-                    "Output": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "title": "Output",
-                    },
-                    "Status": {
-                        "enum": ["processing", "success", "failed"],
-                        "type": "string",
-                        "title": "Status",
-                        "description": "An enumeration.",
-                    },
-                    "Request": {
-                        "type": "object",
-                        "title": "Request",
-                        "properties": {
-                            "input": {"$ref": "#/components/schemas/Input"},
-                            "output_file_prefix": {
-                                "type": "string",
-                                "title": "Output File Prefix",
-                            },
-                        },
-                    },
-                    "Response": {
-                        "type": "object",
-                        "title": "Response",
-                        "required": ["status"],
-                        "properties": {
-                            "error": {"type": "string", "title": "Error"},
-                            "output": {"$ref": "#/components/schemas/Output"},
-                            "status": {"$ref": "#/components/schemas/Status"},
-                        },
-                        "description": "The status of a prediction.",
-                    },
-                    "ValidationError": {
-                        "type": "object",
-                        "title": "ValidationError",
-                        "required": ["loc", "msg", "type"],
-                        "properties": {
-                            "loc": {
-                                "type": "array",
-                                "items": {
-                                    "anyOf": [{"type": "string"}, {"type": "integer"}]
-                                },
-                                "title": "Location",
-                            },
-                            "msg": {"type": "string", "title": "Message"},
-                            "type": {"type": "string", "title": "Error Type"},
-                        },
-                    },
-                    "HTTPValidationError": {
-                        "type": "object",
-                        "title": "HTTPValidationError",
-                        "properties": {
-                            "detail": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/ValidationError"
-                                },
-                                "title": "Detail",
-                            }
-                        },
-                    },
-                }
-            },
-        }
-    )
+    version = create_version(cog_version="0.3.9")
+    version.openapi_schema["components"]["schemas"]["Output"] = {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Output",
+        "x-cog-array-type": "iterator",
+    }
+    return version
+
+
+def create_version_with_list_output():
+    version = create_version(cog_version="0.3.9")
+    version.openapi_schema["components"]["schemas"]["Output"] = {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Output",
+    }
+    return version
+
+
+def create_version_with_iterator_output_backwards_compatibility_0_3_8():
+    version = create_version(cog_version="0.3.8")
+    version.openapi_schema["components"]["schemas"]["Output"] = {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Output",
+    }
+    return version

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,7 +5,12 @@ import responses
 from replicate.exceptions import ModelError
 from responses import matchers
 
-from .factories import create_version, create_version_with_iterator_output
+from .factories import (
+    create_version,
+    create_version_with_iterator_output,
+    create_version_with_iterator_output_backwards_compatibility_0_3_8,
+    create_version_with_list_output,
+)
 
 
 @responses.activate
@@ -60,6 +65,106 @@ def test_predict():
 @responses.activate
 def test_predict_with_iterator():
     version = create_version_with_iterator_output()
+    responses.post(
+        "https://api.replicate.com/v1/predictions",
+        match=[
+            matchers.json_params_matcher({"version": "v1", "input": {"text": "world"}})
+        ],
+        json={
+            "id": "p1",
+            "version": "v1",
+            "urls": {
+                "get": "https://api.replicate.com/v1/predictions/p1",
+                "cancel": "https://api.replicate.com/v1/predictions/p1/cancel",
+            },
+            "created_at": "2022-04-26T20:00:40.658234Z",
+            "completed_at": "2022-04-26T20:02:27.648305Z",
+            "source": "api",
+            "status": "processing",
+            "input": {"text": "world"},
+            "output": None,
+            "error": None,
+            "logs": "",
+        },
+    )
+    responses.get(
+        "https://api.replicate.com/v1/predictions/p1",
+        json={
+            "id": "p1",
+            "version": "v1",
+            "urls": {
+                "get": "https://api.replicate.com/v1/predictions/p1",
+                "cancel": "https://api.replicate.com/v1/predictions/p1/cancel",
+            },
+            "created_at": "2022-04-26T20:00:40.658234Z",
+            "completed_at": "2022-04-26T20:02:27.648305Z",
+            "source": "api",
+            "status": "succeeded",
+            "input": {"text": "world"},
+            "output": ["hello world"],
+            "error": None,
+            "logs": "",
+        },
+    )
+
+    output = version.predict(text="world")
+    assert isinstance(output, Iterable)
+    assert list(output) == ["hello world"]
+
+
+@responses.activate
+def test_predict_with_list():
+    version = create_version_with_list_output()
+    responses.post(
+        "https://api.replicate.com/v1/predictions",
+        match=[
+            matchers.json_params_matcher({"version": "v1", "input": {"text": "world"}})
+        ],
+        json={
+            "id": "p1",
+            "version": "v1",
+            "urls": {
+                "get": "https://api.replicate.com/v1/predictions/p1",
+                "cancel": "https://api.replicate.com/v1/predictions/p1/cancel",
+            },
+            "created_at": "2022-04-26T20:00:40.658234Z",
+            "completed_at": "2022-04-26T20:02:27.648305Z",
+            "source": "api",
+            "status": "processing",
+            "input": {"text": "world"},
+            "output": None,
+            "error": None,
+            "logs": "",
+        },
+    )
+    responses.get(
+        "https://api.replicate.com/v1/predictions/p1",
+        json={
+            "id": "p1",
+            "version": "v1",
+            "urls": {
+                "get": "https://api.replicate.com/v1/predictions/p1",
+                "cancel": "https://api.replicate.com/v1/predictions/p1/cancel",
+            },
+            "created_at": "2022-04-26T20:00:40.658234Z",
+            "completed_at": "2022-04-26T20:02:27.648305Z",
+            "source": "api",
+            "status": "succeeded",
+            "input": {"text": "world"},
+            "output": ["hello world"],
+            "error": None,
+            "logs": "",
+        },
+    )
+
+    output = version.predict(text="world")
+    assert isinstance(output, list)
+    assert output == ["hello world"]
+
+
+@responses.activate
+def test_predict_with_iterator_backwards_compatibility_cog_0_3_8():
+    version = create_version_with_iterator_output_backwards_compatibility_0_3_8()
     responses.post(
         "https://api.replicate.com/v1/predictions",
         match=[


### PR DESCRIPTION
The counterpart to https://github.com/replicate/cog/pull/655

Backwards compatibility functions have been lifted from Replicate. Maybe
we should make Cog the source of truth for these...

Signed-off-by: Ben Firshman <ben@firshman.co.uk>
