### PR TITLE
Add packaging type information to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ repository = "https://github.com/replicate/replicate-python"
 [tool.pytest.ini_options]
 testpaths = "tests/"
 
+[tool.setuptools.package-data]
+"replicate" = ["py.typed"]
+
 [tool.ruff]
 select = [
     "E",   # pycodestyle error


### PR DESCRIPTION
Resolves #124 

This PR adds `py.typed` to the [setuptools package data](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data) for the package into `pyproject.toml`.

```toml
[tool.setuptools.package-data]
replicate = ["py.typed"]
```

My understanding is that this should denote the package as being ["typed" on PyPI](https://pypi.org/search/?c=Typing+%3A%3A+Typed).

For more information, see [PEP 561 – Distributing and Packaging Type Information](https://peps.python.org/pep-0561/#packaging-type-information).