### PR TITLE
Work with both Pydantic 1 and 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Replicate, Inc." }]
 requires-python = ">=3.8"
-dependencies = ["packaging", "pydantic>1,<2", "requests>2"]
+dependencies = ["packaging", "pydantic>1", "requests>2"]
 optional-dependencies = { dev = [
     "black",
     "mypy",

--- a/replicate/base_model.py
+++ b/replicate/base_model.py
@@ -4,7 +4,10 @@ if TYPE_CHECKING:
     from replicate.client import Client
     from replicate.collection import Collection
 
-import pydantic
+try:
+    from pydantic import v1 as pydantic
+except ImportError:
+    import pydantic
 
 
 class BaseModel(pydantic.BaseModel):

--- a/replicate/base_model.py
+++ b/replicate/base_model.py
@@ -5,9 +5,9 @@ if TYPE_CHECKING:
     from replicate.collection import Collection
 
 try:
-    from pydantic import v1 as pydantic
+    from pydantic import v1 as pydantic  # type: ignore
 except ImportError:
-    import pydantic
+    import pydantic  # type: ignore
 
 
 class BaseModel(pydantic.BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ idna==3.4
     # via requests
 packaging==23.0
     # via replicate (pyproject.toml)
-pydantic==1.10.7
+pydantic>=1.10.7
     # via replicate (pyproject.toml)
 requests==2.31.0
     # via replicate (pyproject.toml)


### PR DESCRIPTION
Refs:
- https://github.com/replicate/replicate-python/issues/112

My [LLM](https://llm.datasette.io/) project uses Pydantic 2 and I want to build a plugin for it ([llm-replicate](https://github.com/simonw/llm-replicate)) that adds support for querying Replicate models - but I can't do that easily if Replicate is pinned to Pydantic 1.0.

It looks like it's possible to support both using this idiom:
```python
try:
    from pydantic import v1 as pydantic
except ImportError:
    import pydantic
```
Since 2.0 introduced a `v1` backwards compatibility shim.