### PR TITLE
Adopt `<product>/<version>` convention for `User-Agent` header

### DIFF
--- a/replicate/client.py
+++ b/replicate/client.py
@@ -84,7 +84,7 @@ class Client:
     def _headers(self) -> Dict[str, str]:
         return {
             "Authorization": f"Token {self._api_token()}",
-            "User-Agent": f"replicate-python@{__version__}",
+            "User-Agent": f"replicate-python/{__version__}",
         }
 
     def _api_token(self) -> str:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,7 +25,7 @@ def test_client_sets_authorization_token_and_user_agent_headers():
         "https://api.replicate.com/v1/models/test/model/versions",
         match=[
             matchers.header_matcher({"Authorization": "Token abc123"}),
-            matchers.header_matcher({"User-Agent": f"replicate-python@{__version__}"}),
+            matchers.header_matcher({"User-Agent": f"replicate-python/{__version__}"}),
         ],
         json={"results": []},
     )


### PR DESCRIPTION
Currently, the client sends a `User-Agent` header in the form `replicate-python@<version>`. This PR changes it to `replicate-python/<version>` so that it's more in line with the standard convention [^1].

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent