### PR TITLE
Update release workflow to build source and binary distributions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,18 +16,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install pypa/build
-        run: >-
-          python -m
-          pip install
-          build
-          --user
+        run: python -m pip install build --user
       - name: Build a package
-        run: >-
-          python -m
-          build
-          --sdist
-          --outdir dist/
-          .
+        run: python -m build
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Resolves #81

The current release workflow builds the Python package for distribution using the following command:

```console
python -m build --sdist --outdir dist .
```

Looking at the help text for the command, the default behavior is to build both source and binary distribution. By specifying `--sdist`, we're opting out of a binary distribution, so we can remove it to opt back into that behavior. 

Going a step further, the default options use `dist` as an output directory, use the current directory as the source directory, and build source and binary distribution, which is what we're already doing. So we can get the desired behavior by running without any additional options:

```console
python -m build
```