### PR TITLE
Update deprecation warnings for `Model.predict` and `Version.predict`

### DIFF
--- a/replicate/model.py
+++ b/replicate/model.py
@@ -23,11 +23,11 @@ class Model(BaseModel):
 
     def predict(self, *args, **kwargs) -> None:
         """
-        DEPRECATED: Use `version.predict()` instead.
+        DEPRECATED: Use `replicate.run()` instead.
         """
 
         raise ReplicateException(
-            "The `model.predict()` method has been removed, because it's unstable: if a new version of the model you're using is pushed and its API has changed, your code may break. Use `version.predict()` instead. See https://github.com/replicate/replicate-python#readme"
+            "The `model.predict()` method has been removed, because it's unstable: if a new version of the model you're using is pushed and its API has changed, your code may break. Use `replicate.run()` instead. See https://github.com/replicate/replicate-python#readme"
         )
 
     @property

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -32,6 +32,8 @@ class Version(BaseModel):
 
     def predict(self, **kwargs) -> Union[Any, Iterator[Any]]:
         """
+        DEPRECATED: Use `replicate.run()` instead.
+
         Create a prediction using this model version.
 
         Args:


### PR DESCRIPTION
`Model.predict` was removed in #71. It points users to `Version.predict`, but that method was deprecated in favor of `replicate.run` in #79.

This PR updates the deprecation warnings accordingly.