### PR TITLE
Add packaging dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
+packaging==21.3
 pytest==7.1.2
 responses==0.21.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(
     license="BSD",
     url="https://github.com/replicate/replicate-python",
     python_requires=">=3.6",
-    install_requires=["requests", "pydantic"],
+    install_requires=["requests", "pydantic", "packaging"],
     classifiers=[],
 )


### PR DESCRIPTION
In schema.py we call `from packaging import version`, which requires this package.