### PR TITLE
Require pydantic 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Replicate, Inc." }]
 requires-python = ">=3.8"
-dependencies = ["packaging", "pydantic>1", "requests>2"]
+dependencies = ["packaging", "pydantic>1,<2", "requests>2"]
 optional-dependencies = { dev = [
     "black",
     "mypy",


### PR DESCRIPTION
Resolves #112

[Pydantic 2.0](https://pypi.org/project/pydantic/2.0/) was released a few days ago, with breaking changes for this library.

This PR updates the dependency requirements for this package to disallow pydantic>=2. This provides a short-term fix that will be pushed out in a patch version.

In the longer term, my intention is to update this library to support both 1.x and 2.x.