### PR TITLE
fix usage for pinned versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Python client for Replicate. It lets you run models from your Python code or Jupyter notebook, and do various other things on Replicate.
 
-Grab your token from [replicate.com/account](https://replicate.com/account) and authenticate by setting a it as an environment variable:
+Grab your token from [replicate.com/account](https://replicate.com/account) and authenticate by setting it as an environment variable:
 
 ```
 export REPLICATE_API_TOKEN=[token]

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ You can cancel a running prediction:
 'canceled'
 ```
 
-By default, `model.predict()` uses the latest version. If you want to pin to a particular version, you can get a version with its ID:
+By default, `model.predict()` uses the latest version. If you want to pin to a particular version, you can get a version with its ID, then call the `predict()` method on that version:
 
 ```
 >>> model = replicate.models.get("replicate/hello-world")
 >>> version = model.versions.get("5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa")
->>> model.predict(text="python")
+>>> version.predict(text="python")
 "hello python"
 ```
 


### PR DESCRIPTION
The README has a section for pinning versions, but the code snippet is incorrect: The predict method should be called on the version, not the model.