### PR TITLE
Lint Python sources with ruff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
           cache: "pip"
       - name: Install dependencies
         run: python -m pip install -r requirements.txt -r requirements-dev.txt .
+      - name: Lint
+        run: python -m ruff .
       - name: Test
         run: python -m pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ testpaths = "tests/"
 select = [
     "E", # pycodestyle error
     "F", # Pyflakes
+    "I", # isort
     "W", # pycodestyle warning
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,11 @@ testpaths = "tests/"
 
 [tool.ruff]
 select = [
-    "E", # pycodestyle error
-    "F", # Pyflakes
-    "I", # isort
-    "W", # pycodestyle warning
+    "E",  # pycodestyle error
+    "F",  # Pyflakes
+    "I",  # isort
+    "W",  # pycodestyle warning
+    "UP", # pyupgrade
 ]
 ignore = [
     "E501", # Line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ repository = "https://github.com/replicate/replicate-python"
 testpaths = "tests/"
 
 [tool.ruff]
+select = [
+    "E", # pycodestyle error
+    "F", # Pyflakes
+    "W", # pycodestyle warning
+]
 ignore = [
     "E501", # Line too long
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,18 @@ testpaths = "tests/"
 
 [tool.ruff]
 select = [
-    "E",  # pycodestyle error
-    "F",  # Pyflakes
-    "I",  # isort
-    "W",  # pycodestyle warning
-    "UP", # pyupgrade
+    "E",   # pycodestyle error
+    "F",   # Pyflakes
+    "I",   # isort
+    "W",   # pycodestyle warning
+    "UP",  # pyupgrade
+    "S",   # flake8-bandit
+    "BLE", # flake8-blind-except
 ]
 ignore = [
     "E501", # Line too long
+    "S113", # Probable use of requests call without timeout
 ]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101", "S106"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { file = "LICENSE" }
 authors = [{ name = "Replicate, Inc." }]
 requires-python = ">=3.8"
 dependencies = ["packaging", "pydantic>1", "requests>2"]
-optional-dependencies = { dev = ["black", "pytest", "responses"] }
+optional-dependencies = { dev = ["black", "pytest", "responses", "ruff"] }
 
 [project.urls]
 homepage = "https://replicate.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ select = [
     "S",   # flake8-bandit
     "BLE", # flake8-blind-except
     "FBT", # flake8-boolean-trap
+    "B",   # flake8-bugbear
 ]
 ignore = [
     "E501", # Line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ select = [
     "UP",  # pyupgrade
     "S",   # flake8-bandit
     "BLE", # flake8-blind-except
+    "FBT", # flake8-boolean-trap
 ]
 ignore = [
     "E501", # Line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,8 @@ repository = "https://github.com/replicate/replicate-python"
 
 [tool.pytest.ini_options]
 testpaths = "tests/"
+
+[tool.ruff]
+ignore = [
+    "E501", # Line too long
+]

--- a/replicate/base_model.py
+++ b/replicate/base_model.py
@@ -1,6 +1,6 @@
 from typing import ForwardRef
-import pydantic
 
+import pydantic
 
 Client = ForwardRef("Client")
 Collection = ForwardRef("Collection")

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -35,4 +35,4 @@ class Collection:
             model._collection = self
             return model
         else:
-            raise Exception("Can't create %s from %s" % (self.model.__name__, attrs))
+            raise Exception(f"Can't create {self.model.__name__} from {attrs}")

--- a/replicate/files.py
+++ b/replicate/files.py
@@ -15,7 +15,7 @@ def upload_file(fh: io.IOBase, output_file_prefix: str = None) -> str:
     if output_file_prefix is not None:
         name = getattr(fh, "name", "output")
         url = output_file_prefix + os.path.basename(name)
-        resp = requests.put(url, files={"file": fh})
+        resp = requests.put(url, files={"file": fh}, timeout=None)
         resp.raise_for_status()
         return url
 

--- a/replicate/json.py
+++ b/replicate/json.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from types import GeneratorType
 from typing import Any, Callable
 
-
 try:
     import numpy as np  # type: ignore
 

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
@@ -12,7 +11,7 @@ class Model(BaseModel):
 
     def predict(self, *args, **kwargs):
         raise ReplicateException(
-            f"The `model.predict()` method has been removed, because it's unstable: if a new version of the model you're using is pushed and its API has changed, your code may break. Use `version.predict()` instead. See https://github.com/replicate/replicate-python#readme"
+            "The `model.predict()` method has been removed, because it's unstable: if a new version of the model you're using is pushed and its API has changed, your code may break. Use `version.predict()` instead. See https://github.com/replicate/replicate-python#readme"
         )
 
     @property

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,4 +1,3 @@
-
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
 from replicate.exceptions import ReplicateException

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
-from replicate.exceptions import ModelError, ReplicateException
+from replicate.exceptions import ModelError
 from replicate.files import upload_file
 from replicate.json import encode_json
 from replicate.version import Version
@@ -92,7 +92,7 @@ class PredictionCollection(Collection):
         return self.prepare_model(obj)
 
     def list(self) -> List[Prediction]:
-        resp = self._client._request("GET", f"/v1/predictions")
+        resp = self._client._request("GET", "/v1/predictions")
         # TODO: paginate
         predictions = resp.json()["results"]
         for prediction in predictions:

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -1,13 +1,11 @@
 import re
-import time
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, List, Optional
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
-from replicate.exceptions import ModelError, ReplicateException
+from replicate.exceptions import ReplicateException
 from replicate.files import upload_file
 from replicate.json import encode_json
-from replicate.version import Version
 
 
 class Training(BaseModel):
@@ -55,7 +53,7 @@ class TrainingCollection(Collection):
         )
         if not match:
             raise ReplicateException(
-                f"version must be in format username/model_name:version_id"
+                "version must be in format username/model_name:version_id"
             )
         username = match.group("username")
         model_name = match.group("model_name")

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -18,6 +18,7 @@ class Version(BaseModel):
         warnings.warn(
             "version.predict() is deprecated. Use replicate.run() instead. It will be removed before version 1.0.",
             DeprecationWarning,
+            stacklevel=1,
         )
 
         prediction = self._client.predictions.create(version=self, input=kwargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -43,6 +43,8 @@ requests==2.28.2
     #   responses
 responses==0.23.1
     # via replicate (pyproject.toml)
+ruff==0.0.261
+    # via replicate (pyproject.toml)
 types-pyyaml==6.0.12.9
     # via responses
 typing-extensions==4.5.0

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -1,7 +1,6 @@
 import responses
 from responses import matchers
 
-
 from .factories import create_client, create_version
 
 

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -1,7 +1,6 @@
 import responses
 from responses import matchers
 
-import replicate
 
 from .factories import create_client, create_version
 
@@ -41,7 +40,7 @@ def test_create_works_with_webhooks():
         },
     )
 
-    prediction = client.predictions.create(
+    client.predictions.create(
         version=version,
         input={"text": "world"},
         webhook="https://example.com/webhook",
@@ -156,8 +155,8 @@ def test_async_timings():
     )
 
     assert prediction.created_at == "2022-04-26T20:00:40.658234Z"
-    assert prediction.completed_at == None
-    assert prediction.output == None
+    assert prediction.completed_at is None
+    assert prediction.output is None
     prediction.wait()
     assert prediction.created_at == "2022-04-26T20:00:40.658234Z"
     assert prediction.completed_at == "2022-04-26T20:02:27.648305Z"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,8 +2,9 @@ from collections.abc import Iterable
 
 import pytest
 import responses
-from replicate.exceptions import ModelError
 from responses import matchers
+
+from replicate.exceptions import ModelError
 
 from .factories import (
     create_version,


### PR DESCRIPTION
Depends on #84

This PR adds [ruff](https://beta.ruff.rs/docs/) as a dev dependency to lint Python sources. It enables a handful of checks and fixes resulting violations. Additional checks like `ANN` for type annotations will be more involved, and can be taken in separate PRs.

