### PR TITLE
Read files in output

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -176,6 +176,19 @@ def create_version_with_list_output():
     return version
 
 
+def create_version_with_file_output():
+    version = create_version(cog_version="0.3.9")
+    version.openapi_schema["components"]["schemas"]["Output"] = {
+        "type": "object",
+        "properties": {
+            "file": {"type": "string", "format": "uri"},
+            "text": {"type": "string"},
+        },
+        "title": "Output",
+    }
+    return version
+
+
 def create_version_with_iterator_output_backwards_compatibility_0_3_8():
     version = create_version(cog_version="0.3.8")
     version.openapi_schema["components"]["schemas"]["Output"] = {


### PR DESCRIPTION
Experimenting with opening files in output instead of just returning a URL. This is a breaking change to the API.

Perhaps we still need a way to read files as just a URL. There is no simple way to get the URL here and this will make an unnecessary HTTP request.

A couple of possible solutions:

1. We have an option to return URLs or file objects
2. We make a lazy wrapper file object that can return URLs or open the file. [Something like Django's file objects.](https://docs.djangoproject.com/en/4.0/ref/files/file/)