### PR TITLE
Add `urls` property to `Prediction` and `Training` models

### DIFF
--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -20,6 +20,7 @@ class Prediction(BaseModel):
     started_at: Optional[str]
     created_at: Optional[str]
     completed_at: Optional[str]
+    urls: Optional[Dict[str, str]]
 
     def wait(self) -> None:
         """Wait for prediction to finish."""

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -156,6 +156,7 @@ def test_async_timings():
     assert prediction.created_at == "2022-04-26T20:00:40.658234Z"
     assert prediction.completed_at is None
     assert prediction.output is None
+    assert prediction.urls["get"] == "https://api.replicate.com/v1/predictions/p1"
     prediction.wait()
     assert prediction.created_at == "2022-04-26T20:00:40.658234Z"
     assert prediction.completed_at == "2022-04-26T20:02:27.648305Z"


### PR DESCRIPTION
Replicate's API provides a [`urls` field](https://replicate.com/docs/reference/http#predictions.get) in responses for predictions and trainings. This PR adds this property to the corresponding models.