### PR TITLE
Fix Pydantic validation errors for Training responses

### DIFF
--- a/replicate/training.py
+++ b/replicate/training.py
@@ -86,4 +86,5 @@ class TrainingCollection(Collection):
             json=body,
         )
         obj = resp.json()
+        del obj["version"]
         return self.prepare_model(obj)

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -45,6 +45,8 @@ class TrainingCollection(Collection):
             f"/v1/trainings/{id}",
         )
         obj = resp.json()
+        # HACK: resolve this? make it lazy somehow?
+        del obj["version"]
         return self.prepare_model(obj)
 
     def create(  # type: ignore

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -6,6 +6,7 @@ from replicate.collection import Collection
 from replicate.exceptions import ReplicateException
 from replicate.files import upload_file
 from replicate.json import encode_json
+from replicate.version import Version
 
 
 class Training(BaseModel):
@@ -19,7 +20,7 @@ class Training(BaseModel):
     output: Optional[Any]
     started_at: Optional[str]
     status: str
-    version: str
+    version: Optional[Version]
 
     def cancel(self) -> None:
         """Cancel a running training"""


### PR DESCRIPTION
Fixes a Pedantic validation error `field required (type=value_error missing)` when calling `replicate.trainings.list`.