### PR TITLE
Add `progress` property to `Prediction`

### DIFF
--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -75,6 +75,8 @@ class Prediction(BaseModel):
 
         @classmethod
         def parse(cls, logs: str) -> Optional["Prediction.Progress"]:
+            """Parse the progress from the logs of a prediction."""
+
             lines = logs.split("\n")
             for i in reversed(range(len(lines))):
                 line = lines[i].strip()


### PR DESCRIPTION
Resolves #152 

When a prediction is running, models log progress in a predictable format. By parsing these log lines, we can get a structured representation of the current number of items processed, the total number, and the percentage completed.

This PR defines a `Prediction.Progress` dataclass and a `progress` property on `Prediction` that returns an optional value of that type.