### PR TITLE
Fix Prediction.output_iterator

### DIFF
--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -33,8 +33,7 @@ class Prediction(BaseModel):
         while self.status not in ["succeeded", "failed", "canceled"]:
             output = self.output or []
             new_output = output[len(previous_output) :]
-            for output in new_output:
-                yield output
+            yield from new_output
             previous_output = output
             time.sleep(self._client.poll_interval)
             self.reload()


### PR DESCRIPTION
The `output` variable is shadowed by the yielding loop, so when we hit the line:

    previous_output = output

the value of `output` refers to the last value of `output` from the loop above, not the total output we received. That causes the client to shrink the output down to a single string (which, inconveniently, also is a valid argument to `len()`), which means we take the wrong slice of the output the next time through the loop.