### PR TITLE
Add support for `models.get` and `models.list` endpoints

### DIFF
--- a/replicate/model.py
+++ b/replicate/model.py
@@ -110,7 +110,17 @@ class ModelCollection(Collection):
     model = Model
 
     def list(self) -> List[Model]:
-        raise NotImplementedError()
+        """
+        List all public models.
+
+        Returns:
+            A list of models.
+        """
+
+        resp = self._client._request("GET", "/v1/models")
+        # TODO: paginate
+        models = resp.json()["results"]
+        return [self.prepare_model(obj) for obj in models]
 
     def get(self, key: str) -> Model:
         """

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,9 +1,12 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
+
+from typing_extensions import deprecated
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
 from replicate.exceptions import ReplicateException
-from replicate.version import VersionCollection
+from replicate.prediction import Prediction
+from replicate.version import Version, VersionCollection
 
 
 class Model(BaseModel):
@@ -11,15 +14,79 @@ class Model(BaseModel):
     A machine learning model hosted on Replicate.
     """
 
-    username: str
+    url: str
     """
-    The name of the user or organization that owns the model.
+    The URL of the model.
+    """
+
+    owner: str
+    """
+    The owner of the model.
     """
 
     name: str
     """
     The name of the model.
     """
+
+    description: Optional[str]
+    """
+    The description of the model.
+    """
+
+    visibility: str
+    """
+    The visibility of the model. Can be 'public' or 'private'.
+    """
+
+    github_url: Optional[str]
+    """
+    The GitHub URL of the model.
+    """
+
+    paper_url: Optional[str]
+    """
+    The URL of the paper related to the model.
+    """
+
+    license_url: Optional[str]
+    """
+    The URL of the license for the model.
+    """
+
+    run_count: int
+    """
+    The number of runs of the model.
+    """
+
+    cover_image_url: Optional[str]
+    """
+    The URL of the cover image for the model.
+    """
+
+    default_example: Optional[Prediction]
+    """
+    The default example of the model.
+    """
+
+    latest_version: Optional[Version]
+    """
+    The latest version of the model.
+    """
+
+    @property
+    @deprecated("Use `model.owner` instead.")
+    def username(self) -> str:
+        """
+        The name of the user or organization that owns the model.
+        This attribute is deprecated and will be removed in future versions.
+        """
+        return self.owner
+
+    @username.setter
+    @deprecated("Use `model.owner` instead.")
+    def username(self, value: str) -> None:
+        self.owner = value
 
     def predict(self, *args, **kwargs) -> None:
         """
@@ -45,27 +112,33 @@ class ModelCollection(Collection):
     def list(self) -> List[Model]:
         raise NotImplementedError()
 
-    def get(self, name: str) -> Model:
+    def get(self, key: str) -> Model:
         """
         Get a model by name.
 
         Args:
-            name: The name of the model, in the format `owner/model-name`.
+            key: The qualified name of the model, in the format `owner/model-name`.
         Returns:
             The model.
         """
 
-        # TODO: fetch model from server
-        # TODO: support permanent IDs
-        username, name = name.split("/")
-        return self.prepare_model({"username": username, "name": name})
+        resp = self._client._request("GET", f"/v1/models/{key}")
+        return self.prepare_model(resp.json())
 
     def create(self, **kwargs) -> Model:
         raise NotImplementedError()
 
     def prepare_model(self, attrs: Union[Model, Dict]) -> Model:
-        if isinstance(attrs, BaseModel):
-            attrs.id = f"{attrs.username}/{attrs.name}"
-        elif isinstance(attrs, dict):
-            attrs["id"] = f"{attrs['username']}/{attrs['name']}"
-        return super().prepare_model(attrs)
+        attrs["id"] = f"{attrs['owner']}/{attrs['name']}"
+
+        attrs.get("default_example", {}).pop("version", None)
+
+        model = super().prepare_model(attrs)
+
+        if model.default_example is not None:
+            model.default_example._client = self._client
+
+        if model.latest_version is not None:
+            model.latest_version._client = self._client
+
+        return model

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -139,9 +139,11 @@ class ModelCollection(Collection):
         raise NotImplementedError()
 
     def prepare_model(self, attrs: Union[Model, Dict]) -> Model:
-        attrs["id"] = f"{attrs['owner']}/{attrs['name']}"
-
-        attrs.get("default_example", {}).pop("version", None)
+        if isinstance(attrs, BaseModel):
+            attrs.id = f"{attrs.owner}/{attrs.name}"
+        elif isinstance(attrs, dict):
+            attrs["id"] = f"{attrs['owner']}/{attrs['name']}"
+            attrs.get("default_example", {}).pop("version", None)
 
         model = super().prepare_model(attrs)
 

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -1,7 +1,7 @@
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
@@ -169,7 +169,7 @@ class PredictionCollection(Collection):
 
     def create(  # type: ignore
         self,
-        version: Version | str,
+        version: Union[Version, str],
         input: Dict[str, Any],
         webhook: Optional[str] = None,
         webhook_completed: Optional[str] = None,

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -169,7 +169,7 @@ class PredictionCollection(Collection):
 
     def create(  # type: ignore
         self,
-        version: Version,
+        version: Version | str,
         input: Dict[str, Any],
         webhook: Optional[str] = None,
         webhook_completed: Optional[str] = None,
@@ -195,7 +195,7 @@ class PredictionCollection(Collection):
 
         input = encode_json(input, upload_file=upload_file)
         body = {
-            "version": version.id,
+            "version": version if isinstance(version, str) else version.id,
             "input": input,
         }
         if webhook is not None:
@@ -213,5 +213,9 @@ class PredictionCollection(Collection):
             json=body,
         )
         obj = resp.json()
-        obj["version"] = version
+        if isinstance(version, Version):
+            obj["version"] = version
+        else:
+            del obj["version"]
+
         return self.prepare_model(obj)

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -87,7 +87,7 @@ class VersionCollection(Collection):
             The model version.
         """
         resp = self._client._request(
-            "GET", f"/v1/models/{self._model.username}/{self._model.name}/versions/{id}"
+            "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions/{id}"
         )
         return self.prepare_model(resp.json())
 
@@ -102,6 +102,6 @@ class VersionCollection(Collection):
             List[Version]: A list of version objects.
         """
         resp = self._client._request(
-            "GET", f"/v1/models/{self._model.username}/{self._model.name}/versions"
+            "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions"
         )
         return [self.prepare_model(obj) for obj in resp.json()["results"]]

--- a/tests/cassettes/test_models_get.yaml
+++ b/tests/cassettes/test_models_get.yaml
@@ -1,0 +1,180 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.13.0
+    method: GET
+    uri: https://api.replicate.com/v1/models/stability-ai/sdxl
+  response:
+    content: "{\"url\":\"https://replicate.com/stability-ai/sdxl\",\"owner\":\"stability-ai\",\"name\":\"sdxl\",\"description\":\"A
+      text-to-image generative AI model that creates beautiful 1024x1024 images\",\"visibility\":\"public\",\"github_url\":\"https://github.com/replicate/cog-sdxl\",\"paper_url\":\"https://arxiv.org/abs/2307.01952\",\"license_url\":\"https://github.com/Stability-AI/generative-models/blob/main/model_licenses/LICENSE-SDXL1.0\",\"run_count\":6465507,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/61004930-fb88-4e09-9bd4-74fd8b4aa677/sdxl_cover.png\",\"default_example\":{\"completed_at\":\"2023-07-26T21:04:37.933562Z\",\"created_at\":\"2023-07-26T21:04:23.762683Z\",\"error\":null,\"id\":\"vu42q7dbkm6iicbpal4v6uvbqm\",\"input\":{\"width\":1024,\"height\":1024,\"prompt\":\"An
+      astronaut riding a rainbow unicorn, cinematic, dramatic\",\"refine\":\"expert_ensemble_refiner\",\"scheduler\":\"DDIM\",\"num_outputs\":1,\"guidance_scale\":7.5,\"high_noise_frac\":0.8,\"prompt_strength\":0.8,\"num_inference_steps\":50},\"logs\":\"Using
+      seed: 12103\\ntxt2img mode\\n  0%|          | 0/40 [00:00<?, ?it/s]\\n  2%|\u258E
+      \        | 1/40 [00:00<00:34,  1.14it/s]\\n  5%|\u258C         | 2/40 [00:01<00:18,
+      \ 2.10it/s]\\n  8%|\u258A         | 3/40 [00:01<00:12,  2.86it/s]\\n 10%|\u2588
+      \        | 4/40 [00:01<00:10,  3.44it/s]\\n 12%|\u2588\u258E        | 5/40 [00:01<00:09,
+      \ 3.87it/s]\\n 15%|\u2588\u258C        | 6/40 [00:01<00:08,  4.19it/s]\\n 18%|\u2588\u258A
+      \       | 7/40 [00:02<00:07,  4.43it/s]\\n 20%|\u2588\u2588        | 8/40 [00:02<00:06,
+      \ 4.60it/s]\\n 22%|\u2588\u2588\u258E       | 9/40 [00:02<00:06,  4.72it/s]\\n
+      25%|\u2588\u2588\u258C       | 10/40 [00:02<00:06,  4.80it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 11/40 [00:02<00:05,  4.86it/s]\\n 30%|\u2588\u2588\u2588       | 12/40
+      [00:03<00:05,  4.90it/s]\\n 32%|\u2588\u2588\u2588\u258E      | 13/40 [00:03<00:05,
+      \ 4.93it/s]\\n 35%|\u2588\u2588\u2588\u258C      | 14/40 [00:03<00:05,  4.95it/s]\\n
+      38%|\u2588\u2588\u2588\u258A      | 15/40 [00:03<00:05,  4.97it/s]\\n 40%|\u2588\u2588\u2588\u2588
+      \     | 16/40 [00:03<00:04,  4.99it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258E
+      \    | 17/40 [00:04<00:04,  5.00it/s]\\n 45%|\u2588\u2588\u2588\u2588\u258C
+      \    | 18/40 [00:04<00:04,  5.02it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A
+      \    | 19/40 [00:04<00:04,  5.02it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 20/40 [00:04<00:03,  5.03it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258E
+      \   | 21/40 [00:04<00:03,  5.03it/s]\\n 55%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 22/40 [00:05<00:03,  5.03it/s]\\n 57%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 23/40 [00:05<00:03,  5.03it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 24/40 [00:05<00:03,  5.04it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      \  | 25/40 [00:05<00:02,  5.05it/s]\\n 65%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 26/40 [00:05<00:02,  5.04it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 27/40 [00:06<00:02,  5.03it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 28/40 [00:06<00:02,  5.03it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      \ | 29/40 [00:06<00:02,  5.03it/s]\\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 30/40 [00:06<00:01,  5.04it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 31/40 [00:06<00:01,  5.03it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 32/40 [00:07<00:01,  5.02it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 33/40 [00:07<00:01,  5.02it/s]\\n 85%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 34/40 [00:07<00:01,  5.02it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 35/40 [00:07<00:00,  5.03it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 36/40 [00:07<00:00,  5.03it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      37/40 [00:08<00:00,  5.02it/s]\\n 95%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      38/40 [00:08<00:00,  5.02it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      39/40 [00:08<00:00,  5.02it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      40/40 [00:08<00:00,  5.02it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      40/40 [00:08<00:00,  4.63it/s]\\n  0%|          | 0/10 [00:00<?, ?it/s]\\n 10%|\u2588
+      \        | 1/10 [00:00<00:02,  4.24it/s]\\n 20%|\u2588\u2588        | 2/10 [00:00<00:01,
+      \ 4.33it/s]\\n 30%|\u2588\u2588\u2588       | 3/10 [00:00<00:01,  4.36it/s]\\n
+      40%|\u2588\u2588\u2588\u2588      | 4/10 [00:00<00:01,  4.37it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 5/10 [00:01<00:01,  4.37it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 6/10 [00:01<00:00,  4.38it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 7/10 [00:01<00:00,  4.38it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 8/10 [00:01<00:00,  4.39it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 9/10 [00:02<00:00,  4.37it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      10/10 [00:02<00:00,  4.37it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      10/10 [00:02<00:00,  4.37it/s]\",\"metrics\":{\"predict_time\":14.149563},\"output\":[\"https://replicate.delivery/pbxt/E6Ftpfi0dF1SOi4b6ltUwsfdxUf7zTQSfdhmJfRcfGTdZ88UE/out-0.png\"],\"started_at\":\"2023-07-26T21:04:23.783999Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/vu42q7dbkm6iicbpal4v6uvbqm\",\"cancel\":\"https://api.replicate.com/v1/predictions/vu42q7dbkm6iicbpal4v6uvbqm/cancel\"},\"version\":\"2f779eb9b23b34fe171f8eaa021b8261566f0d2c10cd2674063e7dbcd351509e\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"1bfb924045802467cf8869d96b231a12e6aa994abfe37e337c63a4e49a8c6c41\",\"created_at\":\"2023-10-02T19:04:28.929589Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"mask\":{\"type\":\"string\",\"title\":\"Mask\",\"format\":\"uri\",\"x-order\":3,\"description\":\"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted.\"},\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":11,\"description\":\"Random
+      seed. Leave blank to randomize the seed\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":2,\"description\":\"Input
+      image for img2img or inpaint mode\"},\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"default\":1024,\"x-order\":4,\"description\":\"Width
+      of output image\"},\"height\":{\"type\":\"integer\",\"title\":\"Height\",\"default\":1024,\"x-order\":5,\"description\":\"Height
+      of output image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"An
+      astronaut riding a rainbow unicorn\",\"x-order\":0,\"description\":\"Input prompt\"},\"refine\":{\"allOf\":[{\"$ref\":\"#/components/schemas/refine\"}],\"default\":\"no_refiner\",\"x-order\":12,\"description\":\"Which
+      refine style to use\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER\",\"x-order\":7,\"description\":\"scheduler\"},\"lora_scale\":{\"type\":\"number\",\"title\":\"Lora
+      Scale\",\"default\":0.6,\"maximum\":1,\"minimum\":0,\"x-order\":16,\"description\":\"LoRA
+      additive scale. Only applicable on trained models.\"},\"num_outputs\":{\"type\":\"integer\",\"title\":\"Num
+      Outputs\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Number
+      of images to output.\"},\"refine_steps\":{\"type\":\"integer\",\"title\":\"Refine
+      Steps\",\"x-order\":14,\"description\":\"For base_image_refiner, the number
+      of steps to refine, defaults to num_inference_steps\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":50,\"minimum\":1,\"x-order\":9,\"description\":\"Scale
+      for classifier-free guidance\"},\"apply_watermark\":{\"type\":\"boolean\",\"title\":\"Apply
+      Watermark\",\"default\":true,\"x-order\":15,\"description\":\"Applies a watermark
+      to enable determining if an image is generated in downstream applications. If
+      you have other provisions for generating or deploying images safely, you can
+      use this to disable watermarking.\"},\"high_noise_frac\":{\"type\":\"number\",\"title\":\"High
+      Noise Frac\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":13,\"description\":\"For
+      expert_ensemble_refiner, the fraction of noise to use\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"\",\"x-order\":1,\"description\":\"Input Negative Prompt\"},\"prompt_strength\":{\"type\":\"number\",\"title\":\"Prompt
+      Strength\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":10,\"description\":\"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image\"},\"replicate_weights\":{\"type\":\"string\",\"title\":\"Replicate
+      Weights\",\"x-order\":17,\"description\":\"Replicate LoRA weights to use. Leave
+      blank to use the default weights.\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":50,\"maximum\":500,\"minimum\":1,\"x-order\":8,\"description\":\"Number
+      of denoising steps\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"refine\":{\"enum\":[\"no_refiner\",\"expert_ensemble_refiner\",\"base_image_refiner\"],\"type\":\"string\",\"title\":\"refine\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}}"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 810c642d9b2127a1-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 04 Oct 2023 09:27:50 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      allow:
+      - GET, HEAD, OPTIONS
+      content-security-policy-report-only:
+      - 'script-src ''report-sample'' ''self'' https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js;
+        default-src ''self''; style-src ''report-sample'' ''self'' ''unsafe-inline'';
+        font-src ''report-sample'' ''self'' data:; connect-src ''report-sample'' ''self''
+        https://replicate.delivery https://*.replicate.delivery https://*.rudderlabs.com
+        https://*.rudderstack.com https://*.mux.com https://*.sentry.io; media-src
+        ''report-sample'' ''self'' https://replicate.delivery https://*.replicate.delivery
+        https://*.mux.com https://*.sentry.io; worker-src ''none''; img-src ''report-sample''
+        ''self'' data: https://replicate.delivery https://*.replicate.delivery https://*.githubusercontent.com
+        https://github.com; report-uri'
+      cross-origin-opener-policy:
+      - same-origin
+      nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      ratelimit-remaining:
+      - '2999'
+      ratelimit-reset:
+      - '1'
+      referrer-policy:
+      - same-origin
+      report-to:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1696411670&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=hew4kkx7a9xsK1vI5SagVT8O9LLd7o1QNMpC%2B35Z5Js%3D"}]}'
+      reporting-endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1696411670&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=hew4kkx7a9xsK1vI5SagVT8O9LLd7o1QNMpC%2B35Z5Js%3D
+      vary:
+      - Cookie, origin
+      via:
+      - 1.1 vegur, 1.1 google
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_models_list.yaml
+++ b/tests/cassettes/test_models_list.yaml
@@ -1,0 +1,2818 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.13.0
+    method: GET
+    uri: https://api.replicate.com/v1/models
+  response:
+    content: "{\"next\":\"https://api.replicate.com/v1/models?cursor=cD0yMDIzLTA5LTMwKzE3JTNBMzYlM0ExNS44Mjc2MzIlMkIwMCUzQTAw\",\"previous\":null,\"results\":[{\"url\":\"https://replicate.com/isaacgv/vec2\",\"owner\":\"isaacgv\",\"name\":\"vec2\",\"description\":null,\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":4,\"cover_image_url\":null,\"default_example\":{\"completed_at\":\"2023-10-04T07:21:41.818868Z\",\"created_at\":\"2023-10-04T07:21:37.764231Z\",\"error\":null,\"id\":\"w3bh5rdbh4lo6unn434ticllsa\",\"input\":{\"audio\":\"https://replicate.delivery/pbxt/JdiHR0a8YAD50La2BOcan3rBIuQsNfEREqwLYQo2U5s0t1hu/audio%20(3).mp3\",\"model\":\"large-v2\",\"temperature\":0},\"logs\":\"Transcribe
+      with large-v2 model\\nDetected language: Romanian\\n  0%|          | 0/342 [00:00<?,
+      ?frames/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      342/342 [00:01<00:00, 323.52frames/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      342/342 [00:01<00:00, 323.46frames/s]\\nSpecial tokens have been added in the
+      vocabulary, make sure the associated word embeddings are fine-tuned or trained.\",\"metrics\":{\"predict_time\":4.197268},\"output\":{\"segments\":[{\"end\":2.459,\"text\":\"
+      V\u0103 face la fel \u0219i \xEEn acest caz.\",\"start\":0.34,\"words\":[{\"end\":0.804,\"word\":\"V\u0103\",\"score\":0.166,\"start\":0.34},{\"end\":1.147,\"word\":\"face\",\"score\":0.383,\"start\":0.865},{\"end\":1.309,\"word\":\"la\",\"score\":0.5,\"start\":1.188},{\"end\":1.591,\"word\":\"fel\",\"score\":0.361,\"start\":1.369},{\"end\":1.712,\"word\":\"\u0219i\",\"score\":0.504,\"start\":1.632},{\"end\":1.834,\"word\":\"\xEEn\",\"score\":0.506,\"start\":1.753},{\"end\":2.217,\"word\":\"acest\",\"score\":0.365,\"start\":1.874},{\"end\":2.459,\"word\":\"caz.\",\"score\":0.268,\"start\":2.278}]}],\"detected_language\":\"ro\"},\"started_at\":\"2023-10-04T07:21:37.621600Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/w3bh5rdbh4lo6unn434ticllsa\",\"cancel\":\"https://api.replicate.com/v1/predictions/w3bh5rdbh4lo6unn434ticllsa/cancel\"},\"version\":\"ec9bcadf686c05e859d49f81755ee7427368d44d2350a5f1ec897c04d654201b\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"ec9bcadf686c05e859d49f81755ee7427368d44d2350a5f1ec897c04d654201b\",\"created_at\":\"2023-10-04T07:06:34.713681Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"audio\"],\"properties\":{\"audio\":{\"type\":\"string\",\"title\":\"Audio\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Audio
+      file\"},\"model\":{\"allOf\":[{\"$ref\":\"#/components/schemas/model\"}],\"default\":\"large-v2\",\"x-order\":1,\"description\":\"Choose
+      a Whisper model.\"},\"temperature\":{\"type\":\"number\",\"title\":\"Temperature\",\"default\":0,\"x-order\":2,\"description\":\"temperature
+      to use for sampling\"}}},\"model\":{\"enum\":[\"large-v2\"],\"type\":\"string\",\"title\":\"model\",\"description\":\"An
+      enumeration.\"},\"Output\":{\"$ref\":\"#/components/schemas/ModelOutput\",\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"ModelOutput\":{\"type\":\"object\",\"title\":\"ModelOutput\",\"required\":[\"detected_language\"],\"properties\":{\"segments\":{\"title\":\"Segments\"},\"srt_file\":{\"type\":\"string\",\"title\":\"Srt
+      File\",\"format\":\"uri\"},\"txt_file\":{\"type\":\"string\",\"title\":\"Txt
+      File\",\"format\":\"uri\"},\"detected_language\":{\"type\":\"string\",\"title\":\"Detected
+      Language\"}}},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"completed\",\"logs\",\"output\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/appstanepro/med_mllama_7b\",\"owner\":\"appstanepro\",\"name\":\"med_mllama_7b\",\"description\":\"A
+      Text to text generation model that can help with Stress,Anxiety and Meditation
+      related issue.\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":24,\"cover_image_url\":null,\"default_example\":{\"completed_at\":\"2023-10-04T06:11:47.617078Z\",\"created_at\":\"2023-10-04T06:11:42.202608Z\",\"error\":null,\"id\":\"4v5sv2lbdtjrvfjpofebrfsvq4\",\"input\":{\"top_p\":0.95,\"prompt\":\"i'm
+      feeling stress today how to deal with it\",\"temperature\":0.8,\"system_prompt\":\"you
+      are helpfull mental health advisor,you always only answer for the assistant
+      then you stop.if user input is not related to stress,anxiety and meditation
+      then just reply i can provide assistance related to stress,anxiety and meditation
+      related only,read the history to get context for you,your answer should be brief
+      and complete.\",\"max_new_tokens\":300,\"repetition_penalty\":1.1},\"logs\":null,\"metrics\":{\"predict_time\":3.624992},\"output\":\"
+      \ Hello! I'm here to help you with stress management. It's completely normal
+      to feel stressed from time to time, and there are many effective ways to cope
+      with it. Have you tried any stress-reducing techniques before? If not, I can
+      recommend some that may help.\\nPlease let me know if you have any specific
+      questions or concerns, and I'll do my best to assist you.\",\"started_at\":\"2023-10-04T06:11:43.992086Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/4v5sv2lbdtjrvfjpofebrfsvq4\",\"cancel\":\"https://api.replicate.com/v1/predictions/4v5sv2lbdtjrvfjpofebrfsvq4/cancel\"},\"version\":\"f4dc2287eb677c83ef8d8a152204ebe1e7b1fd8412d84a3151be148a4a34f961\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"f4dc2287eb677c83ef8d8a152204ebe1e7b1fd8412d84a3151be148a4a34f961\",\"created_at\":\"2023-10-04T06:08:23.774828Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"top_p\":{\"type\":\"number\",\"title\":\"Top
+      P\",\"default\":0.95,\"maximum\":1,\"minimum\":0.01,\"x-order\":4,\"description\":\"When
+      decoding text, samples from the top p percentage of most likely tokens; lower
+      to ignore less likely tokens\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"i'm
+      feeling stress today how to deal with it\",\"x-order\":0,\"description\":\"Prompt
+      to send\"},\"temperature\":{\"type\":\"number\",\"title\":\"Temperature\",\"default\":0.8,\"maximum\":5,\"minimum\":0,\"x-order\":3,\"description\":\"Randomness
+      of outputs, 0 is deterministic, greater than 1 is random\"},\"system_prompt\":{\"type\":\"string\",\"title\":\"System
+      Prompt\",\"default\":\"you are helpfull mental health advisor,you always only
+      answer for the assistant then you stop.if user input is not related to stress,anxiety
+      and meditation then just reply i can provide assistance related to stress,anxiety
+      and meditation related only,read the history to get context for you,your answer
+      should be brief and complete.\",\"x-order\":1,\"description\":\"System prompt
+      that helps guide system behavior\"},\"max_new_tokens\":{\"type\":\"integer\",\"title\":\"Max
+      New Tokens\",\"default\":300,\"maximum\":4096,\"minimum\":1,\"x-order\":2,\"description\":\"Number
+      of new tokens\"},\"repetition_penalty\":{\"type\":\"number\",\"title\":\"Repetition
+      Penalty\",\"default\":1.1,\"maximum\":5,\"minimum\":0,\"x-order\":5,\"description\":\"Penalty
+      for repeated words in generated text; 1 is no penalty, values greater than 1
+      discourage repetition, less than 1 encourage it\"}}},\"Output\":{\"type\":\"string\",\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/lucataco/sdxl-controlnet\",\"owner\":\"lucataco\",\"name\":\"sdxl-controlnet\",\"description\":\"SDXL
+      ControlNet - Canny\",\"visibility\":\"public\",\"github_url\":\"https://github.com/lucataco/cog-sdxl-controlnet\",\"paper_url\":null,\"license_url\":\"https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md\",\"run_count\":21357,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/7edf6f87-bd0d-4a4f-9e11-d944bb07a3ea/output.png\",\"default_example\":{\"completed_at\":\"2023-10-04T03:43:32.596373Z\",\"created_at\":\"2023-10-04T03:43:13.838254Z\",\"error\":null,\"id\":\"xkuhaqtbbwcv7pk3psclgtqwtu\",\"input\":{\"seed\":18457,\"image\":\"https://replicate.delivery/pbxt/JLbxAaKmGIUprMAPLUBAiNOdys3UeUmtrphUEX3xafrkfzHL/replicate-prediction-gwlekklbmfsw4vub4vi3uhvgpy.png\",\"prompt\":\"aerial
+      view, a futuristic research complex in a bright foggy jungle, hard lighting\",\"condition_scale\":0.5,\"negative_prompt\":\"low
+      quality, bad quality, sketches\",\"num_inference_steps\":50},\"logs\":\"Using
+      seed: 18457\\nOriginal width:1024, height:1024\\nAspect Ratio: 1.00\\nnew_width:1024,
+      new_height:1024\\n  0%|          | 0/50 [00:00<?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00<00:40,  1.21it/s]\\n  4%|\u258D         | 2/50 [00:01<00:24,  1.95it/s]\\n
+      \ 6%|\u258C         | 3/50 [00:01<00:19,  2.42it/s]\\n  8%|\u258A         |
+      4/50 [00:01<00:16,  2.73it/s]\\n 10%|\u2588         | 5/50 [00:02<00:15,  2.94it/s]\\n
+      12%|\u2588\u258F        | 6/50 [00:02<00:14,  3.08it/s]\\n 14%|\u2588\u258D
+      \       | 7/50 [00:02<00:13,  3.18it/s]\\n 16%|\u2588\u258C        | 8/50 [00:02<00:12,
+      \ 3.24it/s]\\n 18%|\u2588\u258A        | 9/50 [00:03<00:12,  3.29it/s]\\n 20%|\u2588\u2588
+      \       | 10/50 [00:03<00:12,  3.32it/s]\\n 22%|\u2588\u2588\u258F       | 11/50
+      [00:03<00:11,  3.33it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:04<00:11,
+      \ 3.35it/s]\\n 26%|\u2588\u2588\u258C       | 13/50 [00:04<00:11,  3.36it/s]\\n
+      28%|\u2588\u2588\u258A       | 14/50 [00:04<00:10,  3.37it/s]\\n 30%|\u2588\u2588\u2588
+      \      | 15/50 [00:04<00:10,  3.37it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:05<00:10,  3.38it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:05<00:09,  3.38it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50 [00:05<00:09,
+      \ 3.38it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50 [00:06<00:09,  3.38it/s]\\n
+      40%|\u2588\u2588\u2588\u2588      | 20/50 [00:06<00:08,  3.38it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F
+      \    | 21/50 [00:06<00:08,  3.38it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D
+      \    | 22/50 [00:07<00:08,  3.38it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C
+      \    | 23/50 [00:07<00:07,  3.38it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A
+      \    | 24/50 [00:07<00:07,  3.38it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 25/50 [00:07<00:07,  3.38it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:08<00:07,  3.38it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:08<00:06,  3.37it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:08<00:06,  3.37it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:09<00:06,  3.37it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:09<00:05,  3.37it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:09<00:05,  3.37it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:09<00:05,  3.37it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:10<00:05,  3.37it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:10<00:04,  3.37it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:10<00:04,  3.37it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:11<00:04,  3.37it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:11<00:03,  3.37it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:11<00:03,  3.37it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:12<00:03,  3.37it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:12<00:02,  3.37it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:12<00:02,  3.37it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:12<00:02,  3.36it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:13<00:02,  3.36it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:13<00:01,  3.37it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:13<00:01,  3.37it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:14<00:01,  3.37it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:14<00:00,  3.37it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:14<00:00,  3.36it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:15<00:00,  3.36it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:15<00:00,  3.36it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:15<00:00,  3.26it/s]\",\"metrics\":{\"predict_time\":18.310938},\"output\":\"https://pbxt.replicate.delivery/wxFT1zLJGBpePSjuq3feBrdyIPzHgnOC0r7XksLjfCnMWkqGB/output.png\",\"started_at\":\"2023-10-04T03:43:14.285435Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/xkuhaqtbbwcv7pk3psclgtqwtu\",\"cancel\":\"https://api.replicate.com/v1/predictions/xkuhaqtbbwcv7pk3psclgtqwtu/cancel\"},\"version\":\"06d6fae3b75ab68a28cd2900afa6033166910dd09fd9751047043a5bbb4c184b\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"06d6fae3b75ab68a28cd2900afa6033166910dd09fd9751047043a5bbb4c184b\",\"created_at\":\"2023-10-04T03:41:11.578533Z\",\"cog_version\":\"0.8.5\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"default\":0,\"x-order\":5,\"description\":\"Random
+      seed. Set to 0 to randomize the seed\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image for img2img or inpaint mode\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"aerial
+      view, a futuristic research complex in a bright foggy jungle, hard lighting\",\"x-order\":1,\"description\":\"Input
+      prompt\"},\"condition_scale\":{\"type\":\"number\",\"title\":\"Condition Scale\",\"default\":0.5,\"maximum\":1,\"minimum\":0,\"x-order\":4,\"description\":\"controlnet
+      conditioning scale for generalization\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"low quality, bad quality, sketches\",\"x-order\":2,\"description\":\"Input
+      Negative Prompt\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":50,\"maximum\":500,\"minimum\":1,\"x-order\":3,\"description\":\"Number
+      of denoising steps\"}}},\"Output\":{\"type\":\"string\",\"title\":\"Output\",\"format\":\"uri\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"logs\",\"start\",\"output\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/lucataco/mistral-7b-v0.1\",\"owner\":\"lucataco\",\"name\":\"mistral-7b-v0.1\",\"description\":\"Mistral-7B-v0.1
+      is a pretrained generative text model that outperforms Llama 2 13B on (supposedly)
+      all benchmarks\",\"visibility\":\"public\",\"github_url\":\"https://github.com/lucataco/cog-mistral-7B-v0.1\",\"paper_url\":\"https://mistral.ai/news/announcing-mistral-7b/\",\"license_url\":\"https://choosealicense.com/licenses/apache-2.0/\",\"run_count\":7,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/55874689-189a-4164-acbe-dce328a41c2d/mistral.webp\",\"default_example\":{\"completed_at\":\"2023-10-04T03:22:24.696928Z\",\"created_at\":\"2023-10-04T03:17:53.264511Z\",\"error\":null,\"id\":\"k72t7a3bp3nju43tfsv2zdhxqq\",\"input\":{\"prompt\":\"Explain,
+      in a short paragraph, quantum field theory to a high school student\",\"max_new_tokens\":512},\"logs\":\"Setting
+      `pad_token_id` to `eos_token_id`:2 for open-end generation.\",\"metrics\":{\"predict_time\":4.296611},\"output\":\"Explain,
+      in a short paragraph, quantum field theory to a high school student who knows
+      basic physics? A: Quantum field theory is a branch of physics that studies tiny
+      particles, like atoms and subatomic particles, by using advanced math. It's
+      a bit like calculus, which helps us understand how things move. But instead
+      of studying things that move, like cars or planes, we study tiny particles that
+      don't move very much. The theory tells us how these particles behave and how
+      they interact with each other. Because everything around us is made up of tiny
+      particles, understanding quantum field theory can help us understand everything
+      around us, including ourselves!</s>\",\"started_at\":\"2023-10-04T03:22:20.400317Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/k72t7a3bp3nju43tfsv2zdhxqq\",\"cancel\":\"https://api.replicate.com/v1/predictions/k72t7a3bp3nju43tfsv2zdhxqq/cancel\"},\"version\":\"992ccec19c0f8673d24cffbd27756f02010ab9cc453803b7b2da9e890dd87b41\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"992ccec19c0f8673d24cffbd27756f02010ab9cc453803b7b2da9e890dd87b41\",\"created_at\":\"2023-10-04T03:17:02.047728Z\",\"cog_version\":\"0.8.5\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"prompt\"],\"properties\":{\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"x-order\":0,\"description\":\"Input
+      prompt\"},\"max_new_tokens\":{\"type\":\"integer\",\"title\":\"Max New Tokens\",\"default\":512,\"maximum\":2048,\"minimum\":0,\"x-order\":1,\"description\":\"Max
+      new tokens\"}}},\"Output\":{\"type\":\"string\",\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"logs\",\"start\",\"output\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/pnickolas1/sdxl-dreambooth-loras-dev\",\"owner\":\"pnickolas1\",\"name\":\"sdxl-dreambooth-loras-dev\",\"description\":null,\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":1201,\"cover_image_url\":\"https://replicate.delivery/pbxt/ADg1vUiCNIbIBhvxfhEcIfrfdmfpNwZ6bzuEeyvsbK9glCbMC/out-0.png\",\"default_example\":{\"completed_at\":\"2023-09-12T02:55:41.165126Z\",\"created_at\":\"2023-09-12T02:55:25.854689Z\",\"error\":null,\"id\":\"4gtfwxlb5tclrc4oafynjvc5vu\",\"input\":{\"width\":1024,\"height\":1024,\"prompt\":\"line
+      art of TOK man as a policeman with muscles, coloring book style, 8k, white background,
+      vector graphic, \",\"refine\":\"no_refiner\",\"scheduler\":\"K_EULER\",\"lora_scale\":0.6,\"num_outputs\":1,\"guidance_scale\":7.55,\"apply_watermark\":true,\"high_noise_frac\":0.8,\"negative_prompt\":\"anime,
+      photorealistic, 35mm film, deformed, glitch, blurry, noisy, off-center, deformed,
+      cross-eyed, closed eyes, bad anatomy, ugly, disfigured, mutated, realism, realistic,
+      impressionism, expressionism, oil, acrylic, shading\",\"prompt_strength\":0.8,\"num_inference_steps\":50},\"logs\":\"Using
+      seed: 21027\\nskipping loading .. weights already loaded\\nPrompt: line art
+      of <s0><s1> man as a policeman with muscles, coloring book style, 8k, white
+      background, vector graphic,\\ntxt2img mode\\n  0%|          | 0/50 [00:00<?,
+      ?it/s]\\n  2%|\u258F         | 1/50 [00:00<00:13,  3.73it/s]\\n  4%|\u258D         |
+      2/50 [00:00<00:12,  3.72it/s]\\n  6%|\u258C         | 3/50 [00:00<00:12,  3.71it/s]\\n
+      \ 8%|\u258A         | 4/50 [00:01<00:12,  3.70it/s]\\n 10%|\u2588         |
+      5/50 [00:01<00:12,  3.70it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01<00:11,
+      \ 3.69it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01<00:11,  3.69it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:02<00:11,  3.69it/s]\\n 18%|\u2588\u258A        | 9/50 [00:02<00:11,
+      \ 3.69it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02<00:10,  3.69it/s]\\n 22%|\u2588\u2588\u258F
+      \      | 11/50 [00:02<00:10,  3.69it/s]\\n 24%|\u2588\u2588\u258D       | 12/50
+      [00:03<00:10,  3.68it/s]\\n 26%|\u2588\u2588\u258C       | 13/50 [00:03<00:10,
+      \ 3.69it/s]\\n 28%|\u2588\u2588\u258A       | 14/50 [00:03<00:09,  3.69it/s]\\n
+      30%|\u2588\u2588\u2588       | 15/50 [00:04<00:09,  3.68it/s]\\n 32%|\u2588\u2588\u2588\u258F
+      \     | 16/50 [00:04<00:09,  3.68it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:04<00:08,  3.68it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:04<00:08,  3.68it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50 [00:05<00:08,
+      \ 3.68it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50 [00:05<00:08,  3.68it/s]\\n
+      42%|\u2588\u2588\u2588\u2588\u258F     | 21/50 [00:05<00:07,  3.68it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D
+      \    | 22/50 [00:05<00:07,  3.67it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C
+      \    | 23/50 [00:06<00:07,  3.68it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A
+      \    | 24/50 [00:06<00:07,  3.68it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 25/50 [00:06<00:06,  3.68it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:07<00:06,  3.69it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:07<00:06,  3.69it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:07<00:05,  3.69it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:07<00:05,  3.69it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:08<00:05,  3.69it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:08<00:05,  3.70it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:08<00:04,  3.70it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:08<00:04,  3.70it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:09<00:04,  3.70it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:09<00:04,  3.70it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:09<00:03,  3.70it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:10<00:03,  3.70it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:10<00:03,  3.70it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:10<00:02,  3.70it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:10<00:02,  3.70it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:11<00:02,  3.70it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:11<00:02,  3.70it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:11<00:01,  3.70it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:11<00:01,  3.69it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:12<00:01,  3.69it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:12<00:01,  3.69it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:12<00:00,  3.70it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:13<00:00,  3.69it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:13<00:00,  3.69it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:13<00:00,  3.70it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:13<00:00,  3.69it/s]\",\"metrics\":{\"predict_time\":14.446857},\"output\":[\"https://replicate.delivery/pbxt/ADg1vUiCNIbIBhvxfhEcIfrfdmfpNwZ6bzuEeyvsbK9glCbMC/out-0.png\"],\"started_at\":\"2023-09-12T02:55:26.718269Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/4gtfwxlb5tclrc4oafynjvc5vu\",\"cancel\":\"https://api.replicate.com/v1/predictions/4gtfwxlb5tclrc4oafynjvc5vu/cancel\"},\"version\":\"6b3d414bdf58f67766c1fcc2fdd4f5d2ddb50d1cf0e196408b739d13abfae5e0\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"39665c283dd8aaaebf53ca936a0196cdc7826411d2513c4219577ddcd7a7e3b6\",\"created_at\":\"2023-10-04T02:10:36.078006Z\",\"cog_version\":\"v0.8.1+dev\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"mask\":{\"type\":\"string\",\"title\":\"Mask\",\"format\":\"uri\",\"x-order\":3,\"description\":\"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted.\"},\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":11,\"description\":\"Random
+      seed. Leave blank to randomize the seed\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":2,\"description\":\"Input
+      image for img2img or inpaint mode\"},\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"default\":1024,\"x-order\":4,\"description\":\"Width
+      of output image\"},\"height\":{\"type\":\"integer\",\"title\":\"Height\",\"default\":1024,\"x-order\":5,\"description\":\"Height
+      of output image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"An
+      astronaut riding a rainbow unicorn\",\"x-order\":0,\"description\":\"Input prompt\"},\"refine\":{\"allOf\":[{\"$ref\":\"#/components/schemas/refine\"}],\"default\":\"no_refiner\",\"x-order\":12,\"description\":\"Which
+      refine style to use\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER\",\"x-order\":7,\"description\":\"scheduler\"},\"lora_scale\":{\"type\":\"number\",\"title\":\"Lora
+      Scale\",\"default\":0.6,\"maximum\":1,\"minimum\":0,\"x-order\":16,\"description\":\"LoRA
+      additive scale. Only applicable on trained models.\"},\"num_outputs\":{\"type\":\"integer\",\"title\":\"Num
+      Outputs\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Number
+      of images to output.\"},\"refine_steps\":{\"type\":\"integer\",\"title\":\"Refine
+      Steps\",\"x-order\":14,\"description\":\"For base_image_refiner, the number
+      of steps to refine, defaults to num_inference_steps\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":50,\"minimum\":1,\"x-order\":9,\"description\":\"Scale
+      for classifier-free guidance\"},\"apply_watermark\":{\"type\":\"boolean\",\"title\":\"Apply
+      Watermark\",\"default\":true,\"x-order\":15,\"description\":\"Applies a watermark
+      to enable determining if an image is generated in downstream applications. If
+      you have other provisions for generating or deploying images safely, you can
+      use this to disable watermarking.\"},\"high_noise_frac\":{\"type\":\"number\",\"title\":\"High
+      Noise Frac\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":13,\"description\":\"For
+      expert_ensemble_refiner, the fraction of noise to use\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"\",\"x-order\":1,\"description\":\"Input Negative Prompt\"},\"prompt_strength\":{\"type\":\"number\",\"title\":\"Prompt
+      Strength\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":10,\"description\":\"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":50,\"maximum\":500,\"minimum\":1,\"x-order\":8,\"description\":\"Number
+      of denoising steps\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"refine\":{\"enum\":[\"no_refiner\",\"expert_ensemble_refiner\",\"base_image_refiner\"],\"type\":\"string\",\"title\":\"refine\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"output\",\"logs\",\"start\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/moinnadeem/vllm-engine-llama-7b\",\"owner\":\"moinnadeem\",\"name\":\"vllm-engine-llama-7b\",\"description\":null,\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":17,\"cover_image_url\":null,\"default_example\":{\"completed_at\":\"2023-09-25T18:32:09.615526Z\",\"created_at\":\"2023-09-25T18:32:05.915928Z\",\"error\":null,\"id\":\"3mgmzkrb6shggxewdohflfh3i4\",\"input\":{\"debug\":false,\"top_k\":50,\"top_p\":0.9,\"prompt\":\"You
+      are a powerful text-to-SQL model. Your job is to answer questions about a database.
+      You are given a question and context regarding one or more tables. \\n\\nYou
+      must output the SQL query that answers the question.\\n\\n### Input:\\nWhat
+      is the total number of decile for the redwood school locality?\\n\\n### Context:\\nCREATE
+      TABLE table_name_34 (decile VARCHAR, name VARCHAR)\\n\\n### Response:\\n\",\"lora_path\":\"https://pub-df34620a84bb4c0683fae07a260df1ea.r2.dev/sql.zip\",\"temperature\":0.75,\"max_new_tokens\":128},\"logs\":\"Weights
+      path: https://pub-df34620a84bb4c0683fae07a260df1ea.r2.dev/sql.zip\\nDownloading
+      peft weights\\nusing https://pub-df34620a84bb4c0683fae07a260df1ea.r2.dev/sql.zip
+      instead of https://pub-df34620a84bb4c0683fae07a260df1ea.r2.dev/sql.zip\\nDownloaded
+      sql.zip as 12 519 kB chunks in 1.0834 with 0 retries\\nDownloaded peft weights
+      in 1.084\\nUnzipped peft weights in 0.083\\nData keys: dict_keys(['adapter_config.json',
+      'adapter_model.bin'])\\nPrompt:\\nYou are a powerful text-to-SQL model. Your
+      job is to answer questions about a database. You are given a question and context
+      regarding one or more tables.\\nYou must output the SQL query that answers the
+      question.\\n### Input:\\nWhat is the total number of decile for the redwood
+      school locality?\\n### Context:\\nCREATE TABLE table_name_34 (decile VARCHAR,
+      name VARCHAR)\\n### Response:\\nINFO 09-25 18:32:09 async_llm_engine.py:371]
+      Received request 0: prompt: 'You are a powerful text-to-SQL model. Your job
+      is to answer questions about a database. You are given a question and context
+      regarding one or more tables. \\\\n\\\\nYou must output the SQL query that answers
+      the question.\\\\n\\\\n### Input:\\\\nWhat is the total number of decile for
+      the redwood school locality?\\\\n\\\\n### Context:\\\\nCREATE TABLE table_name_34
+      (decile VARCHAR, name VARCHAR)\\\\n\\\\n### Response:\\\\n', sampling params:
+      SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=1.0,
+      temperature=0.75, top_p=0.9, top_k=50, use_beam_search=False, length_penalty=1.0,
+      early_stopping=False, stop=['</s>'], ignore_eos=False, max_tokens=128, logprobs=None),
+      prompt token ids: None.\\nINFO 09-25 18:32:09 llm_engine.py:623] Avg prompt
+      throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running:
+      1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.4%, CPU KV cache
+      usage: 0.0%\\nINFO 09-25 18:32:09 async_llm_engine.py:111] Finished request
+      0.\\nGenerated text: SELECT COUNT(decile) FROM table_name_34 WHERE name = \\\"redwood
+      school\\\"\\nGenerated 22 tokens in 0.416 seconds (52.948 tokens per second)\",\"metrics\":{\"predict_time\":3.738469},\"output\":[\"SELECT\",\"
+      COUNT\",\"(\",\"de\",\"cile\",\")\",\" FROM\",\" table\",\"_\",\"name\",\"_\",\"3\",\"4\",\"
+      WHERE\",\" name\",\" =\",\" \\\"\",\"red\",\"wood\",\" school\",\"\\\"\",\"\"],\"started_at\":\"2023-09-25T18:32:05.877057Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/3mgmzkrb6shggxewdohflfh3i4\",\"cancel\":\"https://api.replicate.com/v1/predictions/3mgmzkrb6shggxewdohflfh3i4/cancel\"},\"version\":\"559ff8c30789d100c13f9bd0f831210f6f9c6f1c81dab06ff16dc61dbfa94b03\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"049b7726f19e862f1654523a3e8567931124effd98db7f1854bf517deeac3033\",\"created_at\":\"2023-10-04T00:16:47.469684Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"prompt\"],\"properties\":{\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":7,\"description\":\"Random
+      seed. Leave blank to randomize the seed\"},\"debug\":{\"type\":\"boolean\",\"title\":\"Debug\",\"default\":false,\"x-order\":8,\"description\":\"provide
+      debugging output in logs\"},\"top_k\":{\"type\":\"integer\",\"title\":\"Top
+      K\",\"default\":50,\"minimum\":0,\"x-order\":5,\"description\":\"When decoding
+      text, samples from the top k most likely tokens; lower to ignore less likely
+      tokens\"},\"top_p\":{\"type\":\"number\",\"title\":\"Top P\",\"default\":0.9,\"maximum\":1,\"minimum\":0,\"x-order\":4,\"description\":\"When
+      decoding text, samples from the top p percentage of most likely tokens; lower
+      to ignore less likely tokens\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"x-order\":0,\"description\":\"Prompt
+      to send to the model.\"},\"temperature\":{\"type\":\"number\",\"title\":\"Temperature\",\"default\":0.75,\"maximum\":5,\"minimum\":0.01,\"x-order\":3,\"description\":\"Adjusts
+      randomness of outputs, greater than 1 is random and 0 is deterministic, 0.75
+      is a good starting value.\"},\"max_new_tokens\":{\"type\":\"integer\",\"title\":\"Max
+      New Tokens\",\"default\":128,\"minimum\":1,\"x-order\":1,\"description\":\"Maximum
+      number of tokens to generate. A word is generally 2-3 tokens\"},\"min_new_tokens\":{\"type\":\"integer\",\"title\":\"Min
+      New Tokens\",\"default\":-1,\"minimum\":-1,\"x-order\":2,\"description\":\"Minimum
+      number of tokens to generate. To disable, set to -1. A word is generally 2-3
+      tokens.\"},\"stop_sequences\":{\"type\":\"string\",\"title\":\"Stop Sequences\",\"x-order\":6,\"description\":\"A
+      comma-separated list of sequences to stop generation at. For example, '<end>,<stop>'
+      will stop generation at the first instance of 'end' or '<stop>'.\"},\"replicate_weights\":{\"type\":\"string\",\"title\":\"Replicate
+      Weights\",\"x-order\":9,\"description\":\"Path to fine-tuned weights produced
+      by a Replicate fine-tune job.\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\"},\"title\":\"Output\",\"x-cog-array-type\":\"iterator\",\"x-cog-array-display\":\"concatenate\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/qr2ai/advanced_ai_qr_code_art\",\"owner\":\"qr2ai\",\"name\":\"advanced_ai_qr_code_art\",\"description\":\"QR
+      Code AI Art Generator\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":5,\"cover_image_url\":\"https://pbxt.replicate.delivery/uMf6Vd8SfLo6MUvcCOeDfY3lXofTYDQlvRkxYfEuW3brqpoaE/output-0.png\",\"default_example\":{\"completed_at\":\"2023-10-03T20:20:59.487110Z\",\"created_at\":\"2023-10-03T20:20:37.059721Z\",\"error\":null,\"id\":\"guxugezb6k5yirharynnfd756i\",\"input\":{\"seed\":130264517,\"prompt\":\"fairy-tale
+      town, quaint village, charming, picturesque, idyllic, cobblestone streets, storybook,
+      fable, folklore, enchanting\",\"strength\":0.95,\"batch_size\":1,\"guidance_scale\":11.15,\"negative_prompt\":\"ugly,
+      disfigured, low quality, blurry, nsfw\",\"qr_code_content\":\"https://qr2ai.com\",\"num_inference_steps\":40,\"controlnet_conditioning_scale\":1.25},\"logs\":\"Generating
+      QR Code from content\\n  0%|          | 0/38 [00:00<?, ?it/s]\\n  3%|\u258E
+      \        | 1/38 [00:01<00:37,  1.02s/it]\\n  5%|\u258C         | 2/38 [00:01<00:25,
+      \ 1.39it/s]\\n  8%|\u258A         | 3/38 [00:02<00:21,  1.60it/s]\\n 11%|\u2588
+      \        | 4/38 [00:02<00:19,  1.72it/s]\\n 13%|\u2588\u258E        | 5/38 [00:03<00:18,
+      \ 1.80it/s]\\n 16%|\u2588\u258C        | 6/38 [00:03<00:17,  1.85it/s]\\n 18%|\u2588\u258A
+      \       | 7/38 [00:04<00:16,  1.88it/s]\\n 21%|\u2588\u2588        | 8/38 [00:04<00:15,
+      \ 1.90it/s]\\n 24%|\u2588\u2588\u258E       | 9/38 [00:05<00:15,  1.91it/s]\\n
+      26%|\u2588\u2588\u258B       | 10/38 [00:05<00:14,  1.92it/s]\\n 29%|\u2588\u2588\u2589
+      \      | 11/38 [00:06<00:14,  1.93it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      12/38 [00:06<00:13,  1.93it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 13/38
+      [00:07<00:12,  1.94it/s]\\n 37%|\u2588\u2588\u2588\u258B      | 14/38 [00:07<00:12,
+      \ 1.94it/s]\\n 39%|\u2588\u2588\u2588\u2589      | 15/38 [00:08<00:11,  1.94it/s]\\n
+      42%|\u2588\u2588\u2588\u2588\u258F     | 16/38 [00:08<00:11,  1.94it/s]\\n 45%|\u2588\u2588\u2588\u2588\u258D
+      \    | 17/38 [00:09<00:10,  1.94it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B
+      \    | 18/38 [00:09<00:10,  1.94it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 19/38 [00:10<00:09,  1.94it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E
+      \   | 20/38 [00:10<00:09,  1.94it/s]\\n 55%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 21/38 [00:11<00:08,  1.94it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 22/38 [00:11<00:08,  1.94it/s]\\n 61%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 23/38 [00:12<00:07,  1.94it/s]\\n 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      \  | 24/38 [00:12<00:07,  1.94it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 25/38 [00:13<00:06,  1.93it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 26/38 [00:13<00:06,  1.94it/s]\\n 71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 27/38 [00:14<00:05,  1.94it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      \ | 28/38 [00:14<00:05,  1.93it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \ | 29/38 [00:15<00:04,  1.94it/s]\\n 79%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      \ | 30/38 [00:15<00:04,  1.93it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 31/38 [00:16<00:03,  1.94it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 32/38 [00:16<00:03,  1.93it/s]\\n 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      | 33/38 [00:17<00:02,  1.94it/s]\\n 89%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 34/38 [00:18<00:02,  1.93it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      35/38 [00:18<00:01,  1.93it/s]\\n 95%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      36/38 [00:19<00:01,  1.93it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      37/38 [00:19<00:00,  1.93it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      38/38 [00:20<00:00,  1.93it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      38/38 [00:20<00:00,  1.89it/s]\",\"metrics\":{\"predict_time\":22.445486},\"output\":[\"https://pbxt.replicate.delivery/uMf6Vd8SfLo6MUvcCOeDfY3lXofTYDQlvRkxYfEuW3brqpoaE/output-0.png\"],\"started_at\":\"2023-10-03T20:20:37.041624Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/guxugezb6k5yirharynnfd756i\",\"cancel\":\"https://api.replicate.com/v1/predictions/guxugezb6k5yirharynnfd756i/cancel\"},\"version\":\"ecb4ee16126b2a2e41e9a57e9b1ad6013ae69e4a4936aeaddd5b04a6b6d38fd8\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"ecb4ee16126b2a2e41e9a57e9b1ad6013ae69e4a4936aeaddd5b04a6b6d38fd8\",\"created_at\":\"2023-10-03T20:02:35.575549Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"prompt\"],\"properties\":{\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"default\":-1,\"x-order\":6,\"description\":\"Seed\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"x-order\":2,\"description\":\"The
+      prompt to guide QR Code generation.\"},\"strength\":{\"type\":\"number\",\"title\":\"Strength\",\"default\":0.9,\"maximum\":1,\"minimum\":0,\"x-order\":8,\"description\":\"Indicates
+      how much to transform the masked portion of the reference `image`. Must be between
+      0 and 1.\"},\"batch_size\":{\"type\":\"integer\",\"title\":\"Batch Size\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":7,\"description\":\"Batch
+      size for this prediction\"},\"qr_code_image\":{\"type\":\"string\",\"title\":\"Qr
+      Code Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"The QR Code
+      image (optional).\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":30,\"minimum\":0.1,\"x-order\":5,\"description\":\"Scale
+      for classifier-free guidance\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"ugly, disfigured, low quality, blurry, nsfw\",\"x-order\":3,\"description\":\"The
+      negative prompt to guide image generation.\"},\"qr_code_content\":{\"type\":\"string\",\"title\":\"Qr
+      Code Content\",\"default\":\"\",\"x-order\":1,\"description\":\"The website/content
+      your QR Code will point to.\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":40,\"maximum\":100,\"minimum\":20,\"x-order\":4,\"description\":\"Number
+      of diffusion steps\"},\"controlnet_conditioning_scale\":{\"type\":\"number\",\"title\":\"Controlnet
+      Conditioning Scale\",\"default\":1.5,\"maximum\":2,\"minimum\":1,\"x-order\":9,\"description\":\"The
+      outputs of the controlnet are multiplied by `controlnet_conditioning_scale`
+      before they are added to the residual in the original unet.\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/alaradirik/t2i-adapter-sdxl-openpose\",\"owner\":\"alaradirik\",\"name\":\"t2i-adapter-sdxl-openpose\",\"description\":\"Modify
+      images using human pose\",\"visibility\":\"public\",\"github_url\":\"https://github.com/replicate/cog-t2i-adapter-sdxl\",\"paper_url\":\"https://arxiv.org/abs/2302.08453\",\"license_url\":null,\"run_count\":227,\"cover_image_url\":\"https://pbxt.replicate.delivery/nuE2A9YWRkLaN1ptkgad1JeHtYJwUWAt6p7Bie0fYDcNlCVjA/out-0.png\",\"default_example\":{\"completed_at\":\"2023-10-03T18:51:19.116216Z\",\"created_at\":\"2023-10-03T18:49:23.572065Z\",\"error\":null,\"id\":\"gk2lem3bosrbmdz5itfokdtvhe\",\"input\":{\"image\":\"https://replicate.delivery/pbxt/JbnAELoOIkMhteHqHJnRfB0ATKgRdZqLjdIgcZB34WlRNCNF/people.jpg\",\"prompt\":\"A
+      couple, 4k photo, highly detailed\",\"scheduler\":\"K_EULER_ANCESTRAL\",\"num_samples\":1,\"guidance_scale\":7.5,\"negative_prompt\":\"anime,
+      cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed,
+      mutated, ugly, disfigured\",\"num_inference_steps\":30,\"adapter_conditioning_scale\":0.9,\"adapter_conditioning_factor\":0.9},\"logs\":\"0%|
+      \         | 0/30 [00:00<?, ?it/s]\\n  3%|\u258E         | 1/30 [00:00<00:04,
+      \ 6.05it/s]\\n  7%|\u258B         | 2/30 [00:00<00:06,  4.50it/s]\\n 10%|\u2588
+      \        | 3/30 [00:00<00:06,  4.12it/s]\\n 13%|\u2588\u258E        | 4/30 [00:00<00:06,
+      \ 3.97it/s]\\n 17%|\u2588\u258B        | 5/30 [00:01<00:06,  3.89it/s]\\n 20%|\u2588\u2588
+      \       | 6/30 [00:01<00:06,  3.83it/s]\\n 23%|\u2588\u2588\u258E       | 7/30
+      [00:01<00:06,  3.80it/s]\\n 27%|\u2588\u2588\u258B       | 8/30 [00:02<00:05,
+      \ 3.78it/s]\\n 30%|\u2588\u2588\u2588       | 9/30 [00:02<00:05,  3.77it/s]\\n
+      33%|\u2588\u2588\u2588\u258E      | 10/30 [00:02<00:05,  3.76it/s]\\n 37%|\u2588\u2588\u2588\u258B
+      \     | 11/30 [00:02<00:05,  3.74it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      12/30 [00:03<00:04,  3.74it/s]\\n 43%|\u2588\u2588\u2588\u2588\u258E     | 13/30
+      [00:03<00:04,  3.74it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B     | 14/30 [00:03<00:04,
+      \ 3.73it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 15/30 [00:03<00:04,
+      \ 3.73it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 16/30 [00:04<00:03,
+      \ 3.73it/s]\\n 57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 17/30 [00:04<00:03,
+      \ 3.73it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 18/30 [00:04<00:03,
+      \ 3.72it/s]\\n 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E   | 19/30 [00:04<00:02,
+      \ 3.73it/s]\\n 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 20/30 [00:05<00:02,
+      \ 3.72it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 21/30 [00:05<00:02,
+      \ 3.72it/s]\\n 73%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E  | 22/30
+      [00:05<00:02,  3.72it/s]\\n 77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \ | 23/30 [00:06<00:01,  3.73it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 24/30 [00:06<00:01,  3.72it/s]\\n 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 25/30 [00:06<00:01,  3.72it/s]\\n 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      | 26/30 [00:06<00:01,  3.72it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 27/30 [00:07<00:00,  3.71it/s]\\n 93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      28/30 [00:07<00:00,  3.72it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      29/30 [00:07<00:00,  3.72it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:07<00:00,  3.72it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:07<00:00,  3.78it/s]\",\"metrics\":{\"predict_time\":12.428266},\"output\":[\"https://pbxt.replicate.delivery/zLV4rptJWbKOKpMauzP4ASa0ZwMhs29NYD4Ckdy3uhSpUoaE/out-preprocessed.png\",\"https://pbxt.replicate.delivery/nuE2A9YWRkLaN1ptkgad1JeHtYJwUWAt6p7Bie0fYDcNlCVjA/out-0.png\"],\"started_at\":\"2023-10-03T18:51:06.687950Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/gk2lem3bosrbmdz5itfokdtvhe\",\"cancel\":\"https://api.replicate.com/v1/predictions/gk2lem3bosrbmdz5itfokdtvhe/cancel\"},\"version\":\"6e87d127eb184d446b8cec0c2b034b3c7b24d08e211ec28247cdeb2e0a460670\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"6e87d127eb184d446b8cec0c2b034b3c7b24d08e211ec28247cdeb2e0a460670\",\"created_at\":\"2023-10-03T17:58:16.293429Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"image\"],\"properties\":{\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"A
+      couple, 4k photo, highly detailed\",\"x-order\":1,\"description\":\"Input prompt\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER_ANCESTRAL\",\"x-order\":8,\"description\":\"Which
+      scheduler to use\"},\"num_samples\":{\"type\":\"integer\",\"title\":\"Num Samples\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":7,\"description\":\"Number
+      of outputs to generate\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":10,\"minimum\":0,\"x-order\":6,\"description\":\"Guidance
+      scale to match the prompt\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"anime, cartoon, graphic, text, painting, crayon, graphite,
+      abstract, glitch, deformed, mutated, ugly, disfigured\",\"x-order\":2,\"description\":\"Specify
+      things to not see in the output\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":30,\"maximum\":100,\"minimum\":0,\"x-order\":3,\"description\":\"Number
+      of diffusion steps\"},\"adapter_conditioning_scale\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Scale\",\"default\":1,\"maximum\":5,\"minimum\":0,\"x-order\":4,\"description\":\"Conditioning
+      scale\"},\"adapter_conditioning_factor\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Factor\",\"default\":1,\"maximum\":1,\"minimum\":0,\"x-order\":5,\"description\":\"Factor
+      to scale image by\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\",\"LMSDiscrete\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"output\",\"start\",\"logs\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/alaradirik/t2i-adapter-sdxl-lineart\",\"owner\":\"alaradirik\",\"name\":\"t2i-adapter-sdxl-lineart\",\"description\":\"Modify
+      images using line art\",\"visibility\":\"public\",\"github_url\":\"https://github.com/replicate/cog-t2i-adapter-sdxl\",\"paper_url\":\"https://arxiv.org/abs/2302.08453\",\"license_url\":null,\"run_count\":262,\"cover_image_url\":\"https://replicate.delivery/pbxt/f8xV2WI2WdzpdCqOdgdBF4p8AI5LNEPTQ5WWjn62yUzLNQ1IA/out-0.png\",\"default_example\":{\"completed_at\":\"2023-10-03T17:51:19.526916Z\",\"created_at\":\"2023-10-03T17:49:17.964542Z\",\"error\":null,\"id\":\"3laatitbp3upivlgg7apan5e64\",\"input\":{\"image\":\"https://replicate.delivery/pbxt/Jbn7HU47GHRIgHPwC9IZRUFGZ8zNzz9kYqyJq77wdEZ8GmTg/org_lin.jpg\",\"prompt\":\"Ice
+      dragon roar, 4k photo\",\"scheduler\":\"K_EULER_ANCESTRAL\",\"num_samples\":1,\"guidance_scale\":7.5,\"negative_prompt\":\"anime,
+      cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed,
+      mutated, ugly, disfigured\",\"num_inference_steps\":30,\"adapter_conditioning_scale\":0.8,\"adapter_conditioning_factor\":1},\"logs\":\"0%|
+      \         | 0/30 [00:00<?, ?it/s]\\n  3%|\u258E         | 1/30 [00:00<00:06,
+      \ 4.70it/s]\\n  7%|\u258B         | 2/30 [00:00<00:08,  3.22it/s]\\n 10%|\u2588
+      \        | 3/30 [00:00<00:09,  2.91it/s]\\n 13%|\u2588\u258E        | 4/30 [00:01<00:09,
+      \ 2.78it/s]\\n 17%|\u2588\u258B        | 5/30 [00:01<00:09,  2.72it/s]\\n 20%|\u2588\u2588
+      \       | 6/30 [00:02<00:08,  2.68it/s]\\n 23%|\u2588\u2588\u258E       | 7/30
+      [00:02<00:08,  2.66it/s]\\n 27%|\u2588\u2588\u258B       | 8/30 [00:02<00:08,
+      \ 2.64it/s]\\n 30%|\u2588\u2588\u2588       | 9/30 [00:03<00:07,  2.63it/s]\\n
+      33%|\u2588\u2588\u2588\u258E      | 10/30 [00:03<00:07,  2.62it/s]\\n 37%|\u2588\u2588\u2588\u258B
+      \     | 11/30 [00:04<00:07,  2.62it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      12/30 [00:04<00:06,  2.61it/s]\\n 43%|\u2588\u2588\u2588\u2588\u258E     | 13/30
+      [00:04<00:06,  2.61it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B     | 14/30 [00:05<00:06,
+      \ 2.60it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 15/30 [00:05<00:05,
+      \ 2.60it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 16/30 [00:05<00:05,
+      \ 2.61it/s]\\n 57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 17/30 [00:06<00:04,
+      \ 2.61it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 18/30 [00:06<00:04,
+      \ 2.61it/s]\\n 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E   | 19/30 [00:07<00:04,
+      \ 2.61it/s]\\n 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 20/30 [00:07<00:03,
+      \ 2.62it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 21/30 [00:07<00:03,
+      \ 2.61it/s]\\n 73%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E  | 22/30
+      [00:08<00:03,  2.61it/s]\\n 77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \ | 23/30 [00:08<00:02,  2.62it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 24/30 [00:09<00:02,  2.62it/s]\\n 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 25/30 [00:09<00:01,  2.61it/s]\\n 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      | 26/30 [00:09<00:01,  2.62it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 27/30 [00:10<00:01,  2.61it/s]\\n 93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      28/30 [00:10<00:00,  2.61it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      29/30 [00:10<00:00,  2.61it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:11<00:00,  2.61it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:11<00:00,  2.65it/s]\",\"metrics\":{\"predict_time\":16.420516},\"output\":[\"https://replicate.delivery/pbxt/fMMx2msHiH0qXC0j4KLO4EWhvHE7BTcs90HOiydNbwILNQ1IA/out-preprocessed.png\",\"https://replicate.delivery/pbxt/f8xV2WI2WdzpdCqOdgdBF4p8AI5LNEPTQ5WWjn62yUzLNQ1IA/out-0.png\"],\"started_at\":\"2023-10-03T17:51:03.106400Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/3laatitbp3upivlgg7apan5e64\",\"cancel\":\"https://api.replicate.com/v1/predictions/3laatitbp3upivlgg7apan5e64/cancel\"},\"version\":\"43672c5012b7e26473bf625831654f6a9452ae3b2f72f29424d8f1a0a6315449\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"43672c5012b7e26473bf625831654f6a9452ae3b2f72f29424d8f1a0a6315449\",\"created_at\":\"2023-10-03T17:39:09.808183Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"image\"],\"properties\":{\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"Ice
+      dragon roar, 4k photo\",\"x-order\":1,\"description\":\"Input prompt\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER_ANCESTRAL\",\"x-order\":8,\"description\":\"Which
+      scheduler to use\"},\"num_samples\":{\"type\":\"integer\",\"title\":\"Num Samples\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":7,\"description\":\"Number
+      of outputs to generate\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":10,\"minimum\":0,\"x-order\":6,\"description\":\"Guidance
+      scale to match the prompt\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"anime, cartoon, graphic, text, painting, crayon, graphite,
+      abstract, glitch, deformed, mutated, ugly, disfigured\",\"x-order\":2,\"description\":\"Specify
+      things to not see in the output\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":30,\"maximum\":100,\"minimum\":0,\"x-order\":3,\"description\":\"Number
+      of diffusion steps\"},\"adapter_conditioning_scale\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Scale\",\"default\":0.8,\"maximum\":5,\"minimum\":0,\"x-order\":4,\"description\":\"Conditioning
+      scale\"},\"adapter_conditioning_factor\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Factor\",\"default\":1,\"maximum\":1,\"minimum\":0,\"x-order\":5,\"description\":\"Factor
+      to scale image by\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\",\"LMSDiscrete\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"logs\",\"completed\",\"start\",\"output\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/alaradirik/t2i-adapter-sdxl-canny\",\"owner\":\"alaradirik\",\"name\":\"t2i-adapter-sdxl-canny\",\"description\":\"Modify
+      images using canny edges\",\"visibility\":\"public\",\"github_url\":\"https://github.com/replicate/cog-t2i-adapter-sdxl\",\"paper_url\":\"https://arxiv.org/abs/2302.08453\",\"license_url\":null,\"run_count\":471,\"cover_image_url\":\"https://replicate.delivery/pbxt/ALPdmbV71P7OAx6kEoiG1vS7H4KBofifF1jGII7g73gZ4gqRA/out-0.png\",\"default_example\":{\"completed_at\":\"2023-10-03T18:23:21.819510Z\",\"created_at\":\"2023-10-03T18:21:43.072968Z\",\"error\":null,\"id\":\"hkkcjs3btzxux5ims3xbw6i33i\",\"input\":{\"image\":\"https://replicate.delivery/pbxt/Jbn8dWczMIyZiWFABt3p78K3mSEwR1d7LK6LQ8KqUyKuBPYd/org_canny.jpg\",\"prompt\":\"Mystical
+      fairy in real, magic, 4k picture, high quality\",\"scheduler\":\"K_EULER_ANCESTRAL\",\"num_samples\":1,\"guidance_scale\":7.5,\"negative_prompt\":\"extra
+      digit, fewer digits, cropped, worst quality, low quality, glitch, deformed,
+      mutated, ugly, disfigured\",\"num_inference_steps\":30,\"adapter_conditioning_scale\":0.8,\"adapter_conditioning_factor\":1},\"logs\":\"0%|
+      \         | 0/30 [00:00<?, ?it/s]\\n  3%|\u258E         | 1/30 [00:00<00:04,
+      \ 6.43it/s]\\n  7%|\u258B         | 2/30 [00:00<00:05,  4.88it/s]\\n 10%|\u2588
+      \        | 3/30 [00:00<00:06,  4.46it/s]\\n 13%|\u2588\u258E        | 4/30 [00:00<00:06,
+      \ 4.28it/s]\\n 17%|\u2588\u258B        | 5/30 [00:01<00:05,  4.17it/s]\\n 20%|\u2588\u2588
+      \       | 6/30 [00:01<00:05,  4.11it/s]\\n 23%|\u2588\u2588\u258E       | 7/30
+      [00:01<00:05,  4.08it/s]\\n 27%|\u2588\u2588\u258B       | 8/30 [00:01<00:05,
+      \ 4.06it/s]\\n 30%|\u2588\u2588\u2588       | 9/30 [00:02<00:05,  4.04it/s]\\n
+      33%|\u2588\u2588\u2588\u258E      | 10/30 [00:02<00:04,  4.03it/s]\\n 37%|\u2588\u2588\u2588\u258B
+      \     | 11/30 [00:02<00:04,  4.02it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      12/30 [00:02<00:04,  4.02it/s]\\n 43%|\u2588\u2588\u2588\u2588\u258E     | 13/30
+      [00:03<00:04,  4.01it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B     | 14/30 [00:03<00:03,
+      \ 4.01it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 15/30 [00:03<00:03,
+      \ 4.00it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 16/30 [00:03<00:03,
+      \ 4.00it/s]\\n 57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 17/30 [00:04<00:03,
+      \ 4.00it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 18/30 [00:04<00:03,
+      \ 3.99it/s]\\n 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E   | 19/30 [00:04<00:02,
+      \ 3.99it/s]\\n 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 20/30 [00:04<00:02,
+      \ 3.99it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 21/30 [00:05<00:02,
+      \ 3.99it/s]\\n 73%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E  | 22/30
+      [00:05<00:02,  3.99it/s]\\n 77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \ | 23/30 [00:05<00:01,  3.99it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 24/30 [00:05<00:01,  3.99it/s]\\n 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 25/30 [00:06<00:01,  3.98it/s]\\n 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      | 26/30 [00:06<00:01,  3.98it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 27/30 [00:06<00:00,  3.98it/s]\\n 93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      28/30 [00:06<00:00,  3.99it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      29/30 [00:07<00:00,  3.98it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:07<00:00,  3.98it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:07<00:00,  4.05it/s]\",\"metrics\":{\"predict_time\":11.955492},\"output\":[\"https://replicate.delivery/pbxt/33OGjp6AlPa2GtIT0QULkoZB5Ue81e40ESbcVKyDXqTY4gqRA/out-preprocessed.png\",\"https://replicate.delivery/pbxt/ALPdmbV71P7OAx6kEoiG1vS7H4KBofifF1jGII7g73gZ4gqRA/out-0.png\"],\"started_at\":\"2023-10-03T18:23:09.864018Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/hkkcjs3btzxux5ims3xbw6i33i\",\"cancel\":\"https://api.replicate.com/v1/predictions/hkkcjs3btzxux5ims3xbw6i33i/cancel\"},\"version\":\"f3666bbaf07a0fb356919cc0907e17cf861d9ad1a1e32379f2434f1953025650\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"f3666bbaf07a0fb356919cc0907e17cf861d9ad1a1e32379f2434f1953025650\",\"created_at\":\"2023-10-03T17:27:23.631644Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"image\"],\"properties\":{\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"Mystical
+      fairy in real, magic, 4k picture, high quality\",\"x-order\":1,\"description\":\"Input
+      prompt\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER_ANCESTRAL\",\"x-order\":8,\"description\":\"Which
+      scheduler to use\"},\"num_samples\":{\"type\":\"integer\",\"title\":\"Num Samples\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":7,\"description\":\"Number
+      of outputs to generate\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":10,\"minimum\":0,\"x-order\":6,\"description\":\"Guidance
+      scale to match the prompt\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"extra digit, fewer digits, cropped, worst quality, low
+      quality, glitch, deformed, mutated, ugly, disfigured\",\"x-order\":2,\"description\":\"Specify
+      things to not see in the output\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":30,\"maximum\":100,\"minimum\":0,\"x-order\":3,\"description\":\"Number
+      of diffusion steps\"},\"adapter_conditioning_scale\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Scale\",\"default\":0.8,\"maximum\":5,\"minimum\":0,\"x-order\":4,\"description\":\"Conditioning
+      scale\"},\"adapter_conditioning_factor\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Factor\",\"default\":1,\"maximum\":1,\"minimum\":0,\"x-order\":5,\"description\":\"Factor
+      to scale image by\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\",\"LMSDiscrete\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"logs\",\"output\",\"start\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/alaradirik/t2i-adapter-sdxl-sketch\",\"owner\":\"alaradirik\",\"name\":\"t2i-adapter-sdxl-sketch\",\"description\":\"Modify
+      images using sketches\",\"visibility\":\"public\",\"github_url\":\"https://github.com/replicate/cog-t2i-adapter-sdxl\",\"paper_url\":\"https://arxiv.org/abs/2302.08453\",\"license_url\":null,\"run_count\":367,\"cover_image_url\":\"https://pbxt.replicate.delivery/gK44xIViC3JgK52HohYGBndUX6iXBI54kTggoaxxBfcScQ1IA/out-0.png\",\"default_example\":{\"completed_at\":\"2023-10-03T18:23:32.775106Z\",\"created_at\":\"2023-10-03T18:21:46.627343Z\",\"error\":null,\"id\":\"mv6wykdbzllym7t52c2gnnqkwy\",\"input\":{\"image\":\"https://replicate.delivery/pbxt/Jbn9KLY1fCG2CNgBrsJgFKARXnIPi5I5vsO0gARPB8Olfz0O/org_sketch.png\",\"prompt\":\"a
+      robot, mount fuji in the background, 4k photo, highly detailed\",\"scheduler\":\"K_EULER_ANCESTRAL\",\"num_samples\":1,\"guidance_scale\":7.5,\"negative_prompt\":\"extra
+      digit, fewer digits, cropped, worst quality, low quality, glitch, deformed,
+      mutated, ugly, disfigured\",\"num_inference_steps\":30,\"adapter_conditioning_scale\":0.9,\"adapter_conditioning_factor\":1},\"logs\":\"0%|
+      \         | 0/30 [00:00<?, ?it/s]\\n  3%|\u258E         | 1/30 [00:00<00:04,
+      \ 6.55it/s]\\n  7%|\u258B         | 2/30 [00:00<00:05,  4.83it/s]\\n 10%|\u2588
+      \        | 3/30 [00:00<00:06,  4.41it/s]\\n 13%|\u2588\u258E        | 4/30 [00:00<00:06,
+      \ 4.24it/s]\\n 17%|\u2588\u258B        | 5/30 [00:01<00:06,  4.15it/s]\\n 20%|\u2588\u2588
+      \       | 6/30 [00:01<00:05,  4.10it/s]\\n 23%|\u2588\u2588\u258E       | 7/30
+      [00:01<00:05,  4.06it/s]\\n 27%|\u2588\u2588\u258B       | 8/30 [00:01<00:05,
+      \ 4.04it/s]\\n 30%|\u2588\u2588\u2588       | 9/30 [00:02<00:05,  4.03it/s]\\n
+      33%|\u2588\u2588\u2588\u258E      | 10/30 [00:02<00:04,  4.02it/s]\\n 37%|\u2588\u2588\u2588\u258B
+      \     | 11/30 [00:02<00:04,  4.01it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      12/30 [00:02<00:04,  4.00it/s]\\n 43%|\u2588\u2588\u2588\u2588\u258E     | 13/30
+      [00:03<00:04,  4.00it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B     | 14/30 [00:03<00:04,
+      \ 4.00it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 15/30 [00:03<00:03,
+      \ 3.99it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 16/30 [00:03<00:03,
+      \ 3.99it/s]\\n 57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 17/30 [00:04<00:03,
+      \ 3.99it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 18/30 [00:04<00:03,
+      \ 3.99it/s]\\n 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E   | 19/30 [00:04<00:02,
+      \ 3.99it/s]\\n 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 20/30 [00:04<00:02,
+      \ 3.99it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 21/30 [00:05<00:02,
+      \ 3.98it/s]\\n 73%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E  | 22/30
+      [00:05<00:02,  3.98it/s]\\n 77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \ | 23/30 [00:05<00:01,  3.98it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 24/30 [00:05<00:01,  3.98it/s]\\n 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 25/30 [00:06<00:01,  3.98it/s]\\n 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      | 26/30 [00:06<00:01,  3.98it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 27/30 [00:06<00:00,  3.98it/s]\\n 93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      28/30 [00:06<00:00,  3.98it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      29/30 [00:07<00:00,  3.97it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:07<00:00,  3.97it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:07<00:00,  4.04it/s]\",\"metrics\":{\"predict_time\":11.641135},\"output\":[\"https://pbxt.replicate.delivery/PYCnrpG2hHLnHBgRkn6f0Egr2Zrl0mVV43CpS2fJBhvj4gqRA/out-preprocessed.png\",\"https://pbxt.replicate.delivery/gK44xIViC3JgK52HohYGBndUX6iXBI54kTggoaxxBfcScQ1IA/out-0.png\"],\"started_at\":\"2023-10-03T18:23:21.133971Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/mv6wykdbzllym7t52c2gnnqkwy\",\"cancel\":\"https://api.replicate.com/v1/predictions/mv6wykdbzllym7t52c2gnnqkwy/cancel\"},\"version\":\"0aa9de8c59aa85091bf5deed8bf73f4bd58bbbece24e37038b036bc8fc1f47f6\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"0aa9de8c59aa85091bf5deed8bf73f4bd58bbbece24e37038b036bc8fc1f47f6\",\"created_at\":\"2023-10-03T17:14:03.714043Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"image\"],\"properties\":{\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"a
+      robot, mount fuji in the background, 4k photo, highly detailed\",\"x-order\":1,\"description\":\"Input
+      prompt\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER_ANCESTRAL\",\"x-order\":8,\"description\":\"Which
+      scheduler to use\"},\"num_samples\":{\"type\":\"integer\",\"title\":\"Num Samples\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":7,\"description\":\"Number
+      of outputs to generate\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":10,\"minimum\":0,\"x-order\":6,\"description\":\"Guidance
+      scale to match the prompt\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"extra digit, fewer digits, cropped, worst quality, low
+      quality, glitch, deformed, mutated, ugly, disfigured\",\"x-order\":2,\"description\":\"Specify
+      things to not see in the output\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":30,\"maximum\":100,\"minimum\":0,\"x-order\":3,\"description\":\"Number
+      of diffusion steps\"},\"adapter_conditioning_scale\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Scale\",\"default\":0.9,\"maximum\":5,\"minimum\":0,\"x-order\":4,\"description\":\"Conditioning
+      scale\"},\"adapter_conditioning_factor\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Factor\",\"default\":1,\"maximum\":1,\"minimum\":0,\"x-order\":5,\"description\":\"Factor
+      to scale image by\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\",\"LMSDiscrete\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"logs\",\"start\",\"output\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/alaradirik/t2i-adapter-sdxl-depth-midas\",\"owner\":\"alaradirik\",\"name\":\"t2i-adapter-sdxl-depth-midas\",\"description\":\"Modify
+      images using depth maps\",\"visibility\":\"public\",\"github_url\":\"https://github.com/replicate/cog-t2i-adapter-sdxl\",\"paper_url\":\"https://arxiv.org/abs/2302.08453\",\"license_url\":null,\"run_count\":225,\"cover_image_url\":\"https://pbxt.replicate.delivery/jR6ZtGztysLkJxhSeGHWu25iu9GfopTWIAeb6GSdr5K8xBVjA/out-0.png\",\"default_example\":{\"completed_at\":\"2023-10-03T18:23:59.395638Z\",\"created_at\":\"2023-10-03T18:21:38.642699Z\",\"error\":null,\"id\":\"xxu6o73bni3qrucb7vh6ect4oi\",\"input\":{\"image\":\"https://replicate.delivery/pbxt/JbnAzlvH84NR20HgqUdfnLlMMwwiU8Fv5N3FSjcRXPH6kmmu/org_mid.jpg\",\"prompt\":\"A
+      photo of a room, 4k photo, highly detailed\",\"scheduler\":\"K_EULER_ANCESTRAL\",\"num_samples\":1,\"guidance_scale\":7.5,\"negative_prompt\":\"anime,
+      cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed,
+      mutated, ugly, disfigured\",\"num_inference_steps\":30,\"adapter_conditioning_scale\":1,\"adapter_conditioning_factor\":1},\"logs\":\"0%|
+      \         | 0/30 [00:00<?, ?it/s]\\n  3%|\u258E         | 1/30 [00:00<00:05,
+      \ 5.32it/s]\\n  7%|\u258B         | 2/30 [00:00<00:07,  3.76it/s]\\n 10%|\u2588
+      \        | 3/30 [00:00<00:07,  3.43it/s]\\n 13%|\u2588\u258E        | 4/30 [00:01<00:07,
+      \ 3.29it/s]\\n 17%|\u2588\u258B        | 5/30 [00:01<00:07,  3.21it/s]\\n 20%|\u2588\u2588
+      \       | 6/30 [00:01<00:07,  3.17it/s]\\n 23%|\u2588\u2588\u258E       | 7/30
+      [00:02<00:07,  3.14it/s]\\n 27%|\u2588\u2588\u258B       | 8/30 [00:02<00:07,
+      \ 3.12it/s]\\n 30%|\u2588\u2588\u2588       | 9/30 [00:02<00:06,  3.11it/s]\\n
+      33%|\u2588\u2588\u2588\u258E      | 10/30 [00:03<00:06,  3.10it/s]\\n 37%|\u2588\u2588\u2588\u258B
+      \     | 11/30 [00:03<00:06,  3.09it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      12/30 [00:03<00:05,  3.09it/s]\\n 43%|\u2588\u2588\u2588\u2588\u258E     | 13/30
+      [00:04<00:05,  3.09it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B     | 14/30 [00:04<00:05,
+      \ 3.08it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 15/30 [00:04<00:04,
+      \ 3.08it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 16/30 [00:05<00:04,
+      \ 3.08it/s]\\n 57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 17/30 [00:05<00:04,
+      \ 3.08it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 18/30 [00:05<00:03,
+      \ 3.08it/s]\\n 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E   | 19/30 [00:06<00:03,
+      \ 3.08it/s]\\n 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 20/30 [00:06<00:03,
+      \ 3.07it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 21/30 [00:06<00:02,
+      \ 3.07it/s]\\n 73%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E  | 22/30
+      [00:07<00:02,  3.07it/s]\\n 77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \ | 23/30 [00:07<00:02,  3.07it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 24/30 [00:07<00:01,  3.07it/s]\\n 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 25/30 [00:07<00:01,  3.07it/s]\\n 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      | 26/30 [00:08<00:01,  3.07it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 27/30 [00:08<00:00,  3.07it/s]\\n 93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      28/30 [00:08<00:00,  3.07it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      29/30 [00:09<00:00,  3.07it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:09<00:00,  3.07it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      30/30 [00:09<00:00,  3.12it/s]\",\"metrics\":{\"predict_time\":14.094359},\"output\":[\"https://pbxt.replicate.delivery/ZgXuoCSFdiYffUaQY06W2nrdaR0uw28el95sIgYffjbzHHUNC/out-preprocessed.png\",\"https://pbxt.replicate.delivery/jR6ZtGztysLkJxhSeGHWu25iu9GfopTWIAeb6GSdr5K8xBVjA/out-0.png\"],\"started_at\":\"2023-10-03T18:23:45.301279Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/xxu6o73bni3qrucb7vh6ect4oi\",\"cancel\":\"https://api.replicate.com/v1/predictions/xxu6o73bni3qrucb7vh6ect4oi/cancel\"},\"version\":\"3263801326d7bf368327b89980371f634086e6bbbf734d9a2943cb516dd8209d\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"3263801326d7bf368327b89980371f634086e6bbbf734d9a2943cb516dd8209d\",\"created_at\":\"2023-10-03T16:57:41.516171Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"image\"],\"properties\":{\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"A
+      photo of a room, 4k photo, highly detailed\",\"x-order\":1,\"description\":\"Input
+      prompt\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER_ANCESTRAL\",\"x-order\":8,\"description\":\"Which
+      scheduler to use\"},\"num_samples\":{\"type\":\"integer\",\"title\":\"Num Samples\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":7,\"description\":\"Number
+      of outputs to generate\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":10,\"minimum\":0,\"x-order\":6,\"description\":\"Guidance
+      scale to match the prompt\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"anime, cartoon, graphic, text, painting, crayon, graphite,
+      abstract, glitch, deformed, mutated, ugly, disfigured\",\"x-order\":2,\"description\":\"Specify
+      things to not see in the output\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":30,\"maximum\":100,\"minimum\":0,\"x-order\":3,\"description\":\"Number
+      of diffusion steps\"},\"adapter_conditioning_scale\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Scale\",\"default\":1,\"maximum\":5,\"minimum\":0,\"x-order\":4,\"description\":\"Conditioning
+      scale\"},\"adapter_conditioning_factor\":{\"type\":\"number\",\"title\":\"Adapter
+      Conditioning Factor\",\"default\":1,\"maximum\":1,\"minimum\":0,\"x-order\":5,\"description\":\"Factor
+      to scale image by\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\",\"LMSDiscrete\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"completed\",\"start\",\"output\",\"logs\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/collectiveai-team/speaker-diarization\",\"owner\":\"collectiveai-team\",\"name\":\"speaker-diarization\",\"description\":null,\"visibility\":\"public\",\"github_url\":\"https://github.com/collectiveai-team/speaker-diarization\",\"paper_url\":null,\"license_url\":\"https://github.com/collectiveai-team/speaker-diarization/blob/master/LICENSE\",\"run_count\":31,\"cover_image_url\":null,\"default_example\":{\"completed_at\":\"2023-10-03T16:34:59.484513Z\",\"created_at\":\"2023-10-03T16:34:46.417939Z\",\"error\":null,\"id\":\"3be7ajzbelaqp37pwal4uezdga\",\"input\":{\"audio\":\"https://replicate.delivery/pbxt/IZjTvet2ZGiyiYaMEEPrzn0xY1UDNsh0NfcO9qeTlpwCo7ig/lex-levin-4min.mp3\"},\"logs\":\"pre-processing
+      audio file...\\ndiarizing audio file...\\npost-processing diarization...\",\"metrics\":{\"predict_time\":13.100666},\"output\":{\"segments\":[{\"stop\":\"0:00:09.779063\",\"start\":\"0:00:00.497812\",\"speaker\":\"A\"},{\"stop\":\"0:00:02.168438\",\"start\":\"0:00:02.033437\",\"speaker\":\"B\"},{\"stop\":\"0:03:34.962188\",\"start\":\"0:00:09.863438\",\"speaker\":\"B\"}],\"speakers\":{\"count\":2,\"labels\":[\"A\",\"B\"],\"embeddings\":{\"A\":[9.310075759887695,-27.64179039001465,-14.762784004211426,-17.466537094116212,2.7580766677856445,19.052671813964842,-16.875370025634766,-7.299699068069458,-65.25508728027344,-12.909603309631347,6.264938735961914,13.358126258850097,38.329629516601564,-3.1308562219142915,-11.796729016304017,4.290087080001831,-8.89090371131897,-10.128324127197265,-4.391824746131897,-30.03853416442871,-30.230362319946288,-14.816092586517334,-24.88817901611328,13.986051940917969,23.342521286010744,11.162271308898926,6.609025371074677,-18.776260375976562,28.81615104675293,-1.3106910467147828,-2.5739843904972077,21.19454154968262,-49.00073089599609,3.5885754108428953,21.810736083984374,25.079504776000977,-14.693890953063965,8.97171196937561,-7.242259883880616,-11.37008695602417,-5.243454313278198,-36.15898513793945,23.34603958129883,-4.157051658630371,21.51844596862793,-11.057127714157104,6.555679512023926,-13.908312797546387,33.92472343444824,11.567938899993896,-23.1836368560791,-5.180275821685791,-0.8282710194587708,21.182611083984376,-23.930481719970704,3.205435943603516,-3.8784342288970945,-15.09575023651123,-48.217420959472655,19.03274574279785,-27.574210739135744,-29.833530044555665,-7.482049655914307,2.9358553379774093,23.87143211364746,-7.623896360397339,-22.34128646850586,11.317081546783447,-6.68978271484375,10.826111316680908,-19.406490898132326,4.7065971970558165,-5.8659594535827635,-6.605202758312226,11.912405586242675,-14.804365730285644,-23.63058376312256,-8.743138122558594,-2.849660134315491,12.16765375137329,38.04754867553711,19.29851188659668,-23.864757537841797,-31.866744613647462,-31.388737869262695,11.139566040039062,-33.58438415527344,-6.406486892700196,1.6627443313598633,-44.30514907836914,-16.48921947479248,-41.213137817382815,-13.999722862243653,20.848640060424806,-18.245179176330566,-9.19658350944519,-29.11732063293457,-7.8856781959533695,5.826227712631225,3.259876823425293,-5.890431690216064,-3.3623939514160157,24.0858943939209,-34.49337158203125,28.32850875854492,-28.183864974975585,4.039748427271843,-35.015088653564455,-15.721043682098388,-8.19205379486084,0.9177106380462646,-39.72734069824219,-13.099750804901124,-10.812837028503418,-25.125615882873536,-6.918192911148071,-21.75787773132324,11.078657054901123,3.1919542849063873,16.539880752563477,-43.23692398071289,-4.214755123853683,16.05810432434082,23.939576721191408,19.378197860717773,-8.028977155685425,-0.8963969230651856,-18.981572151184082,-8.024488830566407,-8.853771877288818,19.528835487365722,-12.61584300994873,-35.648095321655276,18.98358886241913,-9.342331790924073,13.034672319889069,8.31449294090271,-18.11524906158447,18.777167320251465,-9.233685874938965,-24.865371322631837,7.655003094673157,-15.685989379882812,-10.471076393127442,-17.392689323425294,3.411249554157257,-10.969429397583008,9.79410753250122,2.7654022574424744,-7.563679039478302,4.7921384334564205,-14.966182327270507,10.491390800476074,5.369079804420471,-31.566866302490233,15.435317039489746,6.2813084602355955,-12.950390434265136,-15.940205955505371,32.08970222473145,16.64830493927002,-30.746527481079102,7.262925672531128,-32.63815536499023,-51.679510498046874,-11.635008430480957,5.131683993339538,0.4580568313598633,-2.7313339710235596,29.55116844177246,18.610058212280272,-20.68732681274414,35.20017318725586,-54.33326950073242,-9.80185670852661,0.9821877479553223,17.5637677192688,7.773923587799072,2.5621874809265135,5.212954974174499,8.001709985733033,-24.018921661376954,-10.53964672088623,-11.644916296005249,-13.237738132476807,-6.691392850875855,4.536542820930481,30.769504165649415,-30.073589324951172,12.824601435661316,17.575875663757323,34.85966453552246],\"B\":[-6.324989517281294,18.255837196050702,2.1882685653084075,-26.056038615038936,26.447756013601943,8.318345260122777,-28.427924884554674,8.750308856939721,25.348717058420448,9.366928117735611,17.3740619895289,16.86639999687824,20.473001710651324,-13.868836339401161,18.782591860074444,-23.914480289077513,16.95596894471313,-22.689905462057695,-26.458781285740226,30.634765659146908,-0.7209550802574476,-7.769484766113484,0.14328806773018654,11.192924083327242,-11.983569025231139,7.934183676229299,0.6814827359545871,8.958077379447573,13.355168824248453,-13.143657569613907,-18.31448710627873,5.392996171093963,-8.228229944434617,24.907607366361887,-15.1432077243705,2.0106011012954936,5.494847602637299,10.906771529470678,16.742450159238388,8.873203306589895,-7.056081808588999,7.302942982567545,10.343335376409314,-15.74836122837213,3.558724696454985,17.834133593094013,-22.73725928735855,16.715556411525174,-15.667759498214478,-11.460747877293079,-18.775667604583,-6.76814783623685,-19.399986456269804,-6.016207820571521,20.876119234601553,12.416658640974928,-10.234040111922623,12.208783776330216,1.004161010643996,36.92192337884927,-4.2651157933751795,6.151822556686752,-12.776553220799206,-7.129807502745896,-29.281900710919324,9.388462031360172,-8.761145603740612,-1.0274938783046248,-13.58357770003788,1.8826805305907794,-5.531303973244432,0.20366516175782284,13.787652918292434,11.626474774630783,11.948522707080597,-4.550185446324937,-3.045786194555709,1.8169122281319954,33.53838361651086,-16.21456532645256,3.733069306015587,-16.12310902711452,2.3818344679634893,15.838842242117734,0.8476554279017936,-14.019288518239774,-1.1690951749167937,-3.2021734511903714,1.75027914473887,40.45341742922888,8.175747054436094,-16.77663372054963,27.73495996455707,8.301485038017068,-12.589441435816495,6.468082441822114,13.317321401098958,3.3549129249494705,11.237235185702133,5.351735386397222,1.949345800434918,39.1866272489738,20.64522728163873,31.897343108721095,-12.601782777129918,36.48912101999268,-12.825211242927463,-7.744759436075092,-14.26055445474432,-18.6241741303707,7.793904709532057,3.7038692870675147,-9.13023126056737,45.336161962250614,-14.26716025527138,-14.299811104698406,-0.47221089417919937,6.9702567432047156,-13.497803598413688,-12.636516096037063,-29.85302555118985,-5.94576953088536,12.757197166190428,-6.51004730032333,33.108543338678075,6.515193468326574,4.051921340053344,-10.031854083890195,-14.759048526015732,6.1073221517036025,6.161594813132225,-2.2590786151330717,-20.956051638745286,11.376713172897048,-4.0980442202628575,-22.36599188235105,-9.825746321474272,-3.287666120225816,-6.233919148783549,1.7197107593612293,-1.4964318585670209,-3.7073294962458596,-15.867363188272853,-21.1823348799325,-22.443387020465053,27.585523909467565,11.179292719077576,-26.547821239132407,-41.368152314134875,8.557343448652789,-1.0383442460614092,-12.212289186694738,-25.382805775041167,-7.568509068902191,-17.315169315432648,-2.516002532761649,15.600549780080081,-12.379900205470717,8.146948202205893,-22.517786746134842,-8.944775241872538,14.850916515911937,5.686944761020524,7.476606217616707,34.68795469776749,-15.065047556172361,-1.6809848961170257,4.552526558070537,-12.51911949136716,11.280405993504292,-8.971013854074355,-9.87421035081091,-15.997252622528759,8.44555662774369,-0.3300793002838331,-16.695927358049033,-36.540493117573924,-18.103248942081276,-6.5841404468469,-17.76913873304415,-18.394592642650732,-29.242056273285996,4.964236819311557,7.474769217055052,19.742601972711665,9.33293106082036,32.105173540847076,2.532385345081539,-22.320042772366264,-26.563328375291945,-10.930344605070475,-19.84750042181186]}}},\"started_at\":\"2023-10-03T16:34:46.383847Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/3be7ajzbelaqp37pwal4uezdga\",\"cancel\":\"https://api.replicate.com/v1/predictions/3be7ajzbelaqp37pwal4uezdga/cancel\"},\"version\":\"53a87e44f3d3d0795e64e0e2ae1195bf51ce467f87050e9a9cd03f222811b084\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"53a87e44f3d3d0795e64e0e2ae1195bf51ce467f87050e9a9cd03f222811b084\",\"created_at\":\"2023-10-03T16:26:18.115589Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"audio\":{\"type\":\"string\",\"title\":\"Audio\",\"format\":\"uri\",\"default\":\"https://replicate.delivery/pbxt/IZjTvet2ZGiyiYaMEEPrzn0xY1UDNsh0NfcO9qeTlpwCo7ig/lex-levin-4min.mp3\",\"x-order\":0,\"description\":\"Audio
+      file or url\"}}},\"Output\":{\"$ref\":\"#/components/schemas/ModelOutput\",\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"Speakers\":{\"type\":\"object\",\"title\":\"Speakers\",\"required\":[\"count\",\"labels\",\"embeddings\"],\"properties\":{\"count\":{\"type\":\"integer\",\"title\":\"Count\"},\"labels\":{\"type\":\"array\",\"items\":{\"type\":\"string\"},\"title\":\"Labels\"},\"embeddings\":{\"type\":\"object\",\"title\":\"Embeddings\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"number\"}}}}},\"ModelOutput\":{\"type\":\"object\",\"title\":\"ModelOutput\",\"required\":[\"segments\",\"speakers\"],\"properties\":{\"segments\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/SpeakerSegment\"},\"title\":\"Segments\"},\"speakers\":{\"$ref\":\"#/components/schemas/Speakers\"}}},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"SpeakerSegment\":{\"type\":\"object\",\"title\":\"SpeakerSegment\",\"required\":[\"speaker\",\"start\",\"stop\"],\"properties\":{\"stop\":{\"type\":\"string\",\"title\":\"Stop\"},\"start\":{\"type\":\"string\",\"title\":\"Start\"},\"speaker\":{\"type\":\"string\",\"title\":\"Speaker\"}}},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"output\",\"logs\",\"start\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/qr2ai/3d_qr_code_ai_art_generator\",\"owner\":\"qr2ai\",\"name\":\"3d_qr_code_ai_art_generator\",\"description\":\"3D
+      QR CODE AI ART GENERATOR\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":25,\"cover_image_url\":\"https://replicate.delivery/pbxt/SDHaIeSEIRSfr0Z26H84wtZurC2QufbY303pyrTkcf2qz4pGB/output-0.png\",\"default_example\":{\"completed_at\":\"2023-10-03T15:20:26.851069Z\",\"created_at\":\"2023-10-03T15:20:05.453919Z\",\"error\":null,\"id\":\"ck56tdjb23qkhqxbmdlcajkegm\",\"input\":{\"seed\":7649977186,\"prompt\":\"3D
+      fairy-tale town, quaint village, charming, picturesque, idyllic, cobblestone
+      streets, storybook, fable, folklore, enchanting\",\"strength\":0.9,\"batch_size\":1,\"guidance_scale\":9.5,\"negative_prompt\":\"ugly,
+      disfigured, low quality, blurry, nsfw\",\"qr_code_content\":\"https://qr2ai.com\",\"num_inference_steps\":40,\"controlnet_conditioning_scale\":1.3},\"logs\":\"Generating
+      QR Code from content\\n  0%|          | 0/36 [00:00<?, ?it/s]\\n  3%|\u258E
+      \        | 1/36 [00:01<00:36,  1.03s/it]\\n  6%|\u258C         | 2/36 [00:01<00:24,
+      \ 1.38it/s]\\n  8%|\u258A         | 3/36 [00:02<00:20,  1.58it/s]\\n 11%|\u2588
+      \        | 4/36 [00:02<00:18,  1.71it/s]\\n 14%|\u2588\u258D        | 5/36 [00:03<00:17,
+      \ 1.78it/s]\\n 17%|\u2588\u258B        | 6/36 [00:03<00:16,  1.83it/s]\\n 19%|\u2588\u2589
+      \       | 7/36 [00:04<00:15,  1.86it/s]\\n 22%|\u2588\u2588\u258F       | 8/36
+      [00:04<00:14,  1.89it/s]\\n 25%|\u2588\u2588\u258C       | 9/36 [00:05<00:14,
+      \ 1.89it/s]\\n 28%|\u2588\u2588\u258A       | 10/36 [00:05<00:13,  1.91it/s]\\n
+      31%|\u2588\u2588\u2588       | 11/36 [00:06<00:13,  1.91it/s]\\n 33%|\u2588\u2588\u2588\u258E
+      \     | 12/36 [00:06<00:12,  1.91it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      13/36 [00:07<00:12,  1.91it/s]\\n 39%|\u2588\u2588\u2588\u2589      | 14/36
+      [00:07<00:11,  1.92it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 15/36 [00:08<00:10,
+      \ 1.92it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 16/36 [00:08<00:10,
+      \ 1.92it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B     | 17/36 [00:09<00:09,
+      \ 1.91it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 18/36 [00:09<00:09,
+      \ 1.91it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 19/36 [00:10<00:08,
+      \ 1.91it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C    | 20/36 [00:10<00:08,
+      \ 1.92it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A    | 21/36 [00:11<00:07,
+      \ 1.91it/s]\\n 61%|\u2588\u2588\u2588\u2588\u2588\u2588    | 22/36 [00:11<00:07,
+      \ 1.91it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D   | 23/36 [00:12<00:06,
+      \ 1.91it/s]\\n 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 24/36 [00:13<00:06,
+      \ 1.91it/s]\\n 69%|\u2588\u2588\u2588\u2588\u2588\u2588\u2589   | 25/36 [00:13<00:05,
+      \ 1.91it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F  | 26/36
+      [00:14<00:05,  1.90it/s]\\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 27/36 [00:14<00:04,  1.90it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 28/36 [00:15<00:04,  1.90it/s]\\n 81%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 29/36 [00:15<00:03,  1.90it/s]\\n 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 30/36 [00:16<00:03,  1.90it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 31/36 [00:16<00:02,  1.90it/s]\\n 89%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 32/36 [00:17<00:02,  1.89it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      33/36 [00:17<00:01,  1.89it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      34/36 [00:18<00:01,  1.90it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      35/36 [00:18<00:00,  1.89it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      36/36 [00:19<00:00,  1.89it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      36/36 [00:19<00:00,  1.86it/s]\",\"metrics\":{\"predict_time\":21.419276},\"output\":[\"https://replicate.delivery/pbxt/SDHaIeSEIRSfr0Z26H84wtZurC2QufbY303pyrTkcf2qz4pGB/output-0.png\"],\"started_at\":\"2023-10-03T15:20:05.431793Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/ck56tdjb23qkhqxbmdlcajkegm\",\"cancel\":\"https://api.replicate.com/v1/predictions/ck56tdjb23qkhqxbmdlcajkegm/cancel\"},\"version\":\"31c347e84342832ce7647daee2c084a0e0cd0669f5de15c7280f6cefd9146ea5\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"31c347e84342832ce7647daee2c084a0e0cd0669f5de15c7280f6cefd9146ea5\",\"created_at\":\"2023-10-03T14:50:48.248345Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"prompt\",\"qr_code_content\"],\"properties\":{\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"default\":-1,\"x-order\":5,\"description\":\"Seed\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"x-order\":0,\"description\":\"The
+      prompt to guide QR Code generation.\"},\"strength\":{\"type\":\"number\",\"title\":\"Strength\",\"default\":0.9,\"maximum\":1,\"minimum\":0,\"x-order\":7,\"description\":\"Indicates
+      how much to transform the masked portion of the reference `image`. Must be between
+      0 and 1.\"},\"batch_size\":{\"type\":\"integer\",\"title\":\"Batch Size\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Batch
+      size for this prediction\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":30,\"minimum\":0.1,\"x-order\":4,\"description\":\"Scale
+      for classifier-free guidance\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"ugly, disfigured, low quality, blurry, nsfw\",\"x-order\":2,\"description\":\"The
+      negative prompt to guide image generation.\"},\"qr_code_content\":{\"type\":\"string\",\"title\":\"Qr
+      Code Content\",\"x-order\":1,\"description\":\"The website/content your QR Code
+      will point to.\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":40,\"maximum\":100,\"minimum\":20,\"x-order\":3,\"description\":\"Number
+      of diffusion steps\"},\"controlnet_conditioning_scale\":{\"type\":\"number\",\"title\":\"Controlnet
+      Conditioning Scale\",\"default\":1.5,\"maximum\":2,\"minimum\":1,\"x-order\":8,\"description\":\"The
+      outputs of the controlnet are multiplied by `controlnet_conditioning_scale`
+      before they are added to the residual in the original unet.\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/zsxkib/st-mfnet\",\"owner\":\"zsxkib\",\"name\":\"st-mfnet\",\"description\":\"\U0001F4FD\uFE0F
+      Increase Framerate \U0001F3AC ST-MFNet: A Spatio-Temporal Multi-Flow Network
+      for Frame Interpolation\",\"visibility\":\"public\",\"github_url\":\"https://github.com/zsxkib/ST-MFNet\",\"paper_url\":\"https://arxiv.org/abs/2111.15483\",\"license_url\":\"https://github.com/danier97/ST-MFNet/blob/main/LICENSE\",\"run_count\":221,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/62abc5c1-849d-4291-b1e0-255854277aea/output.gif\",\"default_example\":{\"completed_at\":\"2023-10-03T13:09:36.440533Z\",\"created_at\":\"2023-10-03T13:07:48.199237Z\",\"error\":null,\"id\":\"zaxdvzlb6mjb6ymd4edo2a7pra\",\"input\":{\"mp4\":\"https://replicate.delivery/pbxt/JdRZ055TMXkzoGIwS4FiTgOYn840U3rOgGTKjM6gTCz9qztH/a_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z.mp4\",\"custom_fps\":1,\"keep_original_video_length\":true,\"number_of_framerate_doubles\":3},\"logs\":\"Video
+      Name: tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z.mp4\\nOriginal
+      Frame Rate (FPS): 8.0\\nOriginal Total Number of Frames: 16\\nEnhancing iterations:
+      \  0%|          | 0/3 [00:00<?, ?it/s]\\nProcessing frames:   0%|          |
+      0/13 [00:00<?, ?it/s]\\u001b[A/root/.pyenv/versions/3.8.17/lib/python3.8/site-packages/cupy/cuda/compiler.py:464:
+      UserWarning: cupy.cuda.compile_with_cache has been deprecated in CuPy v10, and
+      will be removed in the future. Use cupy.RawModule or cupy.RawKernel instead.\\nwarnings.warn(\\nProcessing
+      frames:   8%|\u258A         | 1/13 [00:02<00:30,  2.52s/it]\\u001b[A\\nProcessing
+      frames:  15%|\u2588\u258C        | 2/13 [00:02<00:13,  1.20s/it]\\u001b[A\\nProcessing
+      frames:  23%|\u2588\u2588\u258E       | 3/13 [00:03<00:07,  1.28it/s]\\u001b[A\\nProcessing
+      frames:  31%|\u2588\u2588\u2588       | 4/13 [00:03<00:05,  1.72it/s]\\u001b[A\\nProcessing
+      frames:  38%|\u2588\u2588\u2588\u258A      | 5/13 [00:03<00:03,  2.12it/s]\\u001b[A\\nProcessing
+      frames:  46%|\u2588\u2588\u2588\u2588\u258C     | 6/13 [00:03<00:02,  2.44it/s]\\u001b[A\\nProcessing
+      frames:  54%|\u2588\u2588\u2588\u2588\u2588\u258D    | 7/13 [00:04<00:02,  2.72it/s]\\u001b[A\\nProcessing
+      frames:  62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F   | 8/13 [00:04<00:01,
+      \ 2.95it/s]\\u001b[A\\nProcessing frames:  69%|\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      \  | 9/13 [00:04<00:01,  3.10it/s]\\u001b[A\\nProcessing frames:  77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \ | 10/13 [00:05<00:00,  3.22it/s]\\u001b[A\\nProcessing frames:  85%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 11/13 [00:05<00:00,  3.30it/s]\\u001b[A\\nProcessing frames:  92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      12/13 [00:05<00:00,  3.35it/s]\\u001b[A\\nProcessing frames: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      13/13 [00:05<00:00,  3.37it/s]\\u001b[A\\nProcessing frames: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      13/13 [00:05<00:00,  2.19it/s]\\nOutput filename: tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0.avi\\nNew
+      Total Number of Frames: 31\\nffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright
+      (c) 2000-2021 the FFmpeg developers\\nbuilt with gcc 11 (Ubuntu 11.2.0-19ubuntu1)\\nconfiguration:
+      --prefix=/usr --extra-version=0ubuntu0.22.04.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu
+      --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping
+      --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray
+      --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d
+      --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi
+      --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa
+      --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse
+      --enable-librabbitmq --enable-librubberband --enable-libshine --enable-libsnappy
+      --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora
+      --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp
+      --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq
+      --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl
+      --enable-sdl2 --enable-pocketsphinx --enable-librsvg --enable-libmfx --enable-libdc1394
+      --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264
+      --enable-shared\\nlibavutil      56. 70.100 / 56. 70.100\\nlibavcodec     58.134.100
+      / 58.134.100\\nlibavformat    58. 76.100 / 58. 76.100\\nlibavdevice    58. 13.100
+      / 58. 13.100\\nlibavfilter     7.110.100 /  7.110.100\\nlibswscale      5.  9.100
+      /  5.  9.100\\nlibswresample   3.  9.100 /  3.  9.100\\nlibpostproc    55.  9.100
+      / 55.  9.100\\nInput #0, avi, from 'tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0.avi':\\nMetadata:\\nsoftware
+      \       : Lavf59.27.100\\nDuration: 00:00:02.00, start: 0.000000, bitrate: 3102
+      kb/s\\nStream #0:0: Video: mpeg4 (Simple Profile) (DIVX / 0x58564944), yuv420p,
+      768x512 [SAR 1:1 DAR 3:2], 3179 kb/s, 15.50 fps, 15.50 tbr, 15.50 tbn, 31 tbc\\nStream
+      mapping:\\nStream #0:0 -> #0:0 (mpeg4 (native) -> h264 (libx264))\\nPress [q]
+      to stop, [?] for help\\n[libx264 @ 0x5562cda6ce80] using SAR=1/1\\n[libx264
+      @ 0x5562cda6ce80] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3
+      BMI2 AVX2\\n[libx264 @ 0x5562cda6ce80] profile High, level 3.0, 4:2:0, 8-bit\\n[libx264
+      @ 0x5562cda6ce80] 264 - core 163 r3060 5db6aa6 - H.264/MPEG-4 AVC codec - Copyleft
+      2003-2021 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0
+      analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16
+      chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2
+      threads=6 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0
+      bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0
+      direct=1 weightb=1 open_gop=0 weightp=2 keyint=250 keyint_min=15 scenecut=40
+      intra_refresh=0 rc_lookahead=40 rc=crf mbtree=1 crf=23.0 qcomp=0.60 qpmin=0
+      qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00\\nOutput #0, mp4, to 'tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0.mp4':\\nMetadata:\\nsoftware
+      \       : Lavf59.27.100\\nencoder         : Lavf58.76.100\\nStream #0:0: Video:
+      h264 (avc1 / 0x31637661), yuv420p(progressive), 768x512 [SAR 1:1 DAR 3:2], q=2-31,
+      15.50 fps, 15872 tbn\\nMetadata:\\nencoder         : Lavc58.134.100 libx264\\nSide
+      data:\\ncpb: bitrate max/min/avg: 0/0/0 buffer size: 0 vbv_delay: N/A\\nframe=
+      \   1 fps=0.0 q=0.0 size=       0kB time=00:00:00.00 bitrate=N/A speed=   0x\\nframe=
+      \  31 fps=0.0 q=-1.0 Lsize=     476kB time=00:00:01.80 bitrate=2160.6kbits/s
+      speed=4.84x\\nvideo:475kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB
+      muxing overhead: 0.225142%\\n[libx264 @ 0x5562cda6ce80] frame I:1     Avg QP:22.88
+      \ size: 35425\\n[libx264 @ 0x5562cda6ce80] frame P:25    Avg QP:23.74  size:
+      16633\\n[libx264 @ 0x5562cda6ce80] frame B:5     Avg QP:25.86  size:  6974\\n[libx264
+      @ 0x5562cda6ce80] consecutive B-frames: 71.0% 19.4%  9.7%  0.0%\\n[libx264 @
+      0x5562cda6ce80] mb I  I16..4:  1.2% 98.4%  0.3%\\n[libx264 @ 0x5562cda6ce80]
+      mb P  I16..4:  0.2%  7.3%  0.3%  P16..4: 51.9% 22.8% 12.5%  0.0%  0.0%    skip:
+      5.1%\\n[libx264 @ 0x5562cda6ce80] mb B  I16..4:  0.1%  1.7%  0.0%  B16..8: 31.6%
+      \ 5.6%  1.5%  direct: 8.3%  skip:51.2%  L0:25.1% L1:62.6% BI:12.4%\\n[libx264
+      @ 0x5562cda6ce80] 8x8 transform intra:95.7% inter:79.7%\\n[libx264 @ 0x5562cda6ce80]
+      coded y,uvDC,uvAC intra: 93.4% 69.7% 7.1% inter: 55.6% 26.0% 0.1%\\n[libx264
+      @ 0x5562cda6ce80] i16 v,h,dc,p:  8% 29% 42% 21%\\n[libx264 @ 0x5562cda6ce80]
+      i8 v,h,dc,ddl,ddr,vr,hd,vl,hu:  6% 26% 32%  4%  6%  3% 11%  3%  9%\\n[libx264
+      @ 0x5562cda6ce80] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu:  4% 32% 18%  5%  8%  4% 16%
+      \ 3% 11%\\n[libx264 @ 0x5562cda6ce80] i8c dc,h,v,p: 48% 38% 10%  4%\\n[libx264
+      @ 0x5562cda6ce80] Weighted P-Frames: Y:8.0% UV:0.0%\\n[libx264 @ 0x5562cda6ce80]
+      ref P L0: 74.1% 21.7%  3.1%  1.1%  0.0%\\n[libx264 @ 0x5562cda6ce80] ref B L0:
+      94.2%  3.8%  2.0%\\n[libx264 @ 0x5562cda6ce80] kb/s:1944.46\\nVideo Name: tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0.mp4\\nOriginal
+      Frame Rate (FPS): 15.5\\nOriginal Total Number of Frames: 31\\nEnhancing iterations:
+      \ 33%|\u2588\u2588\u2588\u258E      | 1/3 [00:06<00:12,  6.50s/it]\\nProcessing
+      frames:   0%|          | 0/28 [00:00<?, ?it/s]\\u001b[A\\nProcessing frames:
+      \  4%|\u258E         | 1/28 [00:00<00:07,  3.58it/s]\\u001b[A\\nProcessing frames:
+      \  7%|\u258B         | 2/28 [00:00<00:07,  3.65it/s]\\u001b[A\\nProcessing frames:
+      \ 11%|\u2588         | 3/28 [00:00<00:07,  3.40it/s]\\u001b[A\\nProcessing frames:
+      \ 14%|\u2588\u258D        | 4/28 [00:01<00:06,  3.51it/s]\\u001b[A\\nProcessing
+      frames:  18%|\u2588\u258A        | 5/28 [00:01<00:06,  3.57it/s]\\u001b[A\\nProcessing
+      frames:  21%|\u2588\u2588\u258F       | 6/28 [00:01<00:06,  3.53it/s]\\u001b[A\\nProcessing
+      frames:  25%|\u2588\u2588\u258C       | 7/28 [00:01<00:05,  3.56it/s]\\u001b[A\\nProcessing
+      frames:  29%|\u2588\u2588\u258A       | 8/28 [00:02<00:05,  3.59it/s]\\u001b[A\\nProcessing
+      frames:  32%|\u2588\u2588\u2588\u258F      | 9/28 [00:02<00:05,  3.60it/s]\\u001b[A\\nProcessing
+      frames:  36%|\u2588\u2588\u2588\u258C      | 10/28 [00:02<00:05,  3.59it/s]\\u001b[A\\nProcessing
+      frames:  39%|\u2588\u2588\u2588\u2589      | 11/28 [00:03<00:04,  3.59it/s]\\u001b[A\\nProcessing
+      frames:  43%|\u2588\u2588\u2588\u2588\u258E     | 12/28 [00:03<00:04,  3.60it/s]\\u001b[A\\nProcessing
+      frames:  46%|\u2588\u2588\u2588\u2588\u258B     | 13/28 [00:03<00:04,  3.59it/s]\\u001b[A\\nProcessing
+      frames:  50%|\u2588\u2588\u2588\u2588\u2588     | 14/28 [00:03<00:03,  3.58it/s]\\u001b[A\\nProcessing
+      frames:  54%|\u2588\u2588\u2588\u2588\u2588\u258E    | 15/28 [00:04<00:03,  3.59it/s]\\u001b[A\\nProcessing
+      frames:  57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 16/28 [00:04<00:03,  3.57it/s]\\u001b[A\\nProcessing
+      frames:  61%|\u2588\u2588\u2588\u2588\u2588\u2588    | 17/28 [00:04<00:03,  3.56it/s]\\u001b[A\\nProcessing
+      frames:  64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D   | 18/28 [00:05<00:02,
+      \ 3.50it/s]\\u001b[A\\nProcessing frames:  68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 19/28 [00:05<00:02,  3.51it/s]\\u001b[A\\nProcessing frames:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 20/28 [00:05<00:02,  3.50it/s]\\u001b[A\\nProcessing frames:  75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 21/28 [00:05<00:02,  3.49it/s]\\u001b[A\\nProcessing frames:  79%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 22/28 [00:06<00:01,  3.51it/s]\\u001b[A\\nProcessing frames:  82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 23/28 [00:06<00:01,  3.50it/s]\\u001b[A\\nProcessing frames:  86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 24/28 [00:06<00:01,  3.50it/s]\\u001b[A\\nProcessing frames:  89%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 25/28 [00:07<00:00,  3.48it/s]\\u001b[A\\nProcessing frames:  93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      26/28 [00:07<00:00,  3.48it/s]\\u001b[A\\nProcessing frames:  96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      27/28 [00:07<00:00,  3.47it/s]\\u001b[A\\nProcessing frames: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      28/28 [00:07<00:00,  3.46it/s]\\u001b[A\\nProcessing frames: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      28/28 [00:07<00:00,  3.53it/s]\\nOutput filename: tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1.avi\\nNew
+      Total Number of Frames: 61\\nffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright
+      (c) 2000-2021 the FFmpeg developers\\nbuilt with gcc 11 (Ubuntu 11.2.0-19ubuntu1)\\nconfiguration:
+      --prefix=/usr --extra-version=0ubuntu0.22.04.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu
+      --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping
+      --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray
+      --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d
+      --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi
+      --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa
+      --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse
+      --enable-librabbitmq --enable-librubberband --enable-libshine --enable-libsnappy
+      --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora
+      --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp
+      --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq
+      --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl
+      --enable-sdl2 --enable-pocketsphinx --enable-librsvg --enable-libmfx --enable-libdc1394
+      --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264
+      --enable-shared\\nlibavutil      56. 70.100 / 56. 70.100\\nlibavcodec     58.134.100
+      / 58.134.100\\nlibavformat    58. 76.100 / 58. 76.100\\nlibavdevice    58. 13.100
+      / 58. 13.100\\nlibavfilter     7.110.100 /  7.110.100\\nlibswscale      5.  9.100
+      /  5.  9.100\\nlibswresample   3.  9.100 /  3.  9.100\\nlibpostproc    55.  9.100
+      / 55.  9.100\\nInput #0, avi, from 'tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1.avi':\\nMetadata:\\nsoftware
+      \       : Lavf59.27.100\\nDuration: 00:00:02.00, start: 0.000000, bitrate: 3304
+      kb/s\\nStream #0:0: Video: mpeg4 (Simple Profile) (DIVX / 0x58564944), yuv420p,
+      768x512 [SAR 1:1 DAR 3:2], 3330 kb/s, 30.50 fps, 30.50 tbr, 30.50 tbn, 61 tbc\\nStream
+      mapping:\\nStream #0:0 -> #0:0 (mpeg4 (native) -> h264 (libx264))\\nPress [q]
+      to stop, [?] for help\\n[libx264 @ 0x555d3a300c40] using SAR=1/1\\n[libx264
+      @ 0x555d3a300c40] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3
+      BMI2 AVX2\\n[libx264 @ 0x555d3a300c40] profile High, level 3.1, 4:2:0, 8-bit\\n[libx264
+      @ 0x555d3a300c40] 264 - core 163 r3060 5db6aa6 - H.264/MPEG-4 AVC codec - Copyleft
+      2003-2021 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0
+      analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16
+      chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2
+      threads=6 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0
+      bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0
+      direct=1 weightb=1 open_gop=0 weightp=2 keyint=250 keyint_min=25 scenecut=40
+      intra_refresh=0 rc_lookahead=40 rc=crf mbtree=1 crf=23.0 qcomp=0.60 qpmin=0
+      qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00\\nOutput #0, mp4, to 'tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1.mp4':\\nMetadata:\\nsoftware
+      \       : Lavf59.27.100\\nencoder         : Lavf58.76.100\\nStream #0:0: Video:
+      h264 (avc1 / 0x31637661), yuv420p(progressive), 768x512 [SAR 1:1 DAR 3:2], q=2-31,
+      30.50 fps, 15616 tbn\\nMetadata:\\nencoder         : Lavc58.134.100 libx264\\nSide
+      data:\\ncpb: bitrate max/min/avg: 0/0/0 buffer size: 0 vbv_delay: N/A\\nframe=
+      \   1 fps=0.0 q=0.0 size=       0kB time=00:00:00.00 bitrate=N/A speed=   0x\\nframe=
+      \  61 fps=0.0 q=-1.0 Lsize=     392kB time=00:00:01.90 bitrate=1688.4kbits/s
+      speed=3.76x\\nvideo:391kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB
+      muxing overhead: 0.311909%\\n[libx264 @ 0x555d3a300c40] frame I:1     Avg QP:23.48
+      \ size: 31903\\n[libx264 @ 0x555d3a300c40] frame P:55    Avg QP:24.68  size:
+      \ 6575\\n[libx264 @ 0x555d3a300c40] frame B:5     Avg QP:27.17  size:  1182\\n[libx264
+      @ 0x555d3a300c40] consecutive B-frames: 83.6% 16.4%  0.0%  0.0%\\n[libx264 @
+      0x555d3a300c40] mb I  I16..4:  2.5% 96.9%  0.5%\\n[libx264 @ 0x555d3a300c40]
+      mb P  I16..4:  0.2%  2.3%  0.0%  P16..4: 52.7% 12.5%  6.6%  0.0%  0.0%    skip:25.6%\\n[libx264
+      @ 0x555d3a300c40] mb B  I16..4:  0.4%  0.8%  0.0%  B16..8: 30.5%  0.4%  0.1%
+      \ direct: 0.5%  skip:67.3%  L0: 3.3% L1:95.8% BI: 0.9%\\n[libx264 @ 0x555d3a300c40]
+      8x8 transform intra:92.8% inter:83.3%\\n[libx264 @ 0x555d3a300c40] coded y,uvDC,uvAC
+      intra: 83.0% 65.9% 3.0% inter: 29.0% 16.6% 0.0%\\n[libx264 @ 0x555d3a300c40]
+      i16 v,h,dc,p:  9% 36% 38% 17%\\n[libx264 @ 0x555d3a300c40] i8 v,h,dc,ddl,ddr,vr,hd,vl,hu:
+      \ 7% 28% 36%  4%  5%  2%  8%  3%  8%\\n[libx264 @ 0x555d3a300c40] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu:
+      10% 33% 16%  7% 10%  5% 10%  3%  7%\\n[libx264 @ 0x555d3a300c40] i8c dc,h,v,p:
+      47% 37% 12%  4%\\n[libx264 @ 0x555d3a300c40] Weighted P-Frames: Y:0.0% UV:0.0%\\n[libx264
+      @ 0x555d3a300c40] ref P L0: 73.3% 20.5%  5.3%  1.0%\\n[libx264 @ 0x555d3a300c40]
+      ref B L0: 83.8% 16.2%\\n[libx264 @ 0x555d3a300c40] kb/s:1597.71\\nVideo Name:
+      tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1.mp4\\nOriginal
+      Frame Rate (FPS): 30.5\\nOriginal Total Number of Frames: 61\\nEnhancing iterations:
+      \ 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 2/3 [00:15<00:07,  7.79s/it]\\nProcessing
+      frames:   0%|          | 0/58 [00:00<?, ?it/s]\\u001b[A\\nProcessing frames:
+      \  2%|\u258F         | 1/58 [00:00<00:15,  3.66it/s]\\u001b[A\\nProcessing frames:
+      \  3%|\u258E         | 2/58 [00:00<00:15,  3.69it/s]\\u001b[A\\nProcessing frames:
+      \  5%|\u258C         | 3/58 [00:00<00:14,  3.72it/s]\\u001b[A\\nProcessing frames:
+      \  7%|\u258B         | 4/58 [00:01<00:14,  3.73it/s]\\u001b[A\\nProcessing frames:
+      \  9%|\u258A         | 5/58 [00:01<00:14,  3.71it/s]\\u001b[A\\nProcessing frames:
+      \ 10%|\u2588         | 6/58 [00:01<00:14,  3.70it/s]\\u001b[A\\nProcessing frames:
+      \ 12%|\u2588\u258F        | 7/58 [00:01<00:13,  3.70it/s]\\u001b[A\\nProcessing
+      frames:  14%|\u2588\u258D        | 8/58 [00:02<00:13,  3.70it/s]\\u001b[A\\nProcessing
+      frames:  16%|\u2588\u258C        | 9/58 [00:02<00:13,  3.70it/s]\\u001b[A\\nProcessing
+      frames:  17%|\u2588\u258B        | 10/58 [00:02<00:12,  3.70it/s]\\u001b[A\\nProcessing
+      frames:  19%|\u2588\u2589        | 11/58 [00:02<00:12,  3.69it/s]\\u001b[A\\nProcessing
+      frames:  21%|\u2588\u2588        | 12/58 [00:03<00:12,  3.69it/s]\\u001b[A\\nProcessing
+      frames:  22%|\u2588\u2588\u258F       | 13/58 [00:03<00:12,  3.67it/s]\\u001b[A\\nProcessing
+      frames:  24%|\u2588\u2588\u258D       | 14/58 [00:03<00:12,  3.66it/s]\\u001b[A\\nProcessing
+      frames:  26%|\u2588\u2588\u258C       | 15/58 [00:04<00:11,  3.66it/s]\\u001b[A\\nProcessing
+      frames:  28%|\u2588\u2588\u258A       | 16/58 [00:04<00:11,  3.65it/s]\\u001b[A\\nProcessing
+      frames:  29%|\u2588\u2588\u2589       | 17/58 [00:04<00:11,  3.64it/s]\\u001b[A\\nProcessing
+      frames:  31%|\u2588\u2588\u2588       | 18/58 [00:04<00:11,  3.63it/s]\\u001b[A\\nProcessing
+      frames:  33%|\u2588\u2588\u2588\u258E      | 19/58 [00:05<00:10,  3.62it/s]\\u001b[A\\nProcessing
+      frames:  34%|\u2588\u2588\u2588\u258D      | 20/58 [00:05<00:10,  3.61it/s]\\u001b[A\\nProcessing
+      frames:  36%|\u2588\u2588\u2588\u258C      | 21/58 [00:05<00:10,  3.60it/s]\\u001b[A\\nProcessing
+      frames:  38%|\u2588\u2588\u2588\u258A      | 22/58 [00:06<00:09,  3.60it/s]\\u001b[A\\nProcessing
+      frames:  40%|\u2588\u2588\u2588\u2589      | 23/58 [00:06<00:09,  3.59it/s]\\u001b[A\\nProcessing
+      frames:  41%|\u2588\u2588\u2588\u2588\u258F     | 24/58 [00:06<00:09,  3.59it/s]\\u001b[A\\nProcessing
+      frames:  43%|\u2588\u2588\u2588\u2588\u258E     | 25/58 [00:06<00:09,  3.57it/s]\\u001b[A\\nProcessing
+      frames:  45%|\u2588\u2588\u2588\u2588\u258D     | 26/58 [00:07<00:08,  3.56it/s]\\u001b[A\\nProcessing
+      frames:  47%|\u2588\u2588\u2588\u2588\u258B     | 27/58 [00:07<00:08,  3.55it/s]\\u001b[A\\nProcessing
+      frames:  48%|\u2588\u2588\u2588\u2588\u258A     | 28/58 [00:07<00:08,  3.55it/s]\\u001b[A\\nProcessing
+      frames:  50%|\u2588\u2588\u2588\u2588\u2588     | 29/58 [00:07<00:08,  3.53it/s]\\u001b[A\\nProcessing
+      frames:  52%|\u2588\u2588\u2588\u2588\u2588\u258F    | 30/58 [00:08<00:07,  3.53it/s]\\u001b[A\\nProcessing
+      frames:  53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 31/58 [00:08<00:07,  3.53it/s]\\u001b[A\\nProcessing
+      frames:  55%|\u2588\u2588\u2588\u2588\u2588\u258C    | 32/58 [00:08<00:07,  3.51it/s]\\u001b[A\\nProcessing
+      frames:  57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 33/58 [00:09<00:07,  3.48it/s]\\u001b[A\\nProcessing
+      frames:  59%|\u2588\u2588\u2588\u2588\u2588\u258A    | 34/58 [00:09<00:06,  3.46it/s]\\u001b[A\\nProcessing
+      frames:  60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 35/58 [00:09<00:06,  3.47it/s]\\u001b[A\\nProcessing
+      frames:  62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F   | 36/58 [00:10<00:06,
+      \ 3.47it/s]\\u001b[A\\nProcessing frames:  64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 37/58 [00:10<00:06,  3.46it/s]\\u001b[A\\nProcessing frames:  66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 38/58 [00:10<00:05,  3.45it/s]\\u001b[A\\nProcessing frames:  67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      \  | 39/58 [00:10<00:05,  3.45it/s]\\u001b[A\\nProcessing frames:  69%|\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      \  | 40/58 [00:11<00:05,  3.45it/s]\\u001b[A\\nProcessing frames:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 41/58 [00:11<00:04,  3.44it/s]\\u001b[A\\nProcessing frames:  72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 42/58 [00:11<00:04,  3.42it/s]\\u001b[A\\nProcessing frames:  74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 43/58 [00:12<00:04,  3.42it/s]\\u001b[A\\nProcessing frames:  76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 44/58 [00:12<00:04,  3.37it/s]\\u001b[A\\nProcessing frames:  78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 45/58 [00:12<00:03,  3.38it/s]\\u001b[A\\nProcessing frames:  79%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      \ | 46/58 [00:12<00:03,  3.37it/s]\\u001b[A\\nProcessing frames:  81%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 47/58 [00:13<00:03,  3.38it/s]\\u001b[A\\nProcessing frames:  83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 48/58 [00:13<00:02,  3.38it/s]\\u001b[A\\nProcessing frames:  84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 49/58 [00:13<00:02,  3.37it/s]\\u001b[A\\nProcessing frames:  86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 50/58 [00:14<00:02,  3.35it/s]\\u001b[A\\nProcessing frames:  88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 51/58 [00:14<00:02,  3.35it/s]\\u001b[A\\nProcessing frames:  90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 52/58 [00:14<00:01,  3.36it/s]\\u001b[A\\nProcessing frames:  91%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      53/58 [00:15<00:01,  3.35it/s]\\u001b[A\\nProcessing frames:  93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      54/58 [00:15<00:01,  3.31it/s]\\u001b[A\\nProcessing frames:  95%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      55/58 [00:15<00:00,  3.33it/s]\\u001b[A\\nProcessing frames:  97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      56/58 [00:15<00:00,  3.32it/s]\\u001b[A\\nProcessing frames:  98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      57/58 [00:16<00:00,  3.34it/s]\\u001b[A\\nProcessing frames: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      58/58 [00:16<00:00,  3.33it/s]\\u001b[A\\nProcessing frames: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      58/58 [00:16<00:00,  3.51it/s]\\nOutput filename: tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1_2.avi\\nNew
+      Total Number of Frames: 121\\nffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright
+      (c) 2000-2021 the FFmpeg developers\\nbuilt with gcc 11 (Ubuntu 11.2.0-19ubuntu1)\\nconfiguration:
+      --prefix=/usr --extra-version=0ubuntu0.22.04.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu
+      --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping
+      --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray
+      --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d
+      --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi
+      --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa
+      --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse
+      --enable-librabbitmq --enable-librubberband --enable-libshine --enable-libsnappy
+      --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora
+      --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp
+      --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq
+      --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl
+      --enable-sdl2 --enable-pocketsphinx --enable-librsvg --enable-libmfx --enable-libdc1394
+      --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264
+      --enable-shared\\nlibavutil      56. 70.100 / 56. 70.100\\nlibavcodec     58.134.100
+      / 58.134.100\\nlibavformat    58. 76.100 / 58. 76.100\\nlibavdevice    58. 13.100
+      / 58. 13.100\\nlibavfilter     7.110.100 /  7.110.100\\nlibswscale      5.  9.100
+      /  5.  9.100\\nlibswresample   3.  9.100 /  3.  9.100\\nlibpostproc    55.  9.100
+      / 55.  9.100\\nInput #0, avi, from 'tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1_2.avi':\\nMetadata:\\nsoftware
+      \       : Lavf59.27.100\\nDuration: 00:00:02.00, start: 0.000000, bitrate: 4273
+      kb/s\\nStream #0:0: Video: mpeg4 (Simple Profile) (DIVX / 0x58564944), yuv420p,
+      768x512 [SAR 1:1 DAR 3:2], 4274 kb/s, 60.50 fps, 60 tbr, 60.50 tbn, 121 tbc\\nStream
+      mapping:\\nStream #0:0 -> #0:0 (mpeg4 (native) -> h264 (libx264))\\nPress [q]
+      to stop, [?] for help\\n[libx264 @ 0x55a8408d5580] using SAR=1/1\\n[libx264
+      @ 0x55a8408d5580] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3
+      BMI2 AVX2\\n[libx264 @ 0x55a8408d5580] profile High, level 3.1, 4:2:0, 8-bit\\n[libx264
+      @ 0x55a8408d5580] 264 - core 163 r3060 5db6aa6 - H.264/MPEG-4 AVC codec - Copyleft
+      2003-2021 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0
+      analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16
+      chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2
+      threads=6 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0
+      bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0
+      direct=1 weightb=1 open_gop=0 weightp=2 keyint=250 keyint_min=25 scenecut=40
+      intra_refresh=0 rc_lookahead=40 rc=crf mbtree=1 crf=23.0 qcomp=0.60 qpmin=0
+      qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00\\nOutput #0, mp4, to 'tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1_2.mp4':\\nMetadata:\\nsoftware
+      \       : Lavf59.27.100\\nencoder         : Lavf58.76.100\\nStream #0:0: Video:
+      h264 (avc1 / 0x31637661), yuv420p(progressive), 768x512 [SAR 1:1 DAR 3:2], q=2-31,
+      60 fps, 15360 tbn\\nMetadata:\\nencoder         : Lavc58.134.100 libx264\\nSide
+      data:\\ncpb: bitrate max/min/avg: 0/0/0 buffer size: 0 vbv_delay: N/A\\nframe=
+      \   1 fps=0.0 q=0.0 size=       0kB time=00:00:00.00 bitrate=N/A speed=   0x\\nframe=
+      \ 121 fps=0.0 q=31.0 size=       0kB time=00:00:01.13 bitrate=   0.3kbits/s
+      speed=2.15x\\nframe=  121 fps=0.0 q=-1.0 Lsize=     308kB time=00:00:01.96 bitrate=1281.4kbits/s
+      speed=2.67x\\nvideo:305kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB
+      muxing overhead: 0.708410%\\n[libx264 @ 0x55a8408d5580] frame I:1     Avg QP:24.24
+      \ size: 28703\\n[libx264 @ 0x55a8408d5580] frame P:60    Avg QP:25.63  size:
+      \ 4208\\n[libx264 @ 0x55a8408d5580] frame B:60    Avg QP:28.35  size:   516\\n[libx264
+      @ 0x55a8408d5580] consecutive B-frames: 18.2% 46.3%  2.5% 33.1%\\n[libx264 @
+      0x55a8408d5580] mb I  I16..4:  2.4% 96.3%  1.3%\\n[libx264 @ 0x55a8408d5580]
+      mb P  I16..4:  0.3%  2.5%  0.0%  P16..4: 51.3%  8.2%  3.6%  0.0%  0.0%    skip:34.1%\\n[libx264
+      @ 0x55a8408d5580] mb B  I16..4:  0.1%  0.1%  0.0%  B16..8: 30.3%  0.1%  0.0%
+      \ direct: 0.0%  skip:69.4%  L0:34.5% L1:64.2% BI: 1.3%\\n[libx264 @ 0x55a8408d5580]
+      8x8 transform intra:88.4% inter:87.2%\\n[libx264 @ 0x55a8408d5580] coded y,uvDC,uvAC
+      intra: 75.2% 63.0% 1.7% inter: 10.6% 8.0% 0.0%\\n[libx264 @ 0x55a8408d5580]
+      i16 v,h,dc,p:  9% 41% 31% 19%\\n[libx264 @ 0x55a8408d5580] i8 v,h,dc,ddl,ddr,vr,hd,vl,hu:
+      \ 9% 30% 35%  3%  4%  2%  7%  3%  7%\\n[libx264 @ 0x55a8408d5580] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu:
+      \ 4% 39% 20%  3%  9%  3% 12%  2%  8%\\n[libx264 @ 0x55a8408d5580] i8c dc,h,v,p:
+      47% 38% 12%  3%\\n[libx264 @ 0x55a8408d5580] Weighted P-Frames: Y:0.0% UV:0.0%\\n[libx264
+      @ 0x55a8408d5580] ref P L0: 68.6% 19.1% 10.3%  2.0%\\n[libx264 @ 0x55a8408d5580]
+      ref B L0: 96.0%  3.7%  0.4%\\n[libx264 @ 0x55a8408d5580] ref B L1: 99.2%  0.8%\\n[libx264
+      @ 0x55a8408d5580] kb/s:1238.18\\nEnhancing iterations: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      3/3 [00:32<00:00, 12.28s/it]\\nEnhancing iterations: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      3/3 [00:32<00:00, 10.94s/it]\",\"metrics\":{\"predict_time\":34.512861},\"output\":[\"https://pbxt.replicate.delivery/lBRXA0rSNkZMPdXR4n3sokiWsywXlxNFbUDypmsmxez6IO1IA/tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0.mp4\",\"https://pbxt.replicate.delivery/mvq7RecOmehiXUV1F6DXEWEaXnn3fbkeQsKZ7ZdZi3P5HxpGB/tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1.mp4\",\"https://pbxt.replicate.delivery/YBivp9ZY0Ap7EJZG3LG9rlG2NhnQJfpfwEazveelAzdeRiTNC/tmpao8iu3bfa_handheld_shot_of_a_colorful__zoom_out_motion_strength_20231003T130605245Z_0_1_2.mp4\"],\"started_at\":\"2023-10-03T13:09:01.927672Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/zaxdvzlb6mjb6ymd4edo2a7pra\",\"cancel\":\"https://api.replicate.com/v1/predictions/zaxdvzlb6mjb6ymd4edo2a7pra/cancel\"},\"version\":\"497fd042485acee69204ac69db98c118eb3c3b66952aba6956b0aeca4fbb6fe0\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"e10e8cee773acea33c0e8b9a2509dde0214552b91a38dadb25b4baf454a46a9b\",\"created_at\":\"2023-10-03T14:40:11.845295Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"mp4\"],\"properties\":{\"mp4\":{\"type\":\"string\",\"title\":\"Mp4\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Upload
+      an mp4 video file.\"},\"custom_fps\":{\"type\":\"number\",\"title\":\"Custom
+      Fps\",\"maximum\":240,\"minimum\":1,\"x-order\":2,\"description\":\"Set `keep_original_duration`
+      to `False` to use this! Desired frame rate (fps) for the enhanced video. This
+      will only be considered if `keep_original_duration` is set to `False`.\"},\"framerate_multiplier\":{\"allOf\":[{\"$ref\":\"#/components/schemas/framerate_multiplier\"}],\"default\":2,\"x-order\":3,\"description\":\"Determines
+      how many intermediate frames to generate between original frames. E.g., a value
+      of 2 will double the frame rate, and 4 will quadruple it, etc.\"},\"keep_original_duration\":{\"type\":\"boolean\",\"title\":\"Keep
+      Original Duration\",\"default\":true,\"x-order\":1,\"description\":\"Should
+      the enhanced video retain the original duration? If set to `True`, the model
+      will adjust the frame rate to maintain the video's original duration after adding
+      interpolated frames. If set to `False`, the frame rate will be set based on
+      `custom_fps`.\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}},\"framerate_multiplier\":{\"enum\":[2,4,8,16,32],\"type\":\"integer\",\"title\":\"framerate_multiplier\",\"description\":\"An
+      enumeration.\"}}}}}},{\"url\":\"https://replicate.com/nelsonjchen/op-replay-clipper\",\"owner\":\"nelsonjchen\",\"name\":\"op-replay-clipper\",\"description\":\"(Alpha)
+      GPU accelerated replay renderer for comma.ai connect's openpilot route data\",\"visibility\":\"public\",\"github_url\":\"https://github.com/nelsonjchen/op-replay-clipper\",\"paper_url\":null,\"license_url\":\"https://github.com/nelsonjchen/op-replay-clipper/blob/master/LICENSE.md\",\"run_count\":221,\"cover_image_url\":\"https://replicate.comNone\",\"default_example\":{\"completed_at\":\"2023-09-25T15:09:55.532347Z\",\"created_at\":\"2023-09-25T15:07:02.910753Z\",\"error\":null,\"id\":\"zjop44zbc3u4yvj5klabxyuaau\",\"input\":{\"notes\":\"\",\"route\":\"a2a0ccea32023010|2023-07-27--13-01-19\",\"fileSize\":50,\"smearAmount\":5,\"startSeconds\":50,\"lengthSeconds\":20,\"speedhackRatio\":1},\"logs\":\"Downloading
+      file list from https://api.commadotai.com/v1/route/a2a0ccea32023010%7C2023-07-27--13-01-19/files\\nFiles
+      Downloaded:   0%|          | 0/6 [00:00<?, ?file/s]\\necamera.hevc:   0%|          |
+      0.00/75.0M [00:00<?, ?B/s]\\u001b[A\\u001b[A\\nrlog.bz2:   0%|          | 0.00/13.4M
+      [00:00<?, ?B/s]\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:   0%|          |
+      0.00/75.0M [00:00<?, ?B/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  0%|          | 0.00/75.1M [00:00<?, ?B/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  0%|          | 0.00/75.0M [00:00<?, ?B/s]\\u001b[A\\nrlog.bz2:   0%|          |
+      0.00/14.1M [00:00<?, ?B/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \  0%|          | 3.00/13.4M [00:00<344:46:38, 10.8B/s]\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  0%|          | 1.02k/75.0M [00:00<5:57:12, 3.50kB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  0%|          | 1.02k/75.0M [00:00<5:38:38, 3.69kB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  0%|          | 1.02k/75.1M [00:00<5:23:07, 3.87kB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  0%|          | 1.02k/75.0M [00:00<6:35:17, 3.16kB/s]\\u001b[A\\nrlog.bz2:
+      \  0%|          | 1.02k/14.1M [00:00<1:13:32, 3.19kB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  1%|          | 767k/75.0M [00:00<00:29, 2.50MB/s]   \\u001b[A\\u001b[A\\necamera.hevc:
+      \  0%|          | 304k/75.1M [00:00<01:10, 1.07MB/s]   \\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  1%|          | 423k/75.0M [00:00<00:52, 1.42MB/s]   \\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \  4%|\u258D         | 538k/13.4M [00:00<00:07, 1.76MB/s]   \\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \  3%|\u258E         | 472k/14.1M [00:00<00:09, 1.45MB/s]   \\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  1%|          | 439k/75.0M [00:00<00:58, 1.27MB/s]   \\u001b[A\\nfcamera.hevc:
+      \  2%|\u258F         | 1.53M/75.0M [00:00<00:16, 4.56MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  4%|\u258E         | 2.73M/75.0M [00:00<00:09, 7.79MB/s]\\u001b[A\\u001b[A\\necamera.hevc:
+      \  1%|\u258F         | 1.09M/75.1M [00:00<00:22, 3.26MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 15%|\u2588\u258D        | 1.96M/13.4M [00:00<00:02, 5.35MB/s]\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  1%|\u258F         | 1.11M/75.0M [00:00<00:25, 2.85MB/s]\\u001b[A\\nrlog.bz2:
+      \  9%|\u2589         | 1.27M/14.1M [00:00<00:03, 3.25MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  7%|\u258B         | 5.13M/75.0M [00:00<00:05, 12.5MB/s]\\u001b[A\\u001b[A\\necamera.hevc:
+      \  3%|\u258E         | 2.03M/75.1M [00:00<00:14, 4.89MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  4%|\u258E         | 2.75M/75.0M [00:00<00:11, 6.38MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 28%|\u2588\u2588\u258A       | 3.77M/13.4M [00:00<00:01, 7.99MB/s]\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 12%|\u2588\u258F        | 1.73M/14.1M [00:00<00:03, 3.62MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  2%|\u258F         | 1.72M/75.0M [00:00<00:19, 3.70MB/s]\\u001b[A\\necamera.hevc:
+      \  9%|\u2589         | 6.66M/75.0M [00:00<00:05, 12.6MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  5%|\u258C         | 4.08M/75.0M [00:00<00:08, 8.00MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  4%|\u258D         | 2.98M/75.1M [00:00<00:12, 5.77MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 40%|\u2588\u2588\u2588\u2589      | 5.34M/13.4M [00:00<00:00, 9.21MB/s]\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 22%|\u2588\u2588\u258F       | 3.03M/14.1M [00:00<00:01, 5.61MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  4%|\u258D         | 2.91M/75.0M [00:00<00:13, 5.32MB/s]\\u001b[A\\necamera.hevc:
+      \ 11%|\u2588\u258F        | 8.50M/75.0M [00:00<00:05, 12.1MB/s]\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 59%|\u2588\u2588\u2588\u2588\u2588\u258A    | 7.88M/13.4M [00:00<00:00, 13.4MB/s]\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  9%|\u258A         | 6.40M/75.0M [00:00<00:06, 10.4MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \  7%|\u258B         | 5.35M/75.1M [00:00<00:07, 9.11MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 36%|\u2588\u2588\u2588\u258C      | 5.04M/14.1M [00:00<00:00, 9.54MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  7%|\u258B         | 5.16M/75.0M [00:00<00:07, 9.86MB/s]\\u001b[A\\necamera.hevc:
+      \ 15%|\u2588\u258D        | 11.1M/75.0M [00:00<00:04, 15.7MB/s]\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2589   | 9.40M/13.4M [00:01<00:00,
+      10.9MB/s]\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  12%|\u2588\u258F        |
+      9.01M/75.0M [00:01<00:05, 11.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 11%|\u2588         | 7.95M/75.1M [00:01<00:06, 10.4MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 49%|\u2588\u2588\u2588\u2588\u2589     | 6.96M/14.1M [00:01<00:00, 9.42MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \  9%|\u258A         | 6.49M/75.0M [00:01<00:08, 8.38MB/s]\\u001b[A\\necamera.hevc:
+      \ 17%|\u2588\u258B        | 12.8M/75.0M [00:01<00:04, 12.6MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 16%|\u2588\u258C        | 11.6M/75.0M [00:01<00:04, 12.8MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 14%|\u2588\u258D        | 10.6M/75.1M [00:01<00:05, 12.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A   | 9.57M/14.1M [00:01<00:00,
+      11.7MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B | 11.7M/13.4M [00:01<00:00,
+      11.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  12%|\u2588\u258F        |
+      9.09M/75.0M [00:01<00:06, 10.9MB/s]\\u001b[A\\necamera.hevc:  20%|\u2588\u2588
+      \       | 15.0M/75.0M [00:01<00:04, 13.0MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 19%|\u2588\u2589        | 14.3M/75.0M [00:01<00:04, 14.1MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 18%|\u2588\u258A        | 13.2M/75.1M [00:01<00:04, 13.8MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B | 12.2M/14.1M [00:01<00:00,
+      13.4MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nrlog.bz2:
+      \ 99%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 13.3M/13.4M
+      [00:01<00:00, 11.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  16%|\u2588\u258C
+      \       | 11.7M/75.0M [00:01<00:04, 13.0MB/s]\\u001b[A\\n\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 24%|\u2588\u2588\u258E       | 17.7M/75.0M [00:01<00:03, 14.7MB/s]\\u001b[A\\u001b[A\\nFiles
+      Downloaded:  17%|\u2588\u258B        | 1/6 [00:01<00:08,  1.80s/file]\\nfcamera.hevc:
+      \ 23%|\u2588\u2588\u258E       | 16.9M/75.0M [00:01<00:03, 15.6MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 21%|\u2588\u2588        | 15.8M/75.1M [00:01<00:03, 15.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 19%|\u2588\u2589        | 14.3M/75.0M [00:01<00:04, 15.1MB/s]\\u001b[A\\nrlog.bz2:
+      \ 99%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 14.0M/14.1M
+      [00:01<00:00, 13.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\n\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 27%|\u2588\u2588\u258B       | 20.3M/75.0M [00:01<00:03, 16.3MB/s]\\u001b[A\\u001b[A\\nFiles
+      Downloaded:  33%|\u2588\u2588\u2588\u258E      | 2/6 [00:01<00:03,  1.23file/s]\\nfcamera.hevc:
+      \ 26%|\u2588\u2588\u258C       | 19.5M/75.0M [00:01<00:03, 17.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 25%|\u2588\u2588\u258D       | 18.4M/75.1M [00:01<00:03, 17.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 23%|\u2588\u2588\u258E       | 16.9M/75.0M [00:01<00:03, 17.0MB/s]\\u001b[A\\necamera.hevc:
+      \ 31%|\u2588\u2588\u2588       | 22.9M/75.0M [00:01<00:02, 18.0MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 30%|\u2588\u2588\u2589       | 22.1M/75.0M [00:01<00:02, 18.9MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 28%|\u2588\u2588\u258A       | 21.0M/75.1M [00:01<00:02, 18.7MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 26%|\u2588\u2588\u258C       | 19.6M/75.0M [00:01<00:02, 18.7MB/s]\\u001b[A\\necamera.hevc:
+      \ 34%|\u2588\u2588\u2588\u258D      | 25.5M/75.0M [00:01<00:02, 19.3MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 33%|\u2588\u2588\u2588\u258E      | 24.7M/75.0M [00:01<00:02, 19.5MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 31%|\u2588\u2588\u2588\u258F      | 23.6M/75.1M [00:01<00:02, 19.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 30%|\u2588\u2588\u2589       | 22.2M/75.0M [00:01<00:02, 19.3MB/s]\\u001b[A\\necamera.hevc:
+      \ 37%|\u2588\u2588\u2588\u258B      | 28.1M/75.0M [00:01<00:02, 19.8MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 36%|\u2588\u2588\u2588\u258B      | 27.4M/75.0M [00:02<00:02, 20.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 35%|\u2588\u2588\u2588\u258D      | 26.3M/75.1M [00:02<00:02, 20.1MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 33%|\u2588\u2588\u2588\u258E      | 24.8M/75.0M [00:02<00:02, 20.0MB/s]\\u001b[A\\necamera.hevc:
+      \ 41%|\u2588\u2588\u2588\u2588      | 30.7M/75.0M [00:02<00:02, 20.5MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 40%|\u2588\u2588\u2588\u2589      | 30.0M/75.0M [00:02<00:02, 20.8MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 38%|\u2588\u2588\u2588\u258A      | 28.9M/75.1M [00:02<00:02, 20.8MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 37%|\u2588\u2588\u2588\u258B      | 27.4M/75.0M [00:02<00:02, 20.8MB/s]\\u001b[A\\necamera.hevc:
+      \ 44%|\u2588\u2588\u2588\u2588\u258D     | 33.4M/75.0M [00:02<00:01, 21.1MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 43%|\u2588\u2588\u2588\u2588\u258E     | 32.6M/75.0M [00:02<00:01, 21.4MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 42%|\u2588\u2588\u2588\u2588\u258F     | 31.5M/75.1M [00:02<00:02, 21.4MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 40%|\u2588\u2588\u2588\u2588      | 30.0M/75.0M [00:02<00:02, 21.3MB/s]\\u001b[A\\necamera.hevc:
+      \ 48%|\u2588\u2588\u2588\u2588\u258A     | 36.0M/75.0M [00:02<00:01, 21.6MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 47%|\u2588\u2588\u2588\u2588\u258B     | 35.2M/75.0M [00:02<00:01, 21.7MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 45%|\u2588\u2588\u2588\u2588\u258C     | 34.1M/75.1M [00:02<00:01, 21.7MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 44%|\u2588\u2588\u2588\u2588\u258E     | 32.6M/75.0M [00:02<00:01, 21.7MB/s]\\u001b[A\\necamera.hevc:
+      \ 51%|\u2588\u2588\u2588\u2588\u2588\u258F    | 38.6M/75.0M [00:02<00:01, 21.9MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 50%|\u2588\u2588\u2588\u2588\u2588     | 37.8M/75.0M [00:02<00:01, 21.9MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 49%|\u2588\u2588\u2588\u2588\u2589     | 36.8M/75.1M [00:02<00:01, 21.9MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 47%|\u2588\u2588\u2588\u2588\u258B     | 35.3M/75.0M [00:02<00:01, 22.0MB/s]\\u001b[A\\necamera.hevc:
+      \ 55%|\u2588\u2588\u2588\u2588\u2588\u258D    | 41.2M/75.0M [00:02<00:01, 22.1MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 54%|\u2588\u2588\u2588\u2588\u2588\u258D    | 40.4M/75.0M [00:02<00:01, 22.1MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 52%|\u2588\u2588\u2588\u2588\u2588\u258F    | 39.4M/75.1M [00:02<00:01, 22.1MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 51%|\u2588\u2588\u2588\u2588\u2588     | 37.9M/75.0M [00:02<00:01, 22.2MB/s]\\u001b[A\\necamera.hevc:
+      \ 58%|\u2588\u2588\u2588\u2588\u2588\u258A    | 43.8M/75.0M [00:02<00:01, 22.2MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 43.1M/75.0M [00:02<00:01, 22.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 56%|\u2588\u2588\u2588\u2588\u2588\u258C    | 42.0M/75.1M [00:02<00:01, 22.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 54%|\u2588\u2588\u2588\u2588\u2588\u258D    | 40.5M/75.0M [00:02<00:01, 22.3MB/s]\\u001b[A\\necamera.hevc:
+      \ 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F   | 46.5M/75.0M [00:02<00:01,
+      22.3MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  61%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 45.7M/75.0M [00:02<00:01, 22.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 59%|\u2588\u2588\u2588\u2588\u2588\u2589    | 44.6M/75.1M [00:02<00:01, 22.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 57%|\u2588\u2588\u2588\u2588\u2588\u258B    | 43.1M/75.0M [00:02<00:01, 22.1MB/s]\\u001b[A\\necamera.hevc:
+      \ 65%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C   | 49.1M/75.0M [00:02<00:01,
+      21.9MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 48.3M/75.0M [00:02<00:01, 22.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E   | 47.2M/75.1M [00:02<00:01,
+      22.1MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  61%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 45.7M/75.0M [00:02<00:01, 22.1MB/s]\\u001b[A\\necamera.hevc:  69%|\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      \  | 51.7M/75.0M [00:03<00:01, 22.2MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 50.9M/75.0M [00:03<00:01, 22.5MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 49.8M/75.1M [00:03<00:01,
+      22.5MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 48.3M/75.0M [00:03<00:01, 22.6MB/s]\\u001b[A\\necamera.hevc:  72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 54.3M/75.0M [00:03<00:00, 22.6MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 53.5M/75.0M [00:03<00:00, 22.9MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2589   | 52.4M/75.1M [00:03<00:00,
+      22.8MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 51.0M/75.0M [00:03<00:01, 22.9MB/s]\\u001b[A\\necamera.hevc:  76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 56.9M/75.0M [00:03<00:00, 23.0MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 56.1M/75.0M [00:03<00:00, 23.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 73%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E  | 55.1M/75.1M [00:03<00:00,
+      23.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 53.6M/75.0M [00:03<00:00, 23.0MB/s]\\u001b[A\\necamera.hevc:  79%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      \ | 59.5M/75.0M [00:03<00:00, 23.0MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 58.8M/75.0M [00:03<00:00, 23.1MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B  | 57.7M/75.1M [00:03<00:00,
+      23.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 56.2M/75.0M [00:03<00:00, 23.2MB/s]\\u001b[A\\necamera.hevc:  83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 62.1M/75.0M [00:03<00:00, 23.2MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 61.4M/75.0M [00:03<00:00, 23.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588  | 60.3M/75.1M [00:03<00:00,
+      23.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 58.8M/75.0M [00:03<00:00, 23.3MB/s]\\u001b[A\\necamera.hevc:  86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B
+      | 64.7M/75.0M [00:03<00:00, 23.3MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  85%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 64.0M/75.0M [00:03<00:00, 23.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D | 62.9M/75.1M [00:03<00:00,
+      23.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 61.4M/75.0M [00:03<00:00, 23.3MB/s]\\u001b[A\\necamera.hevc:  90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 67.4M/75.0M [00:03<00:00, 23.3MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  89%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 66.6M/75.0M [00:03<00:00, 23.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B | 65.5M/75.1M [00:03<00:00,
+      23.3MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  85%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 64.1M/75.0M [00:03<00:00, 23.4MB/s]\\u001b[A\\necamera.hevc:  93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      70.0M/75.0M [00:03<00:00, 23.4MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      69.2M/75.0M [00:03<00:00, 23.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      \ 91%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588 | 68.1M/75.1M [00:03<00:00,
+      22.8MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:  89%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 66.7M/75.0M [00:03<00:00, 22.9MB/s]\\u001b[A\\necamera.hevc:  97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      72.6M/75.0M [00:03<00:00, 22.8MB/s]\\u001b[A\\u001b[A\\nfcamera.hevc:  96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      71.8M/75.0M [00:03<00:00, 23.2MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E| 69.5M/75.0M
+      [00:03<00:00, 24.4MB/s]\\u001b[A\\necamera.hevc:  96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      72.1M/75.1M [00:03<00:00, 25.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\necamera.hevc:
+      100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 74.9M/75.0M
+      [00:04<00:00, 20.3MB/s]\\u001b[A\\u001b[A\\n                                                                  \\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 99%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589| 74.6M/75.0M
+      [00:04<00:00, 24.0MB/s]\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\nfcamera.hevc:
+      \ 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A| 73.3M/75.0M
+      [00:04<00:00, 28.2MB/s]\\u001b[A\\nFiles Downloaded:  50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 3/6 [00:04<00:04,  1.55s/file]\\n\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\u001b[A\\n
+      \                                                                 \\u001b[A\\u001b[A\\u001b[A\\u001b[A\\n
+      \                                                                 \\u001b[A\\nFiles
+      Downloaded: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      6/6 [00:04<00:00,  1.38file/s]\\n++ mount\\n+ echo 'overlay on / type overlay
+      (rw,relatime,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1330/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1329/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1328/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1327/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1326/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1325/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1324/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1323/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1322/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1321/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1320/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1319/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1318/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1317/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1316/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1315/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1314/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1313/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1312/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1311/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1310/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/46/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1331/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1331/work)\\nproc
+      on /proc type proc (rw,nosuid,nodev,noexec,relatime)\\ntmpfs on /dev type tmpfs
+      (rw,nosuid,size=65536k,mode=755)\\ndevpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)\\nmqueue
+      on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)\\nsysfs on /sys
+      type sysfs (ro,nosuid,nodev,noexec,relatime)\\ntmpfs on /sys/fs/cgroup type
+      tmpfs (rw,nosuid,nodev,noexec,relatime,mode=755)\\ncgroup on /sys/fs/cgroup/systemd
+      type cgroup (ro,nosuid,nodev,noexec,relatime,xattr,name=systemd)\\ncgroup on
+      /sys/fs/cgroup/cpu,cpuacct type cgroup (ro,nosuid,nodev,noexec,relatime,cpu,cpuacct)\\ncgroup
+      on /sys/fs/cgroup/freezer type cgroup (ro,nosuid,nodev,noexec,relatime,freezer)\\ncgroup
+      on /sys/fs/cgroup/memory type cgroup (ro,nosuid,nodev,noexec,relatime,memory)\\ncgroup
+      on /sys/fs/cgroup/net_cls,net_prio type cgroup (ro,nosuid,nodev,noexec,relatime,net_cls,net_prio)\\ncgroup
+      on /sys/fs/cgroup/perf_event type cgroup (ro,nosuid,nodev,noexec,relatime,perf_event)\\ncgroup
+      on /sys/fs/cgroup/blkio type cgroup (ro,nosuid,nodev,noexec,relatime,blkio)\\ncgroup
+      on /sys/fs/cgroup/cpuset type cgroup (ro,nosuid,nodev,noexec,relatime,cpuset)\\ncgroup
+      on /sys/fs/cgroup/devices type cgroup (ro,nosuid,nodev,noexec,relatime,devices)\\ncgroup
+      on /sys/fs/cgroup/rdma type cgroup (ro,nosuid,nodev,noexec,relatime,rdma)\\ncgroup
+      on /sys/fs/cgroup/pids type cgroup (ro,nosuid,nodev,noexec,relatime,pids)\\ncgroup
+      on /sys/fs/cgroup/hugetlb type cgroup (ro,nosuid,nodev,noexec,relatime,hugetlb)\\n/dev/nvme0n1
+      on /etc/hosts type ext4 (rw,relatime,discard)\\n/dev/nvme0n1 on /dev/termination-log
+      type ext4 (rw,relatime,discard)\\n/dev/nvme0n1 on /etc/hostname type ext4 (rw,relatime,discard)\\n/dev/nvme0n1
+      on /etc/resolv.conf type ext4 (rw,relatime,discard)\\nshm on /dev/shm type tmpfs
+      (rw,nosuid,nodev,noexec,relatime,size=65536k)\\n/dev/sda1 on /usr/local/nvidia
+      type ext4 (ro,relatime,commit=30)\\n/dev/sda1 on /etc/vulkan/icd.d type ext4
+      (ro,relatime,commit=30)\\nproc on /proc/bus type proc (ro,nosuid,nodev,noexec,relatime)\\nproc
+      on /proc/fs type proc (ro,nosuid,nodev,noexec,relatime)\\nproc on /proc/irq
+      type proc (ro,nosuid,nodev,noexec,relatime)\\nproc on /proc/sys type proc (ro,nosuid,nodev,noexec,relatime)\\nproc
+      on /proc/sysrq-trigger type proc (ro,nosuid,nodev,noexec,relatime)\\ntmpfs on
+      /proc/acpi type tmpfs (ro,relatime)\\ntmpfs on /proc/kcore type tmpfs (rw,nosuid,size=65536k,mode=755)\\ntmpfs
+      on /proc/keys type tmpfs (rw,nosuid,size=65536k,mode=755)\\ntmpfs on /proc/timer_list
+      type tmpfs (rw,nosuid,size=65536k,mode=755)\\ntmpfs on /proc/scsi type tmpfs
+      (ro,relatime)\\ntmpfs on /sys/firmware type tmpfs (ro,relatime)'\\n++ env\\n+
+      echo 'NV_LIBCUBLAS_VERSION=12.1.3.1-1\\nKUBERNETES_SERVICE_PORT_HTTPS=443\\nNVIDIA_VISIBLE_DEVICES=all\\nPYENV_HOOK_PATH=/root/.pyenv/pyenv.d:/usr/local/etc/pyenv.d:/etc/pyenv.d:/usr/lib/pyenv/hooks:/root/.pyenv/plugins/pyenv-virtualenv/etc/pyenv.d\\nNV_NVML_DEV_VERSION=12.1.105-1\\nNV_CUDNN_PACKAGE_NAME=libcudnn8\\nKUBERNETES_SERVICE_PORT=443\\nPYTHONUNBUFFERED=1\\nNV_LIBNCCL_DEV_PACKAGE=libnccl-dev=2.17.1-1+cuda12.1\\nNV_LIBNCCL_DEV_PACKAGE_VERSION=2.17.1-1\\nHOSTNAME=model-a12dfdb8-e96cdbb04a86a16c-gpu-t4-69864557c6-5g7lp\\nNVIDIA_REQUIRE_CUDA=cuda>=12.1
+      brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471
+      brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471
+      brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
+      brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471
+      brand=tesla,driver>=510,driver<511 brand=unknown,driver>=510,driver<511 brand=nvidia,driver>=510,driver<511
+      brand=nvidiartx,driver>=510,driver<511 brand=geforce,driver>=510,driver<511
+      brand=geforcertx,driver>=510,driver<511 brand=quadro,driver>=510,driver<511
+      brand=quadrortx,driver>=510,driver<511 brand=titan,driver>=510,driver<511 brand=titanrtx,driver>=510,driver<511
+      brand=tesla,driver>=515,driver<516 brand=unknown,driver>=515,driver<516 brand=nvidia,driver>=515,driver<516
+      brand=nvidiartx,driver>=515,driver<516 brand=geforce,driver>=515,driver<516
+      brand=geforcertx,driver>=515,driver<516 brand=quadro,driver>=515,driver<516
+      brand=quadrortx,driver>=515,driver<516 brand=titan,driver>=515,driver<516 brand=titanrtx,driver>=515,driver<516
+      brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526
+      brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526
+      brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526
+      brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526\\nNV_LIBCUBLAS_DEV_PACKAGE=libcublas-dev-12-1=12.1.3.1-1\\nNV_NVTX_VERSION=12.1.105-1\\nNV_CUDA_CUDART_DEV_VERSION=12.1.105-1\\nNV_LIBCUSPARSE_VERSION=12.1.0.106-1\\nNV_LIBNPP_VERSION=12.1.0.40-1\\nNCCL_VERSION=2.17.1-1\\nPYENV_VERSION=3.11.5\\nPWD=/src\\nNV_CUDNN_PACKAGE=libcudnn8=8.9.0.131-1+cuda12.1\\nNVIDIA_DRIVER_CAPABILITIES=all\\nNV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-1=12.1.105-1\\nNV_LIBNPP_PACKAGE=libnpp-12-1=12.1.0.40-1\\nNV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-dev\\nNV_LIBCUBLAS_DEV_VERSION=12.1.3.1-1\\nNVIDIA_PRODUCT_NAME=CUDA\\nNV_LIBCUBLAS_DEV_PACKAGE_NAME=libcublas-dev-12-1\\nNV_CUDA_CUDART_VERSION=12.1.105-1\\nHOME=/root\\nKUBERNETES_PORT_443_TCP=tcp://10.8.0.1:443\\nCUDA_VERSION=12.1.1\\nNV_LIBCUBLAS_PACKAGE=libcublas-12-1=12.1.3.1-1\\nNV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-1=12.1.1-1\\nNV_LIBNPP_DEV_PACKAGE=libnpp-dev-12-1=12.1.0.40-1\\nNV_LIBCUBLAS_PACKAGE_NAME=libcublas-12-1\\nPYENV_DIR=/src\\nNV_LIBNPP_DEV_VERSION=12.1.0.40-1\\nNV_LIBCUSPARSE_DEV_VERSION=12.1.0.106-1\\nLIBRARY_PATH=/usr/local/cuda/lib64/stubs\\nNV_CUDNN_VERSION=8.9.0.131\\nSCALE=1\\nDISPLAY=:0\\nSHLVL=0\\nNV_CUDA_LIB_VERSION=12.1.1-1\\nNVARCH=x86_64\\nKUBERNETES_PORT_443_TCP_PROTO=tcp\\nNV_CUDNN_PACKAGE_DEV=libcudnn8-dev=8.9.0.131-1+cuda12.1\\nKUBERNETES_PORT_443_TCP_ADDR=10.8.0.1\\nNV_CUDA_COMPAT_PACKAGE=cuda-compat-12-1\\nNV_LIBNCCL_PACKAGE=libnccl2=2.17.1-1+cuda12.1\\nLD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin\\nLC_CTYPE=C.UTF-8\\nPYENV_ROOT=/root/.pyenv\\nNV_CUDA_NSIGHT_COMPUTE_VERSION=12.1.1-1\\nKUBERNETES_SERVICE_HOST=10.8.0.1\\nNV_NVPROF_VERSION=12.1.105-1\\nKUBERNETES_PORT=tcp://10.8.0.1:443\\nKUBERNETES_PORT_443_TCP_PORT=443\\nPATH=/root/.pyenv/versions/3.11.5/bin:/root/.pyenv/libexec:/root/.pyenv/plugins/python-build/bin:/root/.pyenv/plugins/pyenv-virtualenv/bin:/root/.pyenv/plugins/pyenv-update/bin:/root/.pyenv/plugins/pyenv-install-latest/bin:/root/.pyenv/plugins/pyenv-doctor/bin:/root/.pyenv/shims:/root/.pyenv/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\\nNV_LIBNCCL_PACKAGE_NAME=libnccl2\\nNV_LIBNCCL_PACKAGE_VERSION=2.17.1-1\\nDEBIAN_FRONTEND=noninteractive\\n_=/usr/bin/env'\\n++
+      find /usr/ -name 'libcuda.so.*'\\nb'overlay on / type overlay (rw,relatime,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1330/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1329/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1328/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1327/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1326/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1325/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1324/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1323/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1322/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1321/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1320/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1319/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1318/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1317/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1316/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1315/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1314/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1313/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1312/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1311/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1310/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/46/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1331/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1331/work)\\\\n'\\nb'proc
+      on /proc type proc (rw,nosuid,nodev,noexec,relatime)\\\\n'\\nb'tmpfs on /dev
+      type tmpfs (rw,nosuid,size=65536k,mode=755)\\\\n'\\nb'devpts on /dev/pts type
+      devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)\\\\n'\\nb'mqueue
+      on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)\\\\n'\\nb'sysfs
+      on /sys type sysfs (ro,nosuid,nodev,noexec,relatime)\\\\n'\\nb'tmpfs on /sys/fs/cgroup
+      type tmpfs (rw,nosuid,nodev,noexec,relatime,mode=755)\\\\n'\\nb'cgroup on /sys/fs/cgroup/systemd
+      type cgroup (ro,nosuid,nodev,noexec,relatime,xattr,name=systemd)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/cpu,cpuacct type cgroup (ro,nosuid,nodev,noexec,relatime,cpu,cpuacct)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/freezer type cgroup (ro,nosuid,nodev,noexec,relatime,freezer)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/memory type cgroup (ro,nosuid,nodev,noexec,relatime,memory)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/net_cls,net_prio type cgroup (ro,nosuid,nodev,noexec,relatime,net_cls,net_prio)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/perf_event type cgroup (ro,nosuid,nodev,noexec,relatime,perf_event)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/blkio type cgroup (ro,nosuid,nodev,noexec,relatime,blkio)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/cpuset type cgroup (ro,nosuid,nodev,noexec,relatime,cpuset)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/devices type cgroup (ro,nosuid,nodev,noexec,relatime,devices)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/rdma type cgroup (ro,nosuid,nodev,noexec,relatime,rdma)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/pids type cgroup (ro,nosuid,nodev,noexec,relatime,pids)\\\\n'\\nb'cgroup
+      on /sys/fs/cgroup/hugetlb type cgroup (ro,nosuid,nodev,noexec,relatime,hugetlb)\\\\n'\\nb'/dev/nvme0n1
+      on /etc/hosts type ext4 (rw,relatime,discard)\\\\n'\\nb'/dev/nvme0n1 on /dev/termination-log
+      type ext4 (rw,relatime,discard)\\\\n'\\nb'/dev/nvme0n1 on /etc/hostname type
+      ext4 (rw,relatime,discard)\\\\n'\\nb'/dev/nvme0n1 on /etc/resolv.conf type ext4
+      (rw,relatime,discard)\\\\n'\\nb'shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)\\\\n'\\nb'/dev/sda1
+      on /usr/local/nvidia type ext4 (ro,relatime,commit=30)\\\\n'\\nb'/dev/sda1 on
+      /etc/vulkan/icd.d type ext4 (ro,relatime,commit=30)\\\\n'\\nb'proc on /proc/bus
+      type proc (ro,nosuid,nodev,noexec,relatime)\\\\n'\\nb'proc on /proc/fs type
+      proc (ro,nosuid,nodev,noexec,relatime)\\\\n'\\nb'proc on /proc/irq type proc
+      (ro,nosuid,nodev,noexec,relatime)\\\\n'\\nb'proc on /proc/sys type proc (ro,nosuid,nodev,noexec,relatime)\\\\n'\\nb'proc
+      on /proc/sysrq-trigger type proc (ro,nosuid,nodev,noexec,relatime)\\\\n'\\nb'tmpfs
+      on /proc/acpi type tmpfs (ro,relatime)\\\\n'\\nb'tmpfs on /proc/kcore type tmpfs
+      (rw,nosuid,size=65536k,mode=755)\\\\n'\\nb'tmpfs on /proc/keys type tmpfs (rw,nosuid,size=65536k,mode=755)\\\\n'\\nb'tmpfs
+      on /proc/timer_list type tmpfs (rw,nosuid,size=65536k,mode=755)\\\\n'\\nb'tmpfs
+      on /proc/scsi type tmpfs (ro,relatime)\\\\n'\\nb'tmpfs on /sys/firmware type
+      tmpfs (ro,relatime)\\\\n'\\nb'NV_LIBCUBLAS_VERSION=12.1.3.1-1\\\\n'\\nb'KUBERNETES_SERVICE_PORT_HTTPS=443\\\\n'\\nb'NVIDIA_VISIBLE_DEVICES=all\\\\n'\\nb'PYENV_HOOK_PATH=/root/.pyenv/pyenv.d:/usr/local/etc/pyenv.d:/etc/pyenv.d:/usr/lib/pyenv/hooks:/root/.pyenv/plugins/pyenv-virtualenv/etc/pyenv.d\\\\n'\\nb'NV_NVML_DEV_VERSION=12.1.105-1\\\\n'\\nb'NV_CUDNN_PACKAGE_NAME=libcudnn8\\\\n'\\nb'KUBERNETES_SERVICE_PORT=443\\\\n'\\nb'PYTHONUNBUFFERED=1\\\\n'\\nb'NV_LIBNCCL_DEV_PACKAGE=libnccl-dev=2.17.1-1+cuda12.1\\\\n'\\nb'NV_LIBNCCL_DEV_PACKAGE_VERSION=2.17.1-1\\\\n'\\nb'HOSTNAME=model-a12dfdb8-e96cdbb04a86a16c-gpu-t4-69864557c6-5g7lp\\\\n'\\nb'NVIDIA_REQUIRE_CUDA=cuda>=12.1
+      brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471
+      brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471
+      brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
+      brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471
+      brand=tesla,driver>=510,driver<511 brand=unknown,driver>=510,driver<511 brand=nvidia,driver>=510,driver<511
+      brand=nvidiartx,driver>=510,driver<511 brand=geforce,driver>=510,driver<511
+      brand=geforcertx,driver>=510,driver<511 brand=quadro,driver>=510,driver<511
+      brand=quadrortx,driver>=510,driver<511 brand=titan,driver>=510,driver<511 brand=titanrtx,driver>=510,driver<511
+      brand=tesla,driver>=515,driver<516 brand=unknown,driver>=515,driver<516 brand=nvidia,driver>=515,driver<516
+      brand=nvidiartx,driver>=515,driver<516 brand=geforce,driver>=515,driver<516
+      brand=geforcertx,driver>=515,driver<516 brand=quadro,driver>=515,driver<516
+      brand=quadrortx,driver>=515,driver<516 brand=titan,driver>=515,driver<516 brand=titanrtx,driver>=515,driver<516
+      brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526
+      brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526
+      brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526
+      brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526\\\\n'\\nb'NV_LIBCUBLAS_DEV_PACKAGE=libcublas-dev-12-1=12.1.3.1-1\\\\n'\\nb'NV_NVTX_VERSION=12.1.105-1\\\\n'\\nb'NV_CUDA_CUDART_DEV_VERSION=12.1.105-1\\\\n'\\nb'NV_LIBCUSPARSE_VERSION=12.1.0.106-1\\\\n'\\nb'NV_LIBNPP_VERSION=12.1.0.40-1\\\\n'\\nb'NCCL_VERSION=2.17.1-1\\\\n'\\nb'PYENV_VERSION=3.11.5\\\\n'\\nb'PWD=/src\\\\n'\\nb'NV_CUDNN_PACKAGE=libcudnn8=8.9.0.131-1+cuda12.1\\\\n'\\nb'NVIDIA_DRIVER_CAPABILITIES=all\\\\n'\\nb'NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-1=12.1.105-1\\\\n'\\nb'NV_LIBNPP_PACKAGE=libnpp-12-1=12.1.0.40-1\\\\n'\\nb'NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-dev\\\\n'\\nb'NV_LIBCUBLAS_DEV_VERSION=12.1.3.1-1\\\\n'\\nb'NVIDIA_PRODUCT_NAME=CUDA\\\\n'\\nb'NV_LIBCUBLAS_DEV_PACKAGE_NAME=libcublas-dev-12-1\\\\n'\\nb'NV_CUDA_CUDART_VERSION=12.1.105-1\\\\n'\\nb'HOME=/root\\\\n'\\nb'KUBERNETES_PORT_443_TCP=tcp://10.8.0.1:443\\\\n'\\nb'CUDA_VERSION=12.1.1\\\\n'\\nb'NV_LIBCUBLAS_PACKAGE=libcublas-12-1=12.1.3.1-1\\\\n'\\nb'NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-1=12.1.1-1\\\\n'\\nb'NV_LIBNPP_DEV_PACKAGE=libnpp-dev-12-1=12.1.0.40-1\\\\n'\\nb'NV_LIBCUBLAS_PACKAGE_NAME=libcublas-12-1\\\\n'\\nb'PYENV_DIR=/src\\\\n'\\nb'NV_LIBNPP_DEV_VERSION=12.1.0.40-1\\\\n'\\nb'NV_LIBCUSPARSE_DEV_VERSION=12.1.0.106-1\\\\n'\\nb'LIBRARY_PATH=/usr/local/cuda/lib64/stubs\\\\n'\\nb'NV_CUDNN_VERSION=8.9.0.131\\\\n'\\nb'SCALE=1\\\\n'\\nb'DISPLAY=:0\\\\n'\\nb'SHLVL=0\\\\n'\\nb'NV_CUDA_LIB_VERSION=12.1.1-1\\\\n'\\nb'NVARCH=x86_64\\\\n'\\nb'KUBERNETES_PORT_443_TCP_PROTO=tcp\\\\n'\\nb'NV_CUDNN_PACKAGE_DEV=libcudnn8-dev=8.9.0.131-1+cuda12.1\\\\n'\\nb'KUBERNETES_PORT_443_TCP_ADDR=10.8.0.1\\\\n'\\nb'NV_CUDA_COMPAT_PACKAGE=cuda-compat-12-1\\\\n'\\nb'NV_LIBNCCL_PACKAGE=libnccl2=2.17.1-1+cuda12.1\\\\n'\\nb'LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/nvidia/bin\\\\n'\\nb'LC_CTYPE=C.UTF-8\\\\n'\\nb'PYENV_ROOT=/root/.pyenv\\\\n'\\nb'NV_CUDA_NSIGHT_COMPUTE_VERSION=12.1.1-1\\\\n'\\nb'KUBERNETES_SERVICE_HOST=10.8.0.1\\\\n'\\nb'NV_NVPROF_VERSION=12.1.105-1\\\\n'\\nb'KUBERNETES_PORT=tcp://10.8.0.1:443\\\\n'\\nb'KUBERNETES_PORT_443_TCP_PORT=443\\\\n'\\nb'PATH=/root/.pyenv/versions/3.11.5/bin:/root/.pyenv/libexec:/root/.pyenv/plugins/python-build/bin:/root/.pyenv/plugins/pyenv-virtualenv/bin:/root/.pyenv/plugins/pyenv-update/bin:/root/.pyenv/plugins/pyenv-install-latest/bin:/root/.pyenv/plugins/pyenv-doctor/bin:/root/.pyenv/shims:/root/.pyenv/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\\\\n'\\nb'NV_LIBNCCL_PACKAGE_NAME=libnccl2\\\\n'\\nb'NV_LIBNCCL_PACKAGE_VERSION=2.17.1-1\\\\n'\\nb'DEBIAN_FRONTEND=noninteractive\\\\n'\\nb'_=/usr/bin/env\\\\n'\\n+
+      echo '/usr/local/nvidia/lib64/libcuda.so.525.105.17\\n/usr/local/nvidia/lib64/libcuda.so.1\\n/usr/local/cuda-12.1/compat/libcuda.so.1\\n/usr/local/cuda-12.1/compat/libcuda.so.530.30.02'\\nb'/usr/local/nvidia/lib64/libcuda.so.525.105.17\\\\n'\\nb'/usr/local/nvidia/lib64/libcuda.so.1\\\\n'\\nb'/usr/local/cuda-12.1/compat/libcuda.so.1\\\\n'\\nb'/usr/local/cuda-12.1/compat/libcuda.so.530.30.02\\\\n'\\n++
+      nvidia-smi -q\\n+ echo '\\n==============NVSMI LOG==============\\nTimestamp
+      \                                : Mon Sep 25 15:09:27 2023\\nDriver Version
+      \                           : 525.105.17\\nCUDA Version                              :
+      12.0\\nAttached GPUs                             : 1\\nGPU 00000000:00:05.0\\nProduct
+      Name                          : Tesla T4\\nProduct Brand                         :
+      NVIDIA\\nProduct Architecture                  : Turing\\nDisplay Mode                          :
+      Disabled\\nDisplay Active                        : Disabled\\nPersistence Mode
+      \                     : Disabled\\nMIG Mode\\nCurrent                           :
+      N/A\\nPending                           : N/A\\nAccounting Mode                       :
+      Disabled\\nAccounting Mode Buffer Size           : 4000\\nDriver Model\\nCurrent
+      \                          : N/A\\nPending                           : N/A\\nSerial
+      Number                         : 1562521014820\\nGPU UUID                              :
+      GPU-8da14d8a-fe61-a7bc-ccd6-9589e1bf5a64\\nMinor Number                          :
+      0\\nVBIOS Version                         : 90.04.A7.00.01\\nMultiGPU Board
+      \                       : No\\nBoard ID                              : 0x5\\nBoard
+      Part Number                     : 900-2G183-6300-T00\\nGPU Part Number                       :
+      1EB8-895-A1\\nModule ID                             : 1\\nInforom Version\\nImage
+      Version                     : G183.0200.00.02\\nOEM Object                        :
+      1.1\\nECC Object                        : 5.0\\nPower Management Object           :
+      N/A\\nGPU Operation Mode\\nCurrent                           : N/A\\nPending
+      \                          : N/A\\nGSP Firmware Version                  : 525.105.17\\nGPU
+      Virtualization Mode\\nVirtualization Mode               : Pass-Through\\nHost
+      VGPU Mode                    : N/A\\nIBMNPU\\nRelaxed Ordering Mode             :
+      N/A\\nPCI\\nBus                               : 0x00\\nDevice                            :
+      0x05\\nDomain                            : 0x0000\\nDevice Id                         :
+      0x1EB810DE\\nBus Id                            : 00000000:00:05.0\\nSub System
+      Id                     : 0x12A210DE\\nGPU Link Info\\nPCIe Generation\\nMax
+      \                      : 3\\nCurrent                   : 1\\nDevice Current
+      \           : 1\\nDevice Max                : 3\\nHost Max                  :
+      N/A\\nLink Width\\nMax                       : 16x\\nCurrent                   :
+      16x\\nBridge Chip\\nType                          : N/A\\nFirmware                      :
+      N/A\\nReplays Since Reset               : 0\\nReplay Number Rollovers           :
+      0\\nTx Throughput                     : 0 KB/s\\nRx Throughput                     :
+      0 KB/s\\nAtomic Caps Inbound               : N/A\\nAtomic Caps Outbound              :
+      N/A\\nFan Speed                             : N/A\\nPerformance State                     :
+      P8\\nClocks Throttle Reasons\\nIdle                              : Active\\nApplications
+      Clocks Setting       : Not Active\\nSW Power Cap                      : Not
+      Active\\nHW Slowdown                       : Not Active\\nHW Thermal Slowdown
+      \          : Not Active\\nHW Power Brake Slowdown       : Not Active\\nSync
+      Boost                        : Not Active\\nSW Thermal Slowdown               :
+      Not Active\\nDisplay Clock Setting             : Not Active\\nFB Memory Usage\\nTotal
+      \                            : 15360 MiB\\nReserved                          :
+      431 MiB\\nUsed                              : 2 MiB\\nFree                              :
+      14926 MiB\\nBAR1 Memory Usage\\nTotal                             : 256 MiB\\nUsed
+      \                             : 2 MiB\\nFree                              :
+      254 MiB\\nCompute Mode                          : Default\\nUtilization\\nGpu
+      \                              : 0 %\\nMemory                            : 0
+      %\\nEncoder                           : 0 %\\nDecoder                           :
+      0 %\\nEncoder Stats\\nActive Sessions                   : 0\\nAverage FPS                       :
+      0\\nAverage Latency                   : 0\\nFBC Stats\\nActive Sessions                   :
+      0\\nAverage FPS                       : 0\\nAverage Latency                   :
+      0\\nEcc Mode\\nCurrent                           : Enabled\\nPending                           :
+      Enabled\\nECC Errors\\nVolatile\\nSRAM Correctable              : 0\\nSRAM Uncorrectable
+      \           : 0\\nDRAM Correctable              : 0\\nDRAM Uncorrectable            :
+      0\\nAggregate\\nSRAM Correctable              : 0\\nSRAM Uncorrectable            :
+      0\\nDRAM Correctable              : 0\\nDRAM Uncorrectable            : 0\\nRetired
+      Pages\\nSingle Bit ECC                    : 0\\nDouble Bit ECC                    :
+      0\\nPending Page Blacklist            : No\\nRemapped Rows                         :
+      N/A\\nTemperature\\nGPU Current Temp                  : 35 C\\nGPU T.Limit Temp
+      \                 : N/A\\nGPU Shutdown Temp                 : 96 C\\nGPU Slowdown
+      Temp                 : 93 C\\nGPU Max Operating Temp            : 85 C\\nGPU
+      Target Temperature            : N/A\\nMemory Current Temp               : N/A\\nMemory
+      Max Operating Temp         : N/A\\nPower Readings\\nPower Management                  :
+      Supported\\nPower Draw                        : 10.54 W\\nPower Limit                       :
+      70.00 W\\nDefault Power Limit               : 70.00 W\\nEnforced Power Limit
+      \             : 70.00 W\\nMin Power Limit                   : 60.00 W\\nMax
+      Power Limit                   : 70.00 W\\nClocks\\nGraphics                          :
+      300 MHz\\nSM                                : 300 MHz\\nMemory                            :
+      405 MHz\\nVideo                             : 540 MHz\\nApplications Clocks\\nGraphics
+      \                         : 585 MHz\\nMemory                            : 5001
+      MHz\\nDefault Applications Clocks\\nGraphics                          : 585
+      MHz\\nMemory                            : 5001 MHz\\nDeferred Clocks\\nMemory
+      \                           : N/A\\nMax Clocks\\nGraphics                          :
+      1590 MHz\\nSM                                : 1590 MHz\\nMemory                            :
+      5001 MHz\\nVideo                             : 1470 MHz\\nMax Customer Boost
+      Clocks\\nGraphics                          : 1590 MHz\\nClock Policy\\nAuto
+      Boost                        : N/A\\nAuto Boost Default                : N/A\\nVoltage\\nGraphics
+      \                         : N/A\\nFabric\\nState                             :
+      N/A\\nStatus                            : N/A\\nProcesses                             :
+      None'\\n+ trap ctrl_c INT\\n+ trap ctrl_c ERR\\n+ cleanup\\n+ tmux list-panes
+      -s -t clipper -F '#{pane_pid} #{pane_current_command}'\\n+ grep -v tmux\\n+
+      xargs kill -9\\n+ awk '{print $1}'\\nerror connecting to /tmp/tmux-0/default
+      (No such file or directory)\\nUsage:\\nkill [options] <pid> [...]\\nOptions:\\n<pid>
+      [...]            send signal to every <pid> listed\\n-<signal>, -s, --signal
+      <signal>\\nspecify the <signal> to be sent\\n-q, --queue <value>    integer
+      value to be sent with the signal\\n-l, --list=[<signal>]  list all signal names,
+      or convert one to a name\\n-L, --table            list all signal names in a
+      nice table\\n-h, --help     display this help and exit\\n-V, --version  output
+      version information and exit\\nFor more details see kill(1).\\n+ true\\n+ STARTING_SEC=50\\n+
+      SMEAR_AMOUNT=5\\n+ SMEARED_STARTING_SEC=45\\n+ '[' 45 -lt 0 ']'\\n+ RECORDING_LENGTH=20\\n+
+      RECORDING_LENGTH_PLUS_SMEAR=25\\nb'\\\\n'\\nb'==============NVSMI LOG==============\\\\n'\\nb'\\\\n'\\nb'Timestamp
+      \                                : Mon Sep 25 15:09:27 2023\\\\n'\\nb'Driver
+      Version                            : 525.105.17\\\\n'\\nb'CUDA Version                              :
+      12.0\\\\n'\\nb'\\\\n'\\nb'Attached GPUs                             : 1\\\\n'\\nb'GPU
+      00000000:00:05.0\\\\n'\\nb'    Product Name                          : Tesla
+      T4\\\\n'\\nb'    Product Brand                         : NVIDIA\\\\n'\\nb'    Product
+      Architecture                  : Turing\\\\n'\\nb'    Display Mode                          :
+      Disabled\\\\n'\\nb'    Display Active                        : Disabled\\\\n'\\nb'
+      \   Persistence Mode                      : Disabled\\\\n'\\nb'    MIG Mode\\\\n'\\nb'
+      \       Current                           : N/A\\\\n'\\nb'        Pending                           :
+      N/A\\\\n'\\nb'    Accounting Mode                       : Disabled\\\\n'\\nb'
+      \   Accounting Mode Buffer Size           : 4000\\\\n'\\nb'    Driver Model\\\\n'\\nb'
+      \       Current                           : N/A\\\\n'\\nb'        Pending                           :
+      N/A\\\\n'\\nb'    Serial Number                         : 1562521014820\\\\n'\\nb'
+      \   GPU UUID                              : GPU-8da14d8a-fe61-a7bc-ccd6-9589e1bf5a64\\\\n'\\nb'
+      \   Minor Number                          : 0\\\\n'\\nb'    VBIOS Version                         :
+      90.04.A7.00.01\\\\n'\\nb'    MultiGPU Board                        : No\\\\n'\\nb'
+      \   Board ID                              : 0x5\\\\n'\\nb'    Board Part Number
+      \                    : 900-2G183-6300-T00\\\\n'\\nb'    GPU Part Number                       :
+      1EB8-895-A1\\\\n'\\nb'    Module ID                             : 1\\\\n'\\nb'
+      \   Inforom Version\\\\n'\\nb'        Image Version                     : G183.0200.00.02\\\\n'\\nb'
+      \       OEM Object                        : 1.1\\\\n'\\nb'        ECC Object
+      \                       : 5.0\\\\n'\\nb'        Power Management Object           :
+      N/A\\\\n'\\nb'    GPU Operation Mode\\\\n'\\nb'        Current                           :
+      N/A\\\\n'\\nb'        Pending                           : N/A\\\\n'\\nb'    GSP
+      Firmware Version                  : 525.105.17\\\\n'\\nb'    GPU Virtualization
+      Mode\\\\n'\\nb'        Virtualization Mode               : Pass-Through\\\\n'\\nb'
+      \       Host VGPU Mode                    : N/A\\\\n'\\nb'    IBMNPU\\\\n'\\nb'
+      \       Relaxed Ordering Mode             : N/A\\\\n'\\nb'    PCI\\\\n'\\nb'
+      \       Bus                               : 0x00\\\\n'\\nb'        Device                            :
+      0x05\\\\n'\\nb'        Domain                            : 0x0000\\\\n'\\nb'
+      \       Device Id                         : 0x1EB810DE\\\\n'\\nb'        Bus
+      Id                            : 00000000:00:05.0\\\\n'\\nb'        Sub System
+      Id                     : 0x12A210DE\\\\n'\\nb'        GPU Link Info\\\\n'\\nb'
+      \           PCIe Generation\\\\n'\\nb'                Max                       :
+      3\\\\n'\\nb'                Current                   : 1\\\\n'\\nb'                Device
+      Current            : 1\\\\n'\\nb'                Device Max                :
+      3\\\\n'\\nb'                Host Max                  : N/A\\\\n'\\nb'            Link
+      Width\\\\n'\\nb'                Max                       : 16x\\\\n'\\nb'                Current
+      \                  : 16x\\\\n'\\nb'        Bridge Chip\\\\n'\\nb'            Type
+      \                         : N/A\\\\n'\\nb'            Firmware                      :
+      N/A\\\\n'\\nb'        Replays Since Reset               : 0\\\\n'\\nb'        Replay
+      Number Rollovers           : 0\\\\n'\\nb'        Tx Throughput                     :
+      0 KB/s\\\\n'\\nb'        Rx Throughput                     : 0 KB/s\\\\n'\\nb'
+      \       Atomic Caps Inbound               : N/A\\\\n'\\nb'        Atomic Caps
+      Outbound              : N/A\\\\n'\\nb'    Fan Speed                             :
+      N/A\\\\n'\\nb'    Performance State                     : P8\\\\n'\\nb'    Clocks
+      Throttle Reasons\\\\n'\\nb'        Idle                              : Active\\\\n'\\nb'
+      \       Applications Clocks Setting       : Not Active\\\\n'\\nb'        SW
+      Power Cap                      : Not Active\\\\n'\\nb'        HW Slowdown                       :
+      Not Active\\\\n'\\nb'            HW Thermal Slowdown           : Not Active\\\\n'\\nb'
+      \           HW Power Brake Slowdown       : Not Active\\\\n'\\nb'        Sync
+      Boost                        : Not Active\\\\n'\\nb'        SW Thermal Slowdown
+      \              : Not Active\\\\n'\\nb'        Display Clock Setting             :
+      Not Active\\\\n'\\nb'    FB Memory Usage\\\\n'\\nb'        Total                             :
+      15360 MiB\\\\n'\\nb'        Reserved                          : 431 MiB\\\\n'\\nb'
+      \       Used                              : 2 MiB\\\\n'\\nb'        Free                              :
+      14926 MiB\\\\n'\\nb'    BAR1 Memory Usage\\\\n'\\nb'        Total                             :
+      256 MiB\\\\n'\\nb'        Used                              : 2 MiB\\\\n'\\nb'
+      \       Free                              : 254 MiB\\\\n'\\nb'    Compute Mode
+      \                         : Default\\\\n'\\nb'    Utilization\\\\n'\\nb'        Gpu
+      \                              : 0 %\\\\n'\\nb'        Memory                            :
+      0 %\\\\n'\\nb'        Encoder                           : 0 %\\\\n'\\nb'        Decoder
+      \                          : 0 %\\\\n'\\nb'    Encoder Stats\\\\n'\\nb'        Active
+      Sessions                   : 0\\\\n'\\nb'        Average FPS                       :
+      0\\\\n'\\nb'        Average Latency                   : 0\\\\n'\\nb'    FBC
+      Stats\\\\n'\\nb'        Active Sessions                   : 0\\\\n'\\nb'        Average
+      FPS                       : 0\\\\n'\\nb'        Average Latency                   :
+      0\\\\n'\\nb'    Ecc Mode\\\\n'\\nb'        Current                           :
+      Enabled\\\\n'\\nb'        Pending                           : Enabled\\\\n'\\nb'
+      \   ECC Errors\\\\n'\\nb'        Volatile\\\\n'\\nb'            SRAM Correctable
+      \             : 0\\\\n'\\nb'            SRAM Uncorrectable            : 0\\\\n'\\nb'
+      \           DRAM Correctable              : 0\\\\n'\\nb'            DRAM Uncorrectable
+      \           : 0\\\\n'\\nb'        Aggregate\\\\n'\\nb'            SRAM Correctable
+      \             : 0\\\\n'\\nb'            SRAM Uncorrectable            : 0\\\\n'\\nb'
+      \           DRAM Correctable              : 0\\\\n'\\nb'            DRAM Uncorrectable
+      \           : 0\\\\n'\\nb'    Retired Pages\\\\n'\\nb'        Single Bit ECC
+      \                   : 0\\\\n'\\nb'        Double Bit ECC                    :
+      0\\\\n'\\nb'        Pending Page Blacklist            : No\\\\n'\\nb'    Remapped
+      Rows                         : N/A\\\\n'\\nb'    Temperature\\\\n'\\nb'        GPU
+      Current Temp                  : 35 C\\\\n'\\nb'        GPU T.Limit Temp                  :
+      N/A\\\\n'\\nb'        GPU Shutdown Temp                 : 96 C\\\\n'\\nb'        GPU
+      Slowdown Temp                 : 93 C\\\\n'\\nb'        GPU Max Operating Temp
+      \           : 85 C\\\\n'\\nb'        GPU Target Temperature            : N/A\\\\n'\\nb'
+      \       Memory Current Temp               : N/A\\\\n'\\nb'        Memory Max
+      Operating Temp         : N/A\\\\n'\\nb'    Power Readings\\\\n'\\nb'        Power
+      Management                  : Supported\\\\n'\\nb'        Power Draw                        :
+      10.54 W\\\\n'\\nb'        Power Limit                       : 70.00 W\\\\n'\\nb'
+      \       Default Power Limit               : 70.00 W\\\\n'\\nb'        Enforced
+      Power Limit              : 70.00 W\\\\n'\\nb'        Min Power Limit                   :
+      60.00 W\\\\n'\\nb'        Max Power Limit                   : 70.00 W\\\\n'\\nb'
+      \   Clocks\\\\n'\\nb'        Graphics                          : 300 MHz\\\\n'\\nb'
+      \       SM                                : 300 MHz\\\\n'\\nb'        Memory
+      \                           : 405 MHz\\\\n'\\nb'        Video                             :
+      540 MHz\\\\n'\\nb'    Applications Clocks\\\\n'\\nb'        Graphics                          :
+      585 MHz\\\\n'\\nb'        Memory                            : 5001 MHz\\\\n'\\nb'
+      \   Default Applications Clocks\\\\n'\\nb'        Graphics                          :
+      585 MHz\\\\n'\\nb'        Memory                            : 5001 MHz\\\\n'\\nb'
+      \   Deferred Clocks\\\\n'\\nb'        Memory                            : N/A\\\\n'\\nb'
+      \   Max Clocks\\\\n'\\nb'        Graphics                          : 1590 MHz\\\\n'\\nb'
+      \       SM                                : 1590 MHz\\\\n'\\nb'        Memory
+      \                           : 5001 MHz\\\\n'\\nb'        Video                             :
+      1470 MHz\\\\n'\\nb'    Max Customer Boost Clocks\\\\n'\\nb'        Graphics
+      \                         : 1590 MHz\\\\n'\\nb'    Clock Policy\\\\n'\\nb'        Auto
+      Boost                        : N/A\\\\n'\\nb'        Auto Boost Default                :
+      N/A\\\\n'\\nb'    Voltage\\\\n'\\nb'        Graphics                          :
+      N/A\\\\n'\\nb'    Fabric\\\\n'\\nb'        State                             :
+      N/A\\\\n'\\nb'        Status                            : N/A\\\\n'\\nb'    Processes
+      \                            : None\\\\n'\\n++ echo 'a2a0ccea32023010|2023-07-27--13-01-19'\\n++
+      sed -E 's/--[0-9]+$//g'\\n+ ROUTE='a2a0ccea32023010|2023-07-27--13-01-19'\\n+
+      SEGMENT_NUM=0\\n+ SEGMENT_ID='a2a0ccea32023010|2023-07-27--13-01-19--0'\\n+
+      RENDER_METRIC_SYSTEM=off\\n+ NVIDIA_HARDWARE_RENDERING=on\\n+ NVIDIA_DIRECT_ENCODING=off\\n+
+      NVIDIA_HYBRID_ENCODING=on\\n+ NVIDIA_FAST_ENCODING=off\\n+ JWT_AUTH=\\n+ VIDEO_CWD=./shared\\n+
+      VIDEO_RAW_OUTPUT=clip_raw.mkv\\n+ VIDEO_OUTPUT=cog-clip.mp4\\n+ TARGET_MB=50\\n+
+      TARGET_BYTES=47185920\\n+ TARGET_BITRATE=18874368\\n+ TARGET_BITRATE_PLUS_SMEAR=15099494\\n+
+      VNC_PORT=0\\n+ DATA_DIR=/src/shared/data_dir\\n++ echo 'a2a0ccea32023010|2023-07-27--13-01-19'\\n++
+      sed 's/|/%7C/g'\\n+ URL_ROUTE=a2a0ccea32023010%7C2023-07-27--13-01-19\\n+ '['
+      -n '' ']'\\n++ curl --fail https://api.commadotai.com/v1/route/a2a0ccea32023010%7C2023-07-27--13-01-19/\\n%
+      Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\\nDload
+      \ Upload   Total   Spent    Left  Speed\\n  0     0    0     0    0     0      0
+      \     0 --:--:-- --:--:-- --:--:--     0\\n100  1361  100  1361    0     0   4797
+      \     0 --:--:-- --:--:-- --:--:--  4809\\n+ ROUTE_INFO='{\\\"can\\\":true,\\\"create_time\\\":1690488146,\\\"devicetype\\\":7,\\\"dongle_id\\\":\\\"a2a0ccea32023010\\\",\\\"end_lat\\\":32.7252,\\\"end_lng\\\":-117.162,\\\"fullname\\\":\\\"a2a0ccea32023010|2023-07-27--13-01-19\\\",\\\"git_branch\\\":\\\"release3-staging\\\",\\\"git_commit\\\":\\\"1f77acdc68d28fa5c91fe93af8aab956b7da782b\\\",\\\"git_dirty\\\":false,\\\"git_remote\\\":\\\"https://github.com/commaai/openpilot.git\\\",\\\"hpgps\\\":true,\\\"init_logmonotime\\\":36629898787,\\\"is_public\\\":true,\\\"length\\\":8.02241,\\\"maxcamera\\\":-1,\\\"maxdcamera\\\":-1,\\\"maxecamera\\\":-1,\\\"maxlog\\\":-1,\\\"maxqcamera\\\":12,\\\"maxqlog\\\":12,\\\"passive\\\":false,\\\"platform\\\":\\\"TOYOTA
+      COROLLA TSS2 2019\\\",\\\"proccamera\\\":-1,\\\"proclog\\\":-1,\\\"procqcamera\\\":12,\\\"procqlog\\\":12,\\\"radar\\\":true,\\\"rating\\\":null,\\\"segment_end_times\\\":[1690488142995,1690488203050,1690488263032,1690488322998,1690488383009,1690488443000,1690488503010,1690488563006,1690488623013,1690488683016,1690488743014,1690488803019,1690488851596],\\\"segment_numbers\\\":[0,1,2,3,4,5,6,7,8,9,10,11,12],\\\"segment_start_times\\\":[1690488081496,1690488143038,1690488203035,1690488263028,1690488323037,1690488383025,1690488443035,1690488503030,1690488563038,1690488623040,1690488683035,1690488743039,1690488803035],\\\"start_lat\\\":32.7363,\\\"start_lng\\\":-117.176,\\\"url\\\":\\\"https://chffrprivate.blob.core.windows.net/chffrprivate3/v2/a2a0ccea32023010/e8d8f1d92f2945750e031414a701cca9_2023-07-27--13-01-19\\\",\\\"user_id\\\":\\\"bd3bc34dbea550c8\\\",\\\"version\\\":\\\"0.9.4-release\\\",\\\"vin\\\":\\\"5YFT4RCE1LP005733\\\"}'\\n++
+      echo '{\\\"can\\\":true,\\\"create_time\\\":1690488146,\\\"devicetype\\\":7,\\\"dongle_id\\\":\\\"a2a0ccea32023010\\\",\\\"end_lat\\\":32.7252,\\\"end_lng\\\":-117.162,\\\"fullname\\\":\\\"a2a0ccea32023010|2023-07-27--13-01-19\\\",\\\"git_branch\\\":\\\"release3-staging\\\",\\\"git_commit\\\":\\\"1f77acdc68d28fa5c91fe93af8aab956b7da782b\\\",\\\"git_dirty\\\":false,\\\"git_remote\\\":\\\"https://github.com/commaai/openpilot.git\\\",\\\"hpgps\\\":true,\\\"init_logmonotime\\\":36629898787,\\\"is_public\\\":true,\\\"length\\\":8.02241,\\\"maxcamera\\\":-1,\\\"maxdcamera\\\":-1,\\\"maxecamera\\\":-1,\\\"maxlog\\\":-1,\\\"maxqcamera\\\":12,\\\"maxqlog\\\":12,\\\"passive\\\":false,\\\"platform\\\":\\\"TOYOTA
+      COROLLA TSS2 2019\\\",\\\"proccamera\\\":-1,\\\"proclog\\\":-1,\\\"procqcamera\\\":12,\\\"procqlog\\\":12,\\\"radar\\\":true,\\\"rating\\\":null,\\\"segment_end_times\\\":[1690488142995,1690488203050,1690488263032,1690488322998,1690488383009,1690488443000,1690488503010,1690488563006,1690488623013,1690488683016,1690488743014,1690488803019,1690488851596],\\\"segment_numbers\\\":[0,1,2,3,4,5,6,7,8,9,10,11,12],\\\"segment_start_times\\\":[1690488081496,1690488143038,1690488203035,1690488263028,1690488323037,1690488383025,1690488443035,1690488503030,1690488563038,1690488623040,1690488683035,1690488743039,1690488803035],\\\"start_lat\\\":32.7363,\\\"start_lng\\\":-117.176,\\\"url\\\":\\\"https://chffrprivate.blob.core.windows.net/chffrprivate3/v2/a2a0ccea32023010/e8d8f1d92f2945750e031414a701cca9_2023-07-27--13-01-19\\\",\\\"user_id\\\":\\\"bd3bc34dbea550c8\\\",\\\"version\\\":\\\"0.9.4-release\\\",\\\"vin\\\":\\\"5YFT4RCE1LP005733\\\"}'\\n++
+      jq -r .git_remote\\n+ ROUTE_INFO_GIT_REMOTE=https://github.com/commaai/openpilot.git\\n++
+      echo '{\\\"can\\\":true,\\\"create_time\\\":1690488146,\\\"devicetype\\\":7,\\\"dongle_id\\\":\\\"a2a0ccea32023010\\\",\\\"end_lat\\\":32.7252,\\\"end_lng\\\":-117.162,\\\"fullname\\\":\\\"a2a0ccea32023010|2023-07-27--13-01-19\\\",\\\"git_branch\\\":\\\"release3-staging\\\",\\\"git_commit\\\":\\\"1f77acdc68d28fa5c91fe93af8aab956b7da782b\\\",\\\"git_dirty\\\":false,\\\"git_remote\\\":\\\"https://github.com/commaai/openpilot.git\\\",\\\"hpgps\\\":true,\\\"init_logmonotime\\\":36629898787,\\\"is_public\\\":true,\\\"length\\\":8.02241,\\\"maxcamera\\\":-1,\\\"maxdcamera\\\":-1,\\\"maxecamera\\\":-1,\\\"maxlog\\\":-1,\\\"maxqcamera\\\":12,\\\"maxqlog\\\":12,\\\"passive\\\":false,\\\"platform\\\":\\\"TOYOTA
+      COROLLA TSS2 2019\\\",\\\"proccamera\\\":-1,\\\"proclog\\\":-1,\\\"procqcamera\\\":12,\\\"procqlog\\\":12,\\\"radar\\\":true,\\\"rating\\\":null,\\\"segment_end_times\\\":[1690488142995,1690488203050,1690488263032,1690488322998,1690488383009,1690488443000,1690488503010,1690488563006,1690488623013,1690488683016,1690488743014,1690488803019,1690488851596],\\\"segment_numbers\\\":[0,1,2,3,4,5,6,7,8,9,10,11,12],\\\"segment_start_times\\\":[1690488081496,1690488143038,1690488203035,1690488263028,1690488323037,1690488383025,1690488443035,1690488503030,1690488563038,1690488623040,1690488683035,1690488743039,1690488803035],\\\"start_lat\\\":32.7363,\\\"start_lng\\\":-117.176,\\\"url\\\":\\\"https://chffrprivate.blob.core.windows.net/chffrprivate3/v2/a2a0ccea32023010/e8d8f1d92f2945750e031414a701cca9_2023-07-27--13-01-19\\\",\\\"user_id\\\":\\\"bd3bc34dbea550c8\\\",\\\"version\\\":\\\"0.9.4-release\\\",\\\"vin\\\":\\\"5YFT4RCE1LP005733\\\"}'\\n++
+      jq -r .git_branch\\n+ ROUTE_INFO_GIT_BRANCH=release3-staging\\n++ echo '{\\\"can\\\":true,\\\"create_time\\\":1690488146,\\\"devicetype\\\":7,\\\"dongle_id\\\":\\\"a2a0ccea32023010\\\",\\\"end_lat\\\":32.7252,\\\"end_lng\\\":-117.162,\\\"fullname\\\":\\\"a2a0ccea32023010|2023-07-27--13-01-19\\\",\\\"git_branch\\\":\\\"release3-staging\\\",\\\"git_commit\\\":\\\"1f77acdc68d28fa5c91fe93af8aab956b7da782b\\\",\\\"git_dirty\\\":false,\\\"git_remote\\\":\\\"https://github.com/commaai/openpilot.git\\\",\\\"hpgps\\\":true,\\\"init_logmonotime\\\":36629898787,\\\"is_public\\\":true,\\\"length\\\":8.02241,\\\"maxcamera\\\":-1,\\\"maxdcamera\\\":-1,\\\"maxecamera\\\":-1,\\\"maxlog\\\":-1,\\\"maxqcamera\\\":12,\\\"maxqlog\\\":12,\\\"passive\\\":false,\\\"platform\\\":\\\"TOYOTA
+      COROLLA TSS2 2019\\\",\\\"proccamera\\\":-1,\\\"proclog\\\":-1,\\\"procqcamera\\\":12,\\\"procqlog\\\":12,\\\"radar\\\":true,\\\"rating\\\":null,\\\"segment_end_times\\\":[1690488142995,1690488203050,1690488263032,1690488322998,1690488383009,1690488443000,1690488503010,1690488563006,1690488623013,1690488683016,1690488743014,1690488803019,1690488851596],\\\"segment_numbers\\\":[0,1,2,3,4,5,6,7,8,9,10,11,12],\\\"segment_start_times\\\":[1690488081496,1690488143038,1690488203035,1690488263028,1690488323037,1690488383025,1690488443035,1690488503030,1690488563038,1690488623040,1690488683035,1690488743039,1690488803035],\\\"start_lat\\\":32.7363,\\\"start_lng\\\":-117.176,\\\"url\\\":\\\"https://chffrprivate.blob.core.windows.net/chffrprivate3/v2/a2a0ccea32023010/e8d8f1d92f2945750e031414a701cca9_2023-07-27--13-01-19\\\",\\\"user_id\\\":\\\"bd3bc34dbea550c8\\\",\\\"version\\\":\\\"0.9.4-release\\\",\\\"vin\\\":\\\"5YFT4RCE1LP005733\\\"}'\\n++
+      jq -r .git_commit\\n++ cut -c1-8\\n+ ROUTE_INFO_GIT_COMMIT=1f77acdc\\n++ echo
+      '{\\\"can\\\":true,\\\"create_time\\\":1690488146,\\\"devicetype\\\":7,\\\"dongle_id\\\":\\\"a2a0ccea32023010\\\",\\\"end_lat\\\":32.7252,\\\"end_lng\\\":-117.162,\\\"fullname\\\":\\\"a2a0ccea32023010|2023-07-27--13-01-19\\\",\\\"git_branch\\\":\\\"release3-staging\\\",\\\"git_commit\\\":\\\"1f77acdc68d28fa5c91fe93af8aab956b7da782b\\\",\\\"git_dirty\\\":false,\\\"git_remote\\\":\\\"https://github.com/commaai/openpilot.git\\\",\\\"hpgps\\\":true,\\\"init_logmonotime\\\":36629898787,\\\"is_public\\\":true,\\\"length\\\":8.02241,\\\"maxcamera\\\":-1,\\\"maxdcamera\\\":-1,\\\"maxecamera\\\":-1,\\\"maxlog\\\":-1,\\\"maxqcamera\\\":12,\\\"maxqlog\\\":12,\\\"passive\\\":false,\\\"platform\\\":\\\"TOYOTA
+      COROLLA TSS2 2019\\\",\\\"proccamera\\\":-1,\\\"proclog\\\":-1,\\\"procqcamera\\\":12,\\\"procqlog\\\":12,\\\"radar\\\":true,\\\"rating\\\":null,\\\"segment_end_times\\\":[1690488142995,1690488203050,1690488263032,1690488322998,1690488383009,1690488443000,1690488503010,1690488563006,1690488623013,1690488683016,1690488743014,1690488803019,1690488851596],\\\"segment_numbers\\\":[0,1,2,3,4,5,6,7,8,9,10,11,12],\\\"segment_start_times\\\":[1690488081496,1690488143038,1690488203035,1690488263028,1690488323037,1690488383025,1690488443035,1690488503030,1690488563038,1690488623040,1690488683035,1690488743039,1690488803035],\\\"start_lat\\\":32.7363,\\\"start_lng\\\":-117.176,\\\"url\\\":\\\"https://chffrprivate.blob.core.windows.net/chffrprivate3/v2/a2a0ccea32023010/e8d8f1d92f2945750e031414a701cca9_2023-07-27--13-01-19\\\",\\\"user_id\\\":\\\"bd3bc34dbea550c8\\\",\\\"version\\\":\\\"0.9.4-release\\\",\\\"vin\\\":\\\"5YFT4RCE1LP005733\\\"}'\\n++
+      jq -r .git_dirty\\n+ ROUTE_INFO_GIT_DIRTY=false\\n++ echo '{\\\"can\\\":true,\\\"create_time\\\":1690488146,\\\"devicetype\\\":7,\\\"dongle_id\\\":\\\"a2a0ccea32023010\\\",\\\"end_lat\\\":32.7252,\\\"end_lng\\\":-117.162,\\\"fullname\\\":\\\"a2a0ccea32023010|2023-07-27--13-01-19\\\",\\\"git_branch\\\":\\\"release3-staging\\\",\\\"git_commit\\\":\\\"1f77acdc68d28fa5c91fe93af8aab956b7da782b\\\",\\\"git_dirty\\\":false,\\\"git_remote\\\":\\\"https://github.com/commaai/openpilot.git\\\",\\\"hpgps\\\":true,\\\"init_logmonotime\\\":36629898787,\\\"is_public\\\":true,\\\"length\\\":8.02241,\\\"maxcamera\\\":-1,\\\"maxdcamera\\\":-1,\\\"maxecamera\\\":-1,\\\"maxlog\\\":-1,\\\"maxqcamera\\\":12,\\\"maxqlog\\\":12,\\\"passive\\\":false,\\\"platform\\\":\\\"TOYOTA
+      COROLLA TSS2 2019\\\",\\\"proccamera\\\":-1,\\\"proclog\\\":-1,\\\"procqcamera\\\":12,\\\"procqlog\\\":12,\\\"radar\\\":true,\\\"rating\\\":null,\\\"segment_end_times\\\":[1690488142995,1690488203050,1690488263032,1690488322998,1690488383009,1690488443000,1690488503010,1690488563006,1690488623013,1690488683016,1690488743014,1690488803019,1690488851596],\\\"segment_numbers\\\":[0,1,2,3,4,5,6,7,8,9,10,11,12],\\\"segment_start_times\\\":[1690488081496,1690488143038,1690488203035,1690488263028,1690488323037,1690488383025,1690488443035,1690488503030,1690488563038,1690488623040,1690488683035,1690488743039,1690488803035],\\\"start_lat\\\":32.7363,\\\"start_lng\\\":-117.176,\\\"url\\\":\\\"https://chffrprivate.blob.core.windows.net/chffrprivate3/v2/a2a0ccea32023010/e8d8f1d92f2945750e031414a701cca9_2023-07-27--13-01-19\\\",\\\"user_id\\\":\\\"bd3bc34dbea550c8\\\",\\\"version\\\":\\\"0.9.4-release\\\",\\\"vin\\\":\\\"5YFT4RCE1LP005733\\\"}'\\n++
+      jq -r .platform\\n+ ROUTE_INFO_PLATFORM='TOYOTA COROLLA TSS2 2019'\\n+ SPEEDHACK_AMOUNT=1.0\\n++
+      echo '(1.0 * 20)/1'\\n++ bc\\n+ RECORD_FRAMERATE=20\\n+ pushd /home/batman/openpilot\\nb'/home/batman/openpilot
+      /src\\\\n'\\n+ '[' -n '' ']'\\n+ UI_SERVICES=modelV2,controlsState,liveCalibration,radarState,deviceState,roadCameraState,pandaStates,carParams,driverMonitoringState,carState,liveLocationKalman,driverStateV2,wideRoadCameraState,managerState,navInstruction,navRoute,uiPlan\\n+
+      HIGH_FREQ_SERVICES=modelV2,controlsState,carState,uiPlan\\n+ pushd /var/tmp\\n+
+      rm -rf '/dev/shm/op/*'\\nb'/var/tmp /home/batman/openpilot /src\\\\n'\\n+ mkdir
+      -p /dev/shm/op\\n+ ln -s /dev/shm/op/visionipc_camerad_0 visionipc_camerad_0\\n+
+      ln -s /dev/shm/op/visionipc_camerad_2 visionipc_camerad_2\\n+ for service in
+      ${HIGH_FREQ_SERVICES//,/ }\\n+ ln -s /dev/shm/op/modelV2 modelV2\\n+ for service
+      in ${HIGH_FREQ_SERVICES//,/ }\\n+ ln -s /dev/shm/op/controlsState controlsState\\n+
+      for service in ${HIGH_FREQ_SERVICES//,/ }\\n+ ln -s /dev/shm/op/carState carState\\n+
+      for service in ${HIGH_FREQ_SERVICES//,/ }\\n+ ln -s /dev/shm/op/uiPlan uiPlan\\n+
+      popd\\n+ '[' on = on ']'\\nb'/home/batman/openpilot /src\\\\n'\\n++ nvidia-xconfig
+      --query-gpu-info\\n++ grep -i Name\\n++ awk -F ': ' '{print $2}'\\n+ GPU_BOARD='Tesla
+      T4'\\n++ nvidia-xconfig --query-gpu-info\\n++ grep BusID\\n++ awk '{print $4}'\\n+
+      GPU_PCI=PCI:0:5:0\\n+ mkdir -p /etc/X11\\n+ cat\\n+ tmux new-session -d -s clipper
+      -n x11 'Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile
+      /tmp/xserver.log -logverbose 0 vt1 :0'\\n+ '[' -n /src/shared/data_dir ']'\\n+
+      REPLAY_CMD='./tools/replay/replay --ecam --start \\\"45\\\" --data_dir \\\"/src/shared/data_dir\\\"
+      \\\"a2a0ccea32023010|2023-07-27--13-01-19\\\"'\\n+ tmux new-window -n replay
+      -t clipper: 'TERM=xterm-256color eatmydata faketime -m -f \\\"+0 x1.0\\\" ./tools/replay/replay
+      --ecam --start \\\"45\\\" --data_dir \\\"/src/shared/data_dir\\\" \\\"a2a0ccea32023010|2023-07-27--13-01-19\\\"'\\n+
+      tmux new-window -n ui -t clipper: 'eatmydata faketime -m -f \\\"+0 x1.0\\\"
+      ./selfdrive/ui/ui'\\n+ '[' -z /src/shared/data_dir ']'\\n+ tmux send-keys -t
+      clipper:replay Enter 45 Enter\\n+ tmux send-keys -t clipper:replay Space\\n+
+      sleep 1\\n+ tmux send-keys -t clipper:replay Space\\n+ popd\\n+ '[' off = on
+      ']'\\n+ DISPLAYED_SEGMENT_ID='a2a0ccea32023010|2023-07-27--13-01-19--0'\\n+
+      CLIP_DESC='Segment ID: a2a0ccea32023010|2023-07-27--13-01-19--0, Starting Second:
+      50, Clip Length: 20, https://github.com/commaai/openpilot.git, release3-staging,
+      1f77acdc, Dirty: false, TOYOTA COROLLA TSS2 2019'\\n+ echo -n 'Segment ID: a2a0ccea32023010|2023-07-27--13-01-19--0,
+      Starting Second: 50, Clip Length: 20, https://github.com/commaai/openpilot.git,
+      release3-staging, 1f77acdc, Dirty: false, TOYOTA COROLLA TSS2 2019'\\n+ mkdir
+      -p ./shared\\nb'/src\\\\n'\\n+ pushd ./shared\\nb'/src/shared /src\\\\n'\\n+
+      mkdir -p /root/.comma/params/d/\\n+ '[' off = on ']'\\n+ echo -n 0\\n+ DRAW_TEXT_FILTER='drawtext=textfile=/tmp/overlay.txt:reload=1:fontcolor=white:fontsize=14:box=1:boxcolor=black@0.5:boxborderw=5:x=(w-text_w)/2:y=10'\\n+
+      '[' off = on ']'\\n+ '[' on = on ']'\\n+ eatmydata ffmpeg -framerate 20 -video_size
+      1920x1080 -f x11grab -draw_mouse 0 -i :0.0 -vcodec h264_nvenc -preset llhp -b:v
+      18874368 -maxrate 18874368 -g 20 -r 20 -filter:v 'setpts=1.0*PTS,scale=1920:1080,drawtext=textfile=/tmp/overlay.txt:reload=1:fontcolor=white:fontsize=14:box=1:boxcolor=black@0.5:boxborderw=5:x=(w-text_w)/2:y=10'
+      -y -t 25 clip_raw.mkv\\nffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright (c)
+      2000-2021 the FFmpeg developers\\nbuilt with gcc 11 (Ubuntu 11.2.0-19ubuntu1)\\nconfiguration:
+      --prefix=/usr --extra-version=0ubuntu0.22.04.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu
+      --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping
+      --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray
+      --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d
+      --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi
+      --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa
+      --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse
+      --enable-librabbitmq --enable-librubberband --enable-libshine --enable-libsnappy
+      --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora
+      --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp
+      --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq
+      --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl
+      --enable-sdl2 --enable-pocketsphinx --enable-librsvg --enable-libmfx --enable-libdc1394
+      --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264
+      --enable-shared\\nlibavutil      56. 70.100 / 56. 70.100\\nlibavcodec     58.134.100
+      / 58.134.100\\nlibavformat    58. 76.100 / 58. 76.100\\nlibavdevice    58. 13.100
+      / 58. 13.100\\nlibavfilter     7.110.100 /  7.110.100\\nlibswscale      5.  9.100
+      /  5.  9.100\\nlibswresample   3.  9.100 /  3.  9.100\\nlibpostproc    55.  9.100
+      / 55.  9.100\\n[x11grab @ 0x57b31586e080] Stream #0: not enough frames to estimate
+      rate; consider increasing probesize\\nInput #0, x11grab, from ':0.0':\\nDuration:
+      N/A, start: 1695654569.047985, bitrate: 1327104 kb/s\\nStream #0:0: Video: rawvideo
+      (BGR[0] / 0x524742), bgr0, 1920x1080, 1327104 kb/s, 20 fps, 1000k tbr, 1000k
+      tbn, 1000k tbc\\nStream mapping:\\nStream #0:0 -> #0:0 (rawvideo (native) ->
+      h264 (h264_nvenc))\\nPress [q] to stop, [?] for help\\n[Parsed_drawtext_2 @
+      0x57b31589afc0] Using \\\"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf\\\"\\n[h264_nvenc
+      @ 0x57b31587a000] The selected preset is deprecated. Use p1 to p7 + -tune or
+      fast/medium/slow.\\nOutput #0, matroska, to 'clip_raw.mkv':\\nMetadata:\\nencoder
+      \        : Lavf58.76.100\\nStream #0:0: Video: h264 (Main) (H264 / 0x34363248),
+      bgr0(progressive), 1920x1080, q=2-31, 18874 kb/s, 20 fps, 1k tbn\\nMetadata:\\nencoder
+      \        : Lavc58.134.100 h264_nvenc\\nSide data:\\ncpb: bitrate max/min/avg:
+      18874368/0/18874368 buffer size: 37748736 vbv_delay: N/A\\nframe=    1 fps=0.0
+      q=0.0 size=       1kB time=00:00:00.00 bitrate=N/A speed=N/A\\nframe=    2 fps=0.0
+      q=0.0 size=       1kB time=00:00:00.00 bitrate=N/A speed=   0x\\nframe=   14
+      fps= 11 q=9.0 size=       1kB time=00:00:01.20 bitrate=   4.1kbits/s dup=0 drop=12
+      speed=0.929x\\nframe=   26 fps= 14 q=9.0 size=     512kB time=00:00:01.80 bitrate=2328.9kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=   37 fps= 16 q=11.0 size=     512kB time=00:00:02.35
+      bitrate=1784.1kbits/s dup=0 drop=12 speed=   1x\\nframe=   48 fps= 17 q=11.0
+      size=    2816kB time=00:00:02.90 bitrate=7952.0kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=   59 fps= 17 q=11.0 size=    2816kB time=00:00:03.45 bitrate=6684.6kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=   70 fps= 18 q=10.0 size=    4864kB time=00:00:04.00
+      bitrate=9959.0kbits/s dup=0 drop=12 speed=   1x\\nframe=   81 fps= 18 q=10.0
+      size=    4864kB time=00:00:04.55 bitrate=8755.4kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=   92 fps= 18 q=10.0 size=    6400kB time=00:00:05.10 bitrate=10278.1kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  103 fps= 18 q=10.0 size=    8192kB time=00:00:05.65
+      bitrate=11875.6kbits/s dup=0 drop=12 speed=   1x\\nframe=  113 fps= 18 q=10.0
+      size=    8192kB time=00:00:06.15 bitrate=10910.2kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  123 fps= 19 q=10.0 size=   10240kB time=00:00:06.65 bitrate=12612.6kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  134 fps= 19 q=10.0 size=   10240kB time=00:00:07.20
+      bitrate=11649.2kbits/s dup=0 drop=12 speed=   1x\\nframe=  144 fps= 19 q=10.0
+      size=   11776kB time=00:00:07.70 bitrate=12526.8kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  155 fps= 19 q=10.0 size=   11776kB time=00:00:08.25 bitrate=11691.8kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  165 fps= 19 q=10.0 size=   13568kB time=00:00:08.75
+      bitrate=12701.3kbits/s dup=0 drop=12 speed=   1x\\nframe=  175 fps= 19 q=10.0
+      size=   13568kB time=00:00:09.25 bitrate=12014.8kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  186 fps= 19 q=10.0 size=   15616kB time=00:00:09.80 bitrate=13052.4kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  196 fps= 19 q=11.0 size=   15616kB time=00:00:10.30
+      bitrate=12418.8kbits/s dup=0 drop=12 speed=   1x\\nframe=  206 fps= 19 q=11.0
+      size=   17408kB time=00:00:10.80 bitrate=13203.1kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  217 fps= 19 q=11.0 size=   17408kB time=00:00:11.35 bitrate=12563.3kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  228 fps= 19 q=11.0 size=   19712kB time=00:00:11.90
+      bitrate=13568.7kbits/s dup=0 drop=12 speed=   1x\\nframe=  239 fps= 19 q=11.0
+      size=   19712kB time=00:00:12.45 bitrate=12969.3kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  249 fps= 19 q=11.0 size=   21760kB time=00:00:12.95 bitrate=13764.0kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  259 fps= 19 q=11.0 size=   21760kB time=00:00:13.45
+      bitrate=13252.4kbits/s dup=0 drop=12 speed=   1x\\nframe=  269 fps= 19 q=11.0
+      size=   23808kB time=00:00:13.95 bitrate=13980.0kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  279 fps= 19 q=11.0 size=   23808kB time=00:00:14.45 bitrate=13496.3kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  290 fps= 19 q=11.0 size=   26112kB time=00:00:15.00
+      bitrate=14259.7kbits/s dup=0 drop=12 speed=   1x\\nframe=  300 fps= 19 q=11.0
+      size=   26112kB time=00:00:15.50 bitrate=13799.7kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  310 fps= 19 q=11.0 size=   28160kB time=00:00:16.00 bitrate=14417.0kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  321 fps= 19 q=11.0 size=   28160kB time=00:00:16.55
+      bitrate=13937.9kbits/s dup=0 drop=12 speed=   1x\\nframe=  331 fps= 19 q=11.0
+      size=   30208kB time=00:00:17.05 bitrate=14513.2kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  341 fps= 19 q=11.0 size=   30208kB time=00:00:17.55 bitrate=14099.7kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  352 fps= 19 q=11.0 size=   32000kB time=00:00:18.10
+      bitrate=14482.3kbits/s dup=0 drop=12 speed=   1x\\nframe=  362 fps= 19 q=11.0
+      size=   32000kB time=00:00:18.60 bitrate=14093.0kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  372 fps= 19 q=11.0 size=   34048kB time=00:00:19.10 bitrate=14602.4kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  383 fps= 19 q=10.0 size=   36096kB time=00:00:19.65
+      bitrate=15047.5kbits/s dup=0 drop=12 speed=   1x\\nframe=  393 fps= 20 q=11.0
+      size=   36096kB time=00:00:20.15 bitrate=14674.1kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  404 fps= 20 q=12.0 size=   38144kB time=00:00:20.70 bitrate=15094.7kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  415 fps= 20 q=11.0 size=   38144kB time=00:00:21.25
+      bitrate=14704.0kbits/s dup=0 drop=12 speed=   1x\\nframe=  425 fps= 20 q=11.0
+      size=   40192kB time=00:00:21.75 bitrate=15137.4kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  436 fps= 20 q=11.0 size=   40192kB time=00:00:22.30 bitrate=14764.0kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  447 fps= 20 q=11.0 size=   42240kB time=00:00:22.85
+      bitrate=15142.9kbits/s dup=0 drop=12 speed=   1x\\nframe=  457 fps= 20 q=11.0
+      size=   42240kB time=00:00:23.35 bitrate=14818.6kbits/s dup=0 drop=12 speed=
+      \  1x\\nframe=  468 fps= 20 q=11.0 size=   44288kB time=00:00:23.90 bitrate=15179.6kbits/s
+      dup=0 drop=12 speed=   1x\\nframe=  479 fps= 20 q=11.0 size=   44288kB time=00:00:24.45
+      bitrate=14838.1kbits/s dup=0 drop=12 speed=   1x\\nframe=  487 fps= 20 q=11.0
+      Lsize=   47284kB time=00:00:24.95 bitrate=15524.5kbits/s dup=0 drop=12 speed=
+      \  1x\\nvideo:47279kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB
+      muxing overhead: 0.011206%\\n+ cleanup\\n+ tmux list-panes -s -t clipper -F
+      '#{pane_pid} #{pane_current_command}'\\n+ grep -v tmux\\n+ awk '{print $1}'\\n+
+      xargs kill -9\\n+ ffmpeg -y -ss 5 -i clip_raw.mkv -vcodec copy -movflags +faststart
+      -f MP4 cog-clip.mp4\\nffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright (c) 2000-2021
+      the FFmpeg developers\\nbuilt with gcc 11 (Ubuntu 11.2.0-19ubuntu1)\\nconfiguration:
+      --prefix=/usr --extra-version=0ubuntu0.22.04.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu
+      --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping
+      --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray
+      --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d
+      --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi
+      --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa
+      --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse
+      --enable-librabbitmq --enable-librubberband --enable-libshine --enable-libsnappy
+      --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora
+      --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp
+      --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq
+      --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl
+      --enable-sdl2 --enable-pocketsphinx --enable-librsvg --enable-libmfx --enable-libdc1394
+      --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264
+      --enable-shared\\nlibavutil      56. 70.100 / 56. 70.100\\nlibavcodec     58.134.100
+      / 58.134.100\\nlibavformat    58. 76.100 / 58. 76.100\\nlibavdevice    58. 13.100
+      / 58. 13.100\\nlibavfilter     7.110.100 /  7.110.100\\nlibswscale      5.  9.100
+      /  5.  9.100\\nlibswresample   3.  9.100 /  3.  9.100\\nlibpostproc    55.  9.100
+      / 55.  9.100\\nInput #0, matroska,webm, from 'clip_raw.mkv':\\nMetadata:\\nENCODER
+      \        : Lavf58.76.100\\nDuration: 00:00:25.00, start: 0.000000, bitrate:
+      15494 kb/s\\nStream #0:0: Video: h264 (Main), yuv420p(progressive), 1920x1080
+      [SAR 1:1 DAR 16:9], 20 fps, 20 tbr, 1k tbn, 40 tbc (default)\\nMetadata:\\nENCODER
+      \        : Lavc58.134.100 h264_nvenc\\nDURATION        : 00:00:25.000000000\\nOutput
+      #0, mp4, to 'cog-clip.mp4':\\nMetadata:\\nencoder         : Lavf58.76.100\\nStream
+      #0:0: Video: h264 (Main) (avc1 / 0x31637661), yuv420p(progressive), 1920x1080
+      [SAR 1:1 DAR 16:9], q=2-31, 20 fps, 20 tbr, 16k tbn, 1k tbc (default)\\nMetadata:\\nENCODER
+      \        : Lavc58.134.100 h264_nvenc\\nDURATION        : 00:00:25.000000000\\nStream
+      mapping:\\nStream #0:0 -> #0:0 (copy)\\nPress [q] to stop, [?] for help\\nframe=
+      \   1 fps=0.0 q=-1.0 size=       0kB time=-00:00:00.34 bitrate=N/A speed=N/A\\n[mp4
+      @ 0x57851bb6ba00] Starting second pass: moving the moov atom to the beginning
+      of the file\\nframe=  407 fps=0.0 q=-1.0 Lsize=   40665kB time=00:00:19.95 bitrate=16698.2kbits/s
+      speed= 245x\\nvideo:40662kB audio:0kB subtitle:0kB other streams:0kB global
+      headers:0kB muxing overhead: 0.007640%\\n+ ctrl_c\\n+ cleanup\\n+ tmux list-panes
+      -s -t clipper -F '#{pane_pid} #{pane_current_command}'\\n+ grep -v tmux\\n+
+      awk '{print $1}'\\n+ xargs kill -9\\nno server running on /tmp/tmux-0/default\\nUsage:\\nkill
+      [options] <pid> [...]\\nOptions:\\n<pid> [...]            send signal to every
+      <pid> listed\\n-<signal>, -s, --signal <signal>\\nspecify the <signal> to be
+      sent\\n-q, --queue <value>    integer value to be sent with the signal\\n-l,
+      --list=[<signal>]  list all signal names, or convert one to a name\\n-L, --table
+      \           list all signal names in a nice table\\n-h, --help     display this
+      help and exit\\n-V, --version  output version information and exit\\nFor more
+      details see kill(1).\\n+ true\\n+ pkill -P 303\\n+ true\\n+ RENDER_COMPLETE_MESSAGE='Finished
+      rendering a2a0ccea32023010|2023-07-27--13-01-19--0 to cog-clip.mp4.'\\n+ '['
+      '!' -z '' ']'\\n+ echo -e 'Finished rendering a2a0ccea32023010|2023-07-27--13-01-19--0
+      to cog-clip.mp4.\\\\n' 'Please remember to include the segment ID if posting
+      for comma to look at!\\\\n' '`a2a0ccea32023010|2023-07-27--13-01-19--0`'\\nb'Finished
+      rendering a2a0ccea32023010|2023-07-27--13-01-19--0 to cog-clip.mp4.\\\\n'\\nb'
+      Please remember to include the segment ID if posting for comma to look at!\\\\n'\\nb'
+      `a2a0ccea32023010|2023-07-27--13-01-19--0`\\\\n'\",\"metrics\":{\"predict_time\":37.942858},\"output\":\"https://replicate.delivery/pbxt/hvHx11hdiZZwGJqgeJ2ooi5PmgByf2hhpjI6iAv947fEmqPjA/cog-clip.mp4\",\"started_at\":\"2023-09-25T15:09:17.589489Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/zjop44zbc3u4yvj5klabxyuaau\",\"cancel\":\"https://api.replicate.com/v1/predictions/zjop44zbc3u4yvj5klabxyuaau/cancel\"},\"version\":\"a12dfdb89c9cdb3f88de90467fe55f48bb5a284a624feaccd261c5d0045dabf8\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"d60970d8bbc6c4b3248850b76b3afdcf82512201ca0daf8cb98c2e91e067a5f1\",\"created_at\":\"2023-10-03T00:44:24.673323Z\",\"cog_version\":\"v0.8.6+dev\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"notes\":{\"type\":\"string\",\"title\":\"Notes\",\"default\":\"\",\"x-order\":7,\"description\":\"Notes
+      Text field. Doesn't affect output. For your own reference.\"},\"route\":{\"type\":\"string\",\"title\":\"Route\",\"default\":\"a2a0ccea32023010|2023-07-27--13-01-19\",\"x-order\":0,\"description\":\"Route
+      ID (w/ Segment Number OK but the segment number will be ignored in favor of
+      start seconds)  (\u26A0\uFE0F ROUTE MUST BE PUBLIC! You can set this temporarily
+      in Connect.) (\u26A0\uFE0F Ensure all data from forward and wide cameras and
+      \\\"Logs\\\" to be rendered have been uploaded; See README for more info)\"},\"metric\":{\"type\":\"boolean\",\"title\":\"Metric\",\"default\":false,\"x-order\":6,\"description\":\"Render
+      in metric units (km/h)\"},\"fileSize\":{\"type\":\"integer\",\"title\":\"Filesize\",\"default\":50,\"maximum\":50,\"minimum\":25,\"x-order\":5,\"description\":\"Rough
+      size of clip in MB.\"},\"smearAmount\":{\"type\":\"integer\",\"title\":\"Smearamount\",\"default\":5,\"maximum\":40,\"minimum\":5,\"x-order\":3,\"description\":\"Smear
+      amount (Let the video start this time before beginning recording, useful for
+      making sure the radar \u25B3, if present, is rendered at the start if necessary)\"},\"startSeconds\":{\"type\":\"integer\",\"title\":\"Startseconds\",\"default\":50,\"minimum\":0,\"x-order\":1,\"description\":\"Start
+      time in seconds\"},\"lengthSeconds\":{\"type\":\"integer\",\"title\":\"Lengthseconds\",\"default\":20,\"maximum\":60,\"minimum\":5,\"x-order\":2,\"description\":\"Length
+      of clip in seconds\"},\"speedhackRatio\":{\"type\":\"number\",\"title\":\"Speedhackratio\",\"default\":1,\"maximum\":7,\"minimum\":0.3,\"x-order\":4,\"description\":\"Speedhack
+      ratio (Higher ratio renders faster but renders may be more unstable and have
+      artifacts) (Suggestion: 0.3-0.5 for jitter-free, 1-3 for fast renders, 4+ for
+      buggy territory)\"}}},\"Output\":{\"type\":\"string\",\"title\":\"Output\",\"format\":\"uri\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/andreasjansson/blip-2\",\"owner\":\"andreasjansson\",\"name\":\"blip-2\",\"description\":\"Answers
+      questions about images\",\"visibility\":\"public\",\"github_url\":\"https://github.com/daanelson/cog-blip-2\",\"paper_url\":\"https://arxiv.org/abs/2301.12597\",\"license_url\":null,\"run_count\":9251652,\"cover_image_url\":\"https://replicate.delivery/pbxt/IJEPmgAlL2zNBNDoRRKFegTEcxnlRhoQxlNjPHSZEy0pSIKn/gg_bridge.jpeg\",\"default_example\":{\"completed_at\":\"2023-02-13T22:26:49.396028Z\",\"created_at\":\"2023-02-13T22:26:48.385476Z\",\"error\":null,\"id\":\"uhd4lhedtvdlbnm2cyhzx65zpe\",\"input\":{\"image\":\"https://replicate.delivery/pbxt/IJEPmgAlL2zNBNDoRRKFegTEcxnlRhoQxlNjPHSZEy0pSIKn/gg_bridge.jpeg\",\"caption\":false,\"question\":\"what
+      body of water does this bridge cross?\",\"temperature\":1},\"logs\":\"input
+      for question answering: Question: what body of water does this bridge cross?
+      Answer:\",\"metrics\":{\"predict_time\":0.949567},\"output\":\"san francisco
+      bay\",\"started_at\":\"2023-02-13T22:26:48.446461Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/uhd4lhedtvdlbnm2cyhzx65zpe\",\"cancel\":\"https://api.replicate.com/v1/predictions/uhd4lhedtvdlbnm2cyhzx65zpe/cancel\"},\"version\":\"4b32258c42e9efd4288bb9910bc532a69727f9acd26aa08e175713a0a857a608\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"9109553e37d266369f2750e407ab95649c63eb8e13f13b1f3983ff0feb2f9ef7\",\"created_at\":\"2023-10-02T19:11:38.354691Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"image\"],\"properties\":{\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image to query or caption\"},\"caption\":{\"type\":\"boolean\",\"title\":\"Caption\",\"default\":false,\"x-order\":1,\"description\":\"Select
+      if you want to generate image captions instead of asking questions\"},\"context\":{\"type\":\"string\",\"title\":\"Context\",\"x-order\":3,\"description\":\"Optional
+      - previous questions and answers to be used as context for answering current
+      question\"},\"question\":{\"type\":\"string\",\"title\":\"Question\",\"default\":\"What
+      is this a picture of?\",\"x-order\":2,\"description\":\"Question to ask about
+      this image. Leave blank for captioning\"},\"temperature\":{\"type\":\"number\",\"title\":\"Temperature\",\"default\":1,\"maximum\":1,\"minimum\":0.5,\"x-order\":5,\"description\":\"Temperature
+      for use with nucleus sampling\"},\"use_nucleus_sampling\":{\"type\":\"boolean\",\"title\":\"Use
+      Nucleus Sampling\",\"default\":false,\"x-order\":4,\"description\":\"Toggles
+      the model using nucleus sampling to generate responses\"}}},\"Output\":{\"type\":\"string\",\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/stability-ai/sdxl\",\"owner\":\"stability-ai\",\"name\":\"sdxl\",\"description\":\"A
+      text-to-image generative AI model that creates beautiful 1024x1024 images\",\"visibility\":\"public\",\"github_url\":\"https://github.com/replicate/cog-sdxl\",\"paper_url\":\"https://arxiv.org/abs/2307.01952\",\"license_url\":\"https://github.com/Stability-AI/generative-models/blob/main/model_licenses/LICENSE-SDXL1.0\",\"run_count\":6463655,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/61004930-fb88-4e09-9bd4-74fd8b4aa677/sdxl_cover.png\",\"default_example\":{\"completed_at\":\"2023-07-26T21:04:37.933562Z\",\"created_at\":\"2023-07-26T21:04:23.762683Z\",\"error\":null,\"id\":\"vu42q7dbkm6iicbpal4v6uvbqm\",\"input\":{\"width\":1024,\"height\":1024,\"prompt\":\"An
+      astronaut riding a rainbow unicorn, cinematic, dramatic\",\"refine\":\"expert_ensemble_refiner\",\"scheduler\":\"DDIM\",\"num_outputs\":1,\"guidance_scale\":7.5,\"high_noise_frac\":0.8,\"prompt_strength\":0.8,\"num_inference_steps\":50},\"logs\":\"Using
+      seed: 12103\\ntxt2img mode\\n  0%|          | 0/40 [00:00<?, ?it/s]\\n  2%|\u258E
+      \        | 1/40 [00:00<00:34,  1.14it/s]\\n  5%|\u258C         | 2/40 [00:01<00:18,
+      \ 2.10it/s]\\n  8%|\u258A         | 3/40 [00:01<00:12,  2.86it/s]\\n 10%|\u2588
+      \        | 4/40 [00:01<00:10,  3.44it/s]\\n 12%|\u2588\u258E        | 5/40 [00:01<00:09,
+      \ 3.87it/s]\\n 15%|\u2588\u258C        | 6/40 [00:01<00:08,  4.19it/s]\\n 18%|\u2588\u258A
+      \       | 7/40 [00:02<00:07,  4.43it/s]\\n 20%|\u2588\u2588        | 8/40 [00:02<00:06,
+      \ 4.60it/s]\\n 22%|\u2588\u2588\u258E       | 9/40 [00:02<00:06,  4.72it/s]\\n
+      25%|\u2588\u2588\u258C       | 10/40 [00:02<00:06,  4.80it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 11/40 [00:02<00:05,  4.86it/s]\\n 30%|\u2588\u2588\u2588       | 12/40
+      [00:03<00:05,  4.90it/s]\\n 32%|\u2588\u2588\u2588\u258E      | 13/40 [00:03<00:05,
+      \ 4.93it/s]\\n 35%|\u2588\u2588\u2588\u258C      | 14/40 [00:03<00:05,  4.95it/s]\\n
+      38%|\u2588\u2588\u2588\u258A      | 15/40 [00:03<00:05,  4.97it/s]\\n 40%|\u2588\u2588\u2588\u2588
+      \     | 16/40 [00:03<00:04,  4.99it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258E
+      \    | 17/40 [00:04<00:04,  5.00it/s]\\n 45%|\u2588\u2588\u2588\u2588\u258C
+      \    | 18/40 [00:04<00:04,  5.02it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A
+      \    | 19/40 [00:04<00:04,  5.02it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 20/40 [00:04<00:03,  5.03it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258E
+      \   | 21/40 [00:04<00:03,  5.03it/s]\\n 55%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 22/40 [00:05<00:03,  5.03it/s]\\n 57%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 23/40 [00:05<00:03,  5.03it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 24/40 [00:05<00:03,  5.04it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      \  | 25/40 [00:05<00:02,  5.05it/s]\\n 65%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 26/40 [00:05<00:02,  5.04it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 27/40 [00:06<00:02,  5.03it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 28/40 [00:06<00:02,  5.03it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      \ | 29/40 [00:06<00:02,  5.03it/s]\\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 30/40 [00:06<00:01,  5.04it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 31/40 [00:06<00:01,  5.03it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 32/40 [00:07<00:01,  5.02it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 33/40 [00:07<00:01,  5.02it/s]\\n 85%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 34/40 [00:07<00:01,  5.02it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 35/40 [00:07<00:00,  5.03it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 36/40 [00:07<00:00,  5.03it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E|
+      37/40 [00:08<00:00,  5.02it/s]\\n 95%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      38/40 [00:08<00:00,  5.02it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      39/40 [00:08<00:00,  5.02it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      40/40 [00:08<00:00,  5.02it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      40/40 [00:08<00:00,  4.63it/s]\\n  0%|          | 0/10 [00:00<?, ?it/s]\\n 10%|\u2588
+      \        | 1/10 [00:00<00:02,  4.24it/s]\\n 20%|\u2588\u2588        | 2/10 [00:00<00:01,
+      \ 4.33it/s]\\n 30%|\u2588\u2588\u2588       | 3/10 [00:00<00:01,  4.36it/s]\\n
+      40%|\u2588\u2588\u2588\u2588      | 4/10 [00:00<00:01,  4.37it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 5/10 [00:01<00:01,  4.37it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 6/10 [00:01<00:00,  4.38it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 7/10 [00:01<00:00,  4.38it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 8/10 [00:01<00:00,  4.39it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 9/10 [00:02<00:00,  4.37it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      10/10 [00:02<00:00,  4.37it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      10/10 [00:02<00:00,  4.37it/s]\",\"metrics\":{\"predict_time\":14.149563},\"output\":[\"https://replicate.delivery/pbxt/E6Ftpfi0dF1SOi4b6ltUwsfdxUf7zTQSfdhmJfRcfGTdZ88UE/out-0.png\"],\"started_at\":\"2023-07-26T21:04:23.783999Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/vu42q7dbkm6iicbpal4v6uvbqm\",\"cancel\":\"https://api.replicate.com/v1/predictions/vu42q7dbkm6iicbpal4v6uvbqm/cancel\"},\"version\":\"2f779eb9b23b34fe171f8eaa021b8261566f0d2c10cd2674063e7dbcd351509e\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"1bfb924045802467cf8869d96b231a12e6aa994abfe37e337c63a4e49a8c6c41\",\"created_at\":\"2023-10-02T19:04:28.929589Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"mask\":{\"type\":\"string\",\"title\":\"Mask\",\"format\":\"uri\",\"x-order\":3,\"description\":\"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted.\"},\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":11,\"description\":\"Random
+      seed. Leave blank to randomize the seed\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":2,\"description\":\"Input
+      image for img2img or inpaint mode\"},\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"default\":1024,\"x-order\":4,\"description\":\"Width
+      of output image\"},\"height\":{\"type\":\"integer\",\"title\":\"Height\",\"default\":1024,\"x-order\":5,\"description\":\"Height
+      of output image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"An
+      astronaut riding a rainbow unicorn\",\"x-order\":0,\"description\":\"Input prompt\"},\"refine\":{\"allOf\":[{\"$ref\":\"#/components/schemas/refine\"}],\"default\":\"no_refiner\",\"x-order\":12,\"description\":\"Which
+      refine style to use\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER\",\"x-order\":7,\"description\":\"scheduler\"},\"lora_scale\":{\"type\":\"number\",\"title\":\"Lora
+      Scale\",\"default\":0.6,\"maximum\":1,\"minimum\":0,\"x-order\":16,\"description\":\"LoRA
+      additive scale. Only applicable on trained models.\"},\"num_outputs\":{\"type\":\"integer\",\"title\":\"Num
+      Outputs\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Number
+      of images to output.\"},\"refine_steps\":{\"type\":\"integer\",\"title\":\"Refine
+      Steps\",\"x-order\":14,\"description\":\"For base_image_refiner, the number
+      of steps to refine, defaults to num_inference_steps\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":50,\"minimum\":1,\"x-order\":9,\"description\":\"Scale
+      for classifier-free guidance\"},\"apply_watermark\":{\"type\":\"boolean\",\"title\":\"Apply
+      Watermark\",\"default\":true,\"x-order\":15,\"description\":\"Applies a watermark
+      to enable determining if an image is generated in downstream applications. If
+      you have other provisions for generating or deploying images safely, you can
+      use this to disable watermarking.\"},\"high_noise_frac\":{\"type\":\"number\",\"title\":\"High
+      Noise Frac\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":13,\"description\":\"For
+      expert_ensemble_refiner, the fraction of noise to use\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"\",\"x-order\":1,\"description\":\"Input Negative Prompt\"},\"prompt_strength\":{\"type\":\"number\",\"title\":\"Prompt
+      Strength\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":10,\"description\":\"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image\"},\"replicate_weights\":{\"type\":\"string\",\"title\":\"Replicate
+      Weights\",\"x-order\":17,\"description\":\"Replicate LoRA weights to use. Leave
+      blank to use the default weights.\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":50,\"maximum\":500,\"minimum\":1,\"x-order\":8,\"description\":\"Number
+      of denoising steps\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"refine\":{\"enum\":[\"no_refiner\",\"expert_ensemble_refiner\",\"base_image_refiner\"],\"type\":\"string\",\"title\":\"refine\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/brawnyai/balenciaga-men-2023-alpha\",\"owner\":\"brawnyai\",\"name\":\"balenciaga-men-2023-alpha\",\"description\":\"BrawnyAi's
+      testing new SDXL training capabilities\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":\"https://brawny.ai\",\"license_url\":\"https://brawny.ai\",\"run_count\":59,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/1d12d82a-1ab7-4e01-8c68-16df126e8429/replicate-prediction-gy2i75lbtauh.png\",\"default_example\":{\"completed_at\":\"2023-10-02T17:19:40.267868Z\",\"created_at\":\"2023-10-02T17:19:23.282145Z\",\"error\":null,\"id\":\"xhhzkytbjron4nkwmvg252g5om\",\"input\":{\"width\":1024,\"height\":1024,\"prompt\":\"a
+      man dressing in iridescent Balenciaga\",\"refine\":\"no_refiner\",\"scheduler\":\"K_EULER\",\"lora_scale\":0.6,\"num_outputs\":1,\"guidance_scale\":7.5,\"apply_watermark\":true,\"high_noise_frac\":0.8,\"negative_prompt\":\"\",\"prompt_strength\":0.8,\"num_inference_steps\":50},\"logs\":\"Using
+      seed: 12323\\nLoading fine-tuned model\\nDoes not have Unet. assume we are using
+      LoRA\\nLoading Unet LoRA\\nPrompt: a man dressing in iridescent Balenciaga\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00<?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00<00:13,
+      \ 3.65it/s]\\n  4%|\u258D         | 2/50 [00:00<00:13,  3.65it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00<00:12,  3.65it/s]\\n  8%|\u258A         | 4/50 [00:01<00:12,
+      \ 3.66it/s]\\n 10%|\u2588         | 5/50 [00:01<00:12,  3.66it/s]\\n 12%|\u2588\u258F
+      \       | 6/50 [00:01<00:12,  3.66it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01<00:11,
+      \ 3.65it/s]\\n 16%|\u2588\u258C        | 8/50 [00:02<00:11,  3.65it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:02<00:11,  3.65it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02<00:10,
+      \ 3.65it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:03<00:10,  3.65it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:03<00:10,  3.65it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:03<00:10,  3.65it/s]\\n 28%|\u2588\u2588\u258A       | 14/50
+      [00:03<00:09,  3.65it/s]\\n 30%|\u2588\u2588\u2588       | 15/50 [00:04<00:09,
+      \ 3.65it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50 [00:04<00:09,  3.64it/s]\\n
+      34%|\u2588\u2588\u2588\u258D      | 17/50 [00:04<00:09,  3.64it/s]\\n 36%|\u2588\u2588\u2588\u258C
+      \     | 18/50 [00:04<00:08,  3.64it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:05<00:08,  3.64it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:05<00:08,  3.64it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50 [00:05<00:07,
+      \ 3.64it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50 [00:06<00:07,
+      \ 3.64it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50 [00:06<00:07,
+      \ 3.64it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50 [00:06<00:07,
+      \ 3.64it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50 [00:06<00:06,
+      \ 3.64it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    | 26/50 [00:07<00:06,
+      \ 3.64it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D    | 27/50 [00:07<00:06,
+      \ 3.64it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C    | 28/50 [00:07<00:06,
+      \ 3.63it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A    | 29/50 [00:07<00:05,
+      \ 3.63it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 30/50 [00:08<00:05,
+      \ 3.64it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F   | 31/50 [00:08<00:05,
+      \ 3.64it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D   | 32/50 [00:08<00:04,
+      \ 3.64it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C   | 33/50 [00:09<00:04,
+      \ 3.64it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A   | 34/50 [00:09<00:04,
+      \ 3.64it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 35/50 [00:09<00:04,
+      \ 3.64it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F  | 36/50
+      [00:09<00:03,  3.64it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:10<00:03,  3.64it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:10<00:03,  3.63it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:10<00:03,  3.63it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:10<00:02,  3.63it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:11<00:02,  3.63it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:11<00:02,  3.63it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:11<00:01,  3.63it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:12<00:01,  3.63it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:12<00:01,  3.63it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:12<00:01,  3.63it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:12<00:00,  3.64it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:13<00:00,  3.64it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:13<00:00,  3.63it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:13<00:00,  3.64it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:13<00:00,  3.64it/s]\",\"metrics\":{\"predict_time\":15.998679},\"output\":[\"https://pbxt.replicate.delivery/NmFdPhpTMaaaD16IcoOtA1hIgJXtYx2S5XVdXVzVsq7qtiaE/out-0.png\"],\"started_at\":\"2023-10-02T17:19:24.269189Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/xhhzkytbjron4nkwmvg252g5om\",\"cancel\":\"https://api.replicate.com/v1/predictions/xhhzkytbjron4nkwmvg252g5om/cancel\"},\"version\":\"82e61db9989d13b419eadb58ac5ec636da9f02bb16ab5807683b7581cd6e3c71\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"0fed7be6f7278522690856ee0b20617a51893d68fa07f47b3f463fa5bd955691\",\"created_at\":\"2023-10-02T17:22:18.510223Z\",\"cog_version\":\"v0.8.1+dev\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"mask\":{\"type\":\"string\",\"title\":\"Mask\",\"format\":\"uri\",\"x-order\":3,\"description\":\"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted.\"},\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":11,\"description\":\"Random
+      seed. Leave blank to randomize the seed\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":2,\"description\":\"Input
+      image for img2img or inpaint mode\"},\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"default\":1024,\"x-order\":4,\"description\":\"Width
+      of output image\"},\"height\":{\"type\":\"integer\",\"title\":\"Height\",\"default\":1024,\"x-order\":5,\"description\":\"Height
+      of output image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"An
+      astronaut riding a rainbow unicorn\",\"x-order\":0,\"description\":\"Input prompt\"},\"refine\":{\"allOf\":[{\"$ref\":\"#/components/schemas/refine\"}],\"default\":\"no_refiner\",\"x-order\":12,\"description\":\"Which
+      refine style to use\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER\",\"x-order\":7,\"description\":\"scheduler\"},\"lora_scale\":{\"type\":\"number\",\"title\":\"Lora
+      Scale\",\"default\":0.6,\"maximum\":1,\"minimum\":0,\"x-order\":16,\"description\":\"LoRA
+      additive scale. Only applicable on trained models.\"},\"num_outputs\":{\"type\":\"integer\",\"title\":\"Num
+      Outputs\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Number
+      of images to output.\"},\"refine_steps\":{\"type\":\"integer\",\"title\":\"Refine
+      Steps\",\"x-order\":14,\"description\":\"For base_image_refiner, the number
+      of steps to refine, defaults to num_inference_steps\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":50,\"minimum\":1,\"x-order\":9,\"description\":\"Scale
+      for classifier-free guidance\"},\"apply_watermark\":{\"type\":\"boolean\",\"title\":\"Apply
+      Watermark\",\"default\":true,\"x-order\":15,\"description\":\"Applies a watermark
+      to enable determining if an image is generated in downstream applications. If
+      you have other provisions for generating or deploying images safely, you can
+      use this to disable watermarking.\"},\"high_noise_frac\":{\"type\":\"number\",\"title\":\"High
+      Noise Frac\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":13,\"description\":\"For
+      expert_ensemble_refiner, the fraction of noise to use\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"\",\"x-order\":1,\"description\":\"Input Negative Prompt\"},\"prompt_strength\":{\"type\":\"number\",\"title\":\"Prompt
+      Strength\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":10,\"description\":\"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image\"},\"replicate_weights\":{\"type\":\"string\",\"title\":\"Replicate
+      Weights\",\"x-order\":17,\"description\":\"Replicate LoRA weights to use. Leave
+      blank to use the default weights.\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":50,\"maximum\":500,\"minimum\":1,\"x-order\":8,\"description\":\"Number
+      of denoising steps\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"refine\":{\"enum\":[\"no_refiner\",\"expert_ensemble_refiner\",\"base_image_refiner\"],\"type\":\"string\",\"title\":\"refine\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"output\",\"start\",\"completed\",\"logs\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/zsxkib/animate-diff\",\"owner\":\"zsxkib\",\"name\":\"animate-diff\",\"description\":\"\U0001F3A8
+      AnimateDiff (w/ MotionLoRAs for Panning, Zooming, etc): Animate Your Personalized
+      Text-to-Image Diffusion Models without Specific Tuning\",\"visibility\":\"public\",\"github_url\":\"https://github.com/guoyww/AnimateDiff\",\"paper_url\":\"https://arxiv.org/abs/2307.04725\",\"license_url\":\"https://github.com/guoyww/AnimateDiff/blob/main/LICENSE.txt\",\"run_count\":1298,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/336d5c4e-4fd1-415a-a3f7-4a40fa5bdf2b/a_middle-aged_woman_utilizing__zo.gif\",\"default_example\":{\"completed_at\":\"2023-10-03T15:49:45.880669Z\",\"created_at\":\"2023-10-03T15:47:58.527484Z\",\"error\":null,\"id\":\"ficctqlbvnqq6w3eqvc3gep5si\",\"input\":{\"seed\":-1,\"steps\":25,\"width\":768,\"frames\":16,\"height\":512,\"prompt\":\"a
+      medium shot of a vibrant coral reef with a variety of marine life, rainbow,
+      visual effects, prores, cineon, royal, monumental, hyperrealistic, exceptional,
+      visually stunning\",\"base_model\":\"realisticVisionV20_v20\",\"guidance_scale\":7.5,\"negative_prompt\":\"\",\"pan_up_motion_strength\":0,\"zoom_in_motion_strength\":0,\"pan_down_motion_strength\":0,\"pan_left_motion_strength\":0,\"zoom_out_motion_strength\":0,\"pan_right_motion_strength\":0.75,\"rolling_clockwise_motion_strength\":0,\"rolling_anticlockwise_motion_strength\":0},\"logs\":\"--------------------------------------------------------------------------------\\nCog:\\ninference_config:
+      \\\"configs/inference/inference-v2.yaml\\\"\\nmotion_module:\\n- \\\"models/Motion_Module/mm_sd_v15_v2.ckpt\\\"\\nmotion_module_lora_configs:\\n-
+      path:  \\\"models/MotionLoRA/v2_lora_PanRight.ckpt\\\"\\nalpha: 0.75\\ndreambooth_path:
+      \\\"models/DreamBooth_LoRA/realisticVisionV20_v20.safetensors\\\"\\nlora_model_path:
+      \\\"\\\"\\nseed:           -1\\nsteps:          25\\nguidance_scale: 7.5\\nprompt:\\n-
+      \\\"a medium shot of a vibrant coral reef with a variety of marine life, rainbow,
+      visual effects, prores, cineon, royal, monumental, hyperrealistic, exceptional,
+      visually stunning\\\"\\nn_prompt:\\n- \\\"\\\"\\n--------------------------------------------------------------------------------\\ncurrent
+      seed: 14398808075592566791\\nsampling a medium shot of a vibrant coral reef
+      with a variety of marine life, rainbow, visual effects, prores, cineon, royal,
+      monumental, hyperrealistic, exceptional, visually stunning ...\\n  0%|          |
+      0/25 [00:00<?, ?it/s]\\n  4%|\u258D         | 1/25 [00:04<01:38,  4.11s/it]\\n
+      \ 8%|\u258A         | 2/25 [00:08<01:34,  4.12s/it]\\n 12%|\u2588\u258F        |
+      3/25 [00:12<01:30,  4.12s/it]\\n 16%|\u2588\u258C        | 4/25 [00:16<01:26,
+      \ 4.12s/it]\\n 20%|\u2588\u2588        | 5/25 [00:20<01:22,  4.12s/it]\\n 24%|\u2588\u2588\u258D
+      \      | 6/25 [00:24<01:18,  4.12s/it]\\n 28%|\u2588\u2588\u258A       | 7/25
+      [00:28<01:14,  4.12s/it]\\n 32%|\u2588\u2588\u2588\u258F      | 8/25 [00:32<01:10,
+      \ 4.12s/it]\\n 36%|\u2588\u2588\u2588\u258C      | 9/25 [00:37<01:05,  4.12s/it]\\n
+      40%|\u2588\u2588\u2588\u2588      | 10/25 [00:41<01:01,  4.12s/it]\\n 44%|\u2588\u2588\u2588\u2588\u258D
+      \    | 11/25 [00:45<00:57,  4.13s/it]\\n 48%|\u2588\u2588\u2588\u2588\u258A
+      \    | 12/25 [00:49<00:53,  4.13s/it]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 13/25 [00:53<00:49,  4.13s/it]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 14/25 [00:57<00:45,  4.13s/it]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 15/25 [01:01<00:41,  4.13s/it]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 16/25 [01:06<00:37,  4.14s/it]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 17/25 [01:10<00:33,  4.14s/it]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 18/25 [01:14<00:28,  4.14s/it]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 19/25 [01:18<00:24,  4.14s/it]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 20/25 [01:22<00:20,  4.14s/it]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 21/25 [01:26<00:16,  4.14s/it]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 22/25 [01:30<00:12,  4.14s/it]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      23/25 [01:35<00:08,  4.14s/it]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      24/25 [01:39<00:04,  4.14s/it]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      25/25 [01:43<00:00,  4.14s/it]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      25/25 [01:43<00:00,  4.13s/it]\\n  0%|          | 0/16 [00:00<?, ?it/s]\\n 31%|\u2588\u2588\u2588\u258F
+      \     | 5/16 [00:00<00:00, 26.35it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588
+      \    | 8/16 [00:00<00:00, 12.33it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      \  | 10/16 [00:00<00:00, 10.37it/s]\\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 12/16 [00:01<00:00,  9.33it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 14/16 [00:01<00:00,  8.72it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      15/16 [00:01<00:00,  8.47it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      16/16 [00:01<00:00,  8.21it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      16/16 [00:01<00:00,  9.73it/s]\\nsave to samples/99a6f7b49d305094d1391b37d153ab22-2023-10-03T15-47-58/sample/amediumshotofa.mp4\",\"metrics\":{\"predict_time\":107.357321},\"output\":[\"https://pbxt.replicate.delivery/tWckdpnVflzJZyOesJqVdnueqxEyvcPi30BygYDtI3KwQ9UjA/0-amediumshotofa.mp4\"],\"started_at\":\"2023-10-03T15:47:58.523348Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/ficctqlbvnqq6w3eqvc3gep5si\",\"cancel\":\"https://api.replicate.com/v1/predictions/ficctqlbvnqq6w3eqvc3gep5si/cancel\"},\"version\":\"5feed37289b3e23f46e103b778b7acd64e69ecac1d89347e131c642fbfd3eaef\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"5feed37289b3e23f46e103b778b7acd64e69ecac1d89347e131c642fbfd3eaef\",\"created_at\":\"2023-10-02T16:59:36.422731Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"default\":-1,\"x-order\":8,\"description\":\"Seed
+      for different images and reproducibility. Use -1 to randomise seed\"},\"steps\":{\"type\":\"integer\",\"title\":\"Steps\",\"default\":25,\"maximum\":100,\"minimum\":1,\"x-order\":3,\"description\":\"Number
+      of inference steps\"},\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"default\":512,\"x-order\":6,\"description\":\"Width
+      in pixels\"},\"frames\":{\"type\":\"integer\",\"title\":\"Frames\",\"default\":16,\"maximum\":32,\"minimum\":1,\"x-order\":5,\"description\":\"Length
+      of the video in frames (playback is at 8 fps e.g. 16 frames @ 8 fps is 2 seconds)\"},\"height\":{\"type\":\"integer\",\"title\":\"Height\",\"default\":512,\"x-order\":7,\"description\":\"Height
+      in pixels\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"photo
+      of vocano, rocks, storm weather, wind, lava waves, lightning, 8k uhd, dslr,
+      soft lighting, high quality, film grain, Fujifilm XT3\",\"x-order\":0},\"base_model\":{\"allOf\":[{\"$ref\":\"#/components/schemas/base_model\"}],\"default\":\"realisticVisionV20_v20\",\"x-order\":2,\"description\":\"Select
+      a base model (DreamBooth checkpoint)\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":20,\"minimum\":0,\"x-order\":4,\"description\":\"Guidance
+      Scale. How closely do we want to adhere to the prompt and its contents\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"blur, haze, deformed iris, deformed pupils, semi-realistic,
+      cgi, 3d, render, sketch, cartoon, drawing, anime, mutated hands and fingers,
+      deformed, distorted, disfigured, poorly drawn, bad anatomy, wrong anatomy, extra
+      limb, missing limb, floating limbs, disconnected limbs, mutation, mutated, ugly,
+      disgusting, amputation\",\"x-order\":1},\"pan_up_motion_strength\":{\"type\":\"number\",\"title\":\"Pan
+      Up Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":13,\"description\":\"Strength
+      of Pan Up Motion LoRA. 0 disables the LoRA\"},\"zoom_in_motion_strength\":{\"type\":\"number\",\"title\":\"Zoom
+      In Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":9,\"description\":\"Strength
+      of Zoom In Motion LoRA. 0 disables the LoRA\"},\"pan_down_motion_strength\":{\"type\":\"number\",\"title\":\"Pan
+      Down Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":14,\"description\":\"Strength
+      of Pan Down Motion LoRA. 0 disables the LoRA\"},\"pan_left_motion_strength\":{\"type\":\"number\",\"title\":\"Pan
+      Left Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":11,\"description\":\"Strength
+      of Pan Left Motion LoRA. 0 disables the LoRA\"},\"zoom_out_motion_strength\":{\"type\":\"number\",\"title\":\"Zoom
+      Out Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":10,\"description\":\"Strength
+      of Zoom Out Motion LoRA. 0 disables the LoRA\"},\"pan_right_motion_strength\":{\"type\":\"number\",\"title\":\"Pan
+      Right Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":12,\"description\":\"Strength
+      of Pan Right Motion LoRA. 0 disables the LoRA\"},\"rolling_clockwise_motion_strength\":{\"type\":\"number\",\"title\":\"Rolling
+      Clockwise Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":15,\"description\":\"Strength
+      of Rolling Clockwise Motion LoRA. 0 disables the LoRA\"},\"rolling_anticlockwise_motion_strength\":{\"type\":\"number\",\"title\":\"Rolling
+      Anticlockwise Motion Strength\",\"default\":0,\"maximum\":1,\"minimum\":0,\"x-order\":16,\"description\":\"Strength
+      of Rolling Anticlockwise Motion LoRA. 0 disables the LoRA\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"base_model\":{\"enum\":[\"realisticVisionV20_v20\",\"lyriel_v16\",\"majicmixRealistic_v5Preview\",\"rcnzCartoon3d_v10\",\"toonyou_beta3\"],\"type\":\"string\",\"title\":\"base_model\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/cjwbw/internlm-xcomposer\",\"owner\":\"cjwbw\",\"name\":\"internlm-xcomposer\",\"description\":\"Advanced
+      text-image comprehension and composition based on InternLM\",\"visibility\":\"public\",\"github_url\":\"https://github.com/chenxwh/InternLM-XComposer\",\"paper_url\":\"https://arxiv.org/pdf/2309.15112.pdf\",\"license_url\":\"https://huggingface.co/models?license=license%3Aapache-2.0\",\"run_count\":235,\"cover_image_url\":\"https://replicate.delivery/pbxt/JcqDxAZJWep7WsZdWM0gc6Ead2ie0YDEXyemc9HXogSdpsOM/out-0%20(1).png\",\"default_example\":{\"completed_at\":\"2023-10-01T20:24:45.424113Z\",\"created_at\":\"2023-10-01T20:24:35.494781Z\",\"error\":null,\"id\":\"7s4rnulbxfzswyq2cc6n223fwi\",\"input\":{\"text\":\"What
+      makes this image special?\",\"image\":\"https://replicate.delivery/pbxt/JcqDxAZJWep7WsZdWM0gc6Ead2ie0YDEXyemc9HXogSdpsOM/out-0%20(1).png\"},\"logs\":null,\"metrics\":{\"predict_time\":9.940584},\"output\":\"This
+      image is special because it depicts an astronaut sitting in a chair surrounded
+      by psychedelic mushrooms. The astronaut is wearing an orange spacesuit, which
+      adds to the surreal and dreamlike atmosphere of the scene. The combination of
+      the astronaut and the psychedelic mushrooms creates a unique and captivating
+      composition.\\n\",\"started_at\":\"2023-10-01T20:24:35.483529Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/7s4rnulbxfzswyq2cc6n223fwi\",\"cancel\":\"https://api.replicate.com/v1/predictions/7s4rnulbxfzswyq2cc6n223fwi/cancel\"},\"version\":\"d16df299dbe3454023fcb47ed48dbff052e9b7cdf2837707adff3581edd11e95\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"d16df299dbe3454023fcb47ed48dbff052e9b7cdf2837707adff3581edd11e95\",\"created_at\":\"2023-10-01T19:42:22.670936Z\",\"cog_version\":\"0.8.3\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"text\"],\"properties\":{\"text\":{\"type\":\"string\",\"title\":\"Text\",\"x-order\":1,\"description\":\"Input
+      text.\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Input
+      image.\"}}},\"Output\":{\"type\":\"string\",\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"logs\",\"output\",\"completed\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/robot007/sdxl-run\",\"owner\":\"robot007\",\"name\":\"sdxl-run\",\"description\":\"Train
+      WestElm furniture with captions\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":278,\"cover_image_url\":\"https://pbxt.replicate.delivery/4WFIwdpJZjp8Cp6snwFwUpKmeMMJEzPIwFmq2v1AmQvOwG0IA/out-0.png\",\"default_example\":{\"completed_at\":\"2023-09-26T18:42:38.376648Z\",\"created_at\":\"2023-09-26T18:42:24.836544Z\",\"error\":null,\"id\":\"b7ptl5tbboqtt7isaluijh4jf4\",\"input\":{\"width\":1024,\"height\":1024,\"prompt\":\"beige
+      sofa, traditional living room,\",\"refine\":\"expert_ensemble_refiner\",\"scheduler\":\"K_EULER\",\"lora_scale\":0.6,\"num_outputs\":1,\"guidance_scale\":7.5,\"apply_watermark\":true,\"high_noise_frac\":0.8,\"negative_prompt\":\"\",\"prompt_strength\":0.8,\"num_inference_steps\":50},\"logs\":null,\"metrics\":{\"predict_time\":13.020319},\"output\":[\"https://pbxt.replicate.delivery/4WFIwdpJZjp8Cp6snwFwUpKmeMMJEzPIwFmq2v1AmQvOwG0IA/out-0.png\"],\"started_at\":\"2023-09-26T18:42:25.356329Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/b7ptl5tbboqtt7isaluijh4jf4\",\"cancel\":\"https://api.replicate.com/v1/predictions/b7ptl5tbboqtt7isaluijh4jf4/cancel\"},\"version\":\"4f4d397a040113d84e33a7832b0a7efc324f573b322824fadbd4d6a480d8bf9e\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"2ce6891e21dcc1582c5ea66a7f2de1208a588a27d18e215cec62acf30bd80060\",\"created_at\":\"2023-10-01T09:42:52.725480Z\",\"cog_version\":\"v0.8.1+dev\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"mask\":{\"type\":\"string\",\"title\":\"Mask\",\"format\":\"uri\",\"x-order\":3,\"description\":\"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted.\"},\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":11,\"description\":\"Random
+      seed. Leave blank to randomize the seed\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":2,\"description\":\"Input
+      image for img2img or inpaint mode\"},\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"default\":1024,\"x-order\":4,\"description\":\"Width
+      of output image\"},\"height\":{\"type\":\"integer\",\"title\":\"Height\",\"default\":1024,\"x-order\":5,\"description\":\"Height
+      of output image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"An
+      astronaut riding a rainbow unicorn\",\"x-order\":0,\"description\":\"Input prompt\"},\"refine\":{\"allOf\":[{\"$ref\":\"#/components/schemas/refine\"}],\"default\":\"no_refiner\",\"x-order\":12,\"description\":\"Which
+      refine style to use\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER\",\"x-order\":7,\"description\":\"scheduler\"},\"lora_scale\":{\"type\":\"number\",\"title\":\"Lora
+      Scale\",\"default\":0.6,\"maximum\":1,\"minimum\":0,\"x-order\":16,\"description\":\"LoRA
+      additive scale. Only applicable on trained models.\"},\"num_outputs\":{\"type\":\"integer\",\"title\":\"Num
+      Outputs\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Number
+      of images to output.\"},\"refine_steps\":{\"type\":\"integer\",\"title\":\"Refine
+      Steps\",\"x-order\":14,\"description\":\"For base_image_refiner, the number
+      of steps to refine, defaults to num_inference_steps\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":50,\"minimum\":1,\"x-order\":9,\"description\":\"Scale
+      for classifier-free guidance\"},\"apply_watermark\":{\"type\":\"boolean\",\"title\":\"Apply
+      Watermark\",\"default\":true,\"x-order\":15,\"description\":\"Applies a watermark
+      to enable determining if an image is generated in downstream applications. If
+      you have other provisions for generating or deploying images safely, you can
+      use this to disable watermarking.\"},\"high_noise_frac\":{\"type\":\"number\",\"title\":\"High
+      Noise Frac\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":13,\"description\":\"For
+      expert_ensemble_refiner, the fraction of noise to use\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"\",\"x-order\":1,\"description\":\"Input Negative Prompt\"},\"prompt_strength\":{\"type\":\"number\",\"title\":\"Prompt
+      Strength\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":10,\"description\":\"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image\"},\"replicate_weights\":{\"type\":\"string\",\"title\":\"Replicate
+      Weights\",\"x-order\":17,\"description\":\"Replicate LoRA weights to use. Leave
+      blank to use the default weights.\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":50,\"maximum\":500,\"minimum\":1,\"x-order\":8,\"description\":\"Number
+      of denoising steps\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"refine\":{\"enum\":[\"no_refiner\",\"expert_ensemble_refiner\",\"base_image_refiner\"],\"type\":\"string\",\"title\":\"refine\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"output\",\"start\",\"completed\",\"logs\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/catacolabs/headshot-pics\",\"owner\":\"catacolabs\",\"name\":\"headshot-pics\",\"description\":\"Turn
+      your selfies into a professional headshot in seconds - proHeadshot.pics\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":57069,\"cover_image_url\":\"https://replicate.delivery/pbxt/IpeieCYC6Wrq6kdbaxKhjqmZoV8V5lY2xUkIKpapWRAdxrpRA/1696139869.jpg\",\"default_example\":{\"completed_at\":\"2023-10-01T05:57:49.527785Z\",\"created_at\":\"2023-10-01T05:57:37.106806Z\",\"error\":null,\"id\":\"qpsggpbbsavvq6n2mh4zqnbb7y\",\"input\":{\"pose\":\"random\",\"seed\":1338,\"image\":\"https://replicate.delivery/pbxt/Jc879x8thCiO5N9myg8XXPpm4Rj062YpolrtMyZlyRizIjzJ/rafa.jpg\",\"gender\":\"man\"},\"logs\":\"Using
+      Seed: 1338\\nRunning Analysis on image...\\n  0%|          | 0/50 [00:00<?,
+      ?it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50 [00:00<00:00, 187.25it/s]\\n
+      76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C  | 38/50 [00:00<00:00,
+      186.10it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:00<00:00, 188.85it/s]\\n  0%|          | 0/6 [00:00<?, ?it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      6/6 [00:00<00:00, 139.84it/s]\\n  0%|          | 0/1 [00:00<?, ?it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      1/1 [00:00<00:00, 55.43it/s]\\nInspecting:   0%|          | 0/32 [00:00<?, ?it/s]\\nInspecting:
+      \  3%|\u258E         | 1/32 [00:00<00:25,  1.21it/s]\\nInspecting:   6%|\u258B
+      \        | 2/32 [00:01<00:23,  1.26it/s]\\nInspecting:   9%|\u2589         |
+      3/32 [00:02<00:23,  1.23it/s]\\nInspecting:  12%|\u2588\u258E        | 4/32
+      [00:03<00:23,  1.19it/s]\\nInspecting:  16%|\u2588\u258C        | 5/32 [00:04<00:23,
+      \ 1.16it/s]\\nInspecting:  19%|\u2588\u2589        | 6/32 [00:05<00:23,  1.13it/s]\\nInspecting:
+      \ 22%|\u2588\u2588\u258F       | 7/32 [00:06<00:22,  1.11it/s]\\nInspecting:
+      \ 25%|\u2588\u2588\u258C       | 8/32 [00:07<00:22,  1.07it/s]\\nInspecting:
+      \ 25%|\u2588\u2588\u258C       | 8/32 [00:08<00:24,  1.02s/it]\\nUsing gender:
+      man\\nUsing random pose...\\nThe following part of your input was truncated
+      because CLIP can only handle sequences up to 77 tokens: ['3 0 s, 9 5,']\\n  0%|
+      \         | 0/20 [00:00<?, ?it/s]\\n  5%|\u258C         | 1/20 [00:00<00:02,
+      \ 8.78it/s]\\n 10%|\u2588         | 2/20 [00:00<00:02,  8.76it/s]\\n 15%|\u2588\u258C
+      \       | 3/20 [00:00<00:01,  8.76it/s]\\n 20%|\u2588\u2588        | 4/20 [00:00<00:01,
+      \ 8.70it/s]\\n 25%|\u2588\u2588\u258C       | 5/20 [00:00<00:01,  8.71it/s]\\n
+      30%|\u2588\u2588\u2588       | 6/20 [00:00<00:01,  8.73it/s]\\n 35%|\u2588\u2588\u2588\u258C
+      \     | 7/20 [00:00<00:01,  8.74it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      8/20 [00:00<00:01,  8.74it/s]\\n 45%|\u2588\u2588\u2588\u2588\u258C     | 9/20
+      [00:01<00:01,  8.75it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 10/20 [00:01<00:01,
+      \ 8.75it/s]\\n 55%|\u2588\u2588\u2588\u2588\u2588\u258C    | 11/20 [00:01<00:01,
+      \ 8.75it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 12/20 [00:01<00:00,
+      \ 8.75it/s]\\n 65%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C   | 13/20 [00:01<00:00,
+      \ 8.63it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 14/20 [00:01<00:00,
+      \ 8.67it/s]\\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C  | 15/20
+      [00:01<00:00,  8.70it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 16/20 [00:01<00:00,  8.69it/s]\\n 85%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 17/20 [00:01<00:00,  8.71it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 18/20 [00:02<00:00,  8.72it/s]\\n 95%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      19/20 [00:02<00:00,  8.74it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      20/20 [00:02<00:00,  8.75it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      20/20 [00:02<00:00,  8.72it/s]\\n(728, 512, 3) None None\",\"metrics\":{\"predict_time\":12.45042},\"output\":\"https://replicate.delivery/pbxt/IpeieCYC6Wrq6kdbaxKhjqmZoV8V5lY2xUkIKpapWRAdxrpRA/1696139869.jpg\",\"started_at\":\"2023-10-01T05:57:37.077365Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/qpsggpbbsavvq6n2mh4zqnbb7y\",\"cancel\":\"https://api.replicate.com/v1/predictions/qpsggpbbsavvq6n2mh4zqnbb7y/cancel\"},\"version\":\"f07d61d6b859b7e2dc9e8685489bc08966662443afa85faad6a549fff6029a3b\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"f07d61d6b859b7e2dc9e8685489bc08966662443afa85faad6a549fff6029a3b\",\"created_at\":\"2023-10-01T05:19:28.698596Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"pose\":{\"enum\":[\"random\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\",\"9\"],\"type\":\"string\",\"title\":\"pose\",\"description\":\"An
+      enumeration.\"},\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"image\"],\"properties\":{\"pose\":{\"allOf\":[{\"$ref\":\"#/components/schemas/pose\"}],\"default\":\"random\",\"x-order\":2,\"description\":\"Choose
+      your pose\"},\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":3,\"description\":\"Seed
+      (0 or lower for random, max: 2147483647)\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":0,\"description\":\"Upload
+      a photo of your face\"},\"gender\":{\"allOf\":[{\"$ref\":\"#/components/schemas/gender\"}],\"default\":\"man\",\"x-order\":1,\"description\":\"Choose
+      your gender\"}}},\"Output\":{\"type\":\"string\",\"title\":\"Output\",\"format\":\"uri\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"gender\":{\"enum\":[\"man\",\"woman\",\"unisex\"],\"type\":\"string\",\"title\":\"gender\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/qr2ai/qr2ai\",\"owner\":\"qr2ai\",\"name\":\"qr2ai\",\"description\":\"qr2ai
+      AI-Generated QR Codes with Stable Diffusion\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":227,\"cover_image_url\":\"https://replicate.delivery/pbxt/BvOd0mnwol5SKxVIZtb02IwA9dt9nzr9St6WtswcCwRwAaaE/output-0.png\",\"default_example\":{\"completed_at\":\"2023-10-01T01:43:29.811326Z\",\"created_at\":\"2023-10-01T01:38:57.241602Z\",\"error\":null,\"id\":\"bjsilybbj7qrpwqh27gaw76ksi\",\"input\":{\"seed\":6623517335,\"prompt\":\"a
+      row of charming houses on a hill done in folk art style please--ar 16;9  high
+      detailed,  immaculate scale, hyper-realistic, Unreal Engine, Octane Render,
+      digital art, trending on Artstation, 8k resolution, cinema 4d, 3D, beautiful,
+      cinematic, art by artgerm and greg rutkowski and alphonse mucha and loish and
+      WLOP\",\"strength\":0.9,\"batch_size\":1,\"guidance_scale\":13,\"negative_prompt\":\"ugly,
+      disfigured, low quality, blurry, nsfw\",\"qr_code_content\":\"https://qr2ai.com\",\"num_inference_steps\":40,\"controlnet_conditioning_scale\":1.1},\"logs\":\"Generating
+      QR Code from content\\nToken indices sequence length is longer than the specified
+      maximum sequence length for this model (81 > 77). Running this sequence through
+      the model will result in indexing errors\\nThe following part of your input
+      was truncated because CLIP can only handle sequences up to 77 tokens: ['ish
+      and wlop']\\n  0%|          | 0/36 [00:00<?, ?it/s]\\n  3%|\u258E         |
+      1/36 [00:01<00:37,  1.08s/it]\\n  6%|\u258C         | 2/36 [00:01<00:25,  1.34it/s]\\n
+      \ 8%|\u258A         | 3/36 [00:02<00:20,  1.57it/s]\\n 11%|\u2588         |
+      4/36 [00:02<00:18,  1.71it/s]\\n 14%|\u2588\u258D        | 5/36 [00:03<00:17,
+      \ 1.79it/s]\\n 17%|\u2588\u258B        | 6/36 [00:03<00:16,  1.85it/s]\\n 19%|\u2588\u2589
+      \       | 7/36 [00:04<00:15,  1.88it/s]\\n 22%|\u2588\u2588\u258F       | 8/36
+      [00:04<00:14,  1.91it/s]\\n 25%|\u2588\u2588\u258C       | 9/36 [00:05<00:13,
+      \ 1.93it/s]\\n 28%|\u2588\u2588\u258A       | 10/36 [00:05<00:13,  1.94it/s]\\n
+      31%|\u2588\u2588\u2588       | 11/36 [00:06<00:12,  1.95it/s]\\n 33%|\u2588\u2588\u2588\u258E
+      \     | 12/36 [00:06<00:12,  1.96it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      13/36 [00:07<00:11,  1.96it/s]\\n 39%|\u2588\u2588\u2588\u2589      | 14/36
+      [00:07<00:11,  1.97it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 15/36 [00:08<00:10,
+      \ 1.97it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 16/36 [00:08<00:10,
+      \ 1.97it/s]\\n 47%|\u2588\u2588\u2588\u2588\u258B     | 17/36 [00:09<00:09,
+      \ 1.96it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 18/36 [00:09<00:09,
+      \ 1.96it/s]\\n 53%|\u2588\u2588\u2588\u2588\u2588\u258E    | 19/36 [00:10<00:08,
+      \ 1.96it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C    | 20/36 [00:10<00:08,
+      \ 1.97it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A    | 21/36 [00:11<00:07,
+      \ 1.97it/s]\\n 61%|\u2588\u2588\u2588\u2588\u2588\u2588    | 22/36 [00:11<00:07,
+      \ 1.96it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D   | 23/36 [00:12<00:06,
+      \ 1.96it/s]\\n 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258B   | 24/36 [00:12<00:06,
+      \ 1.96it/s]\\n 69%|\u2588\u2588\u2588\u2588\u2588\u2588\u2589   | 25/36 [00:13<00:05,
+      \ 1.96it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F  | 26/36
+      [00:13<00:05,  1.95it/s]\\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 27/36 [00:14<00:04,  1.95it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 28/36 [00:14<00:04,  1.95it/s]\\n 81%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 29/36 [00:15<00:03,  1.95it/s]\\n 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258E
+      | 30/36 [00:15<00:03,  1.95it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 31/36 [00:16<00:02,  1.94it/s]\\n 89%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589
+      | 32/36 [00:16<00:02,  1.95it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      33/36 [00:17<00:01,  1.95it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      34/36 [00:17<00:01,  1.95it/s]\\n 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258B|
+      35/36 [00:18<00:00,  1.95it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      36/36 [00:18<00:00,  1.94it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      36/36 [00:18<00:00,  1.90it/s]\",\"metrics\":{\"predict_time\":24.082372},\"output\":[\"https://replicate.delivery/pbxt/BvOd0mnwol5SKxVIZtb02IwA9dt9nzr9St6WtswcCwRwAaaE/output-0.png\"],\"started_at\":\"2023-10-01T01:43:05.728954Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/bjsilybbj7qrpwqh27gaw76ksi\",\"cancel\":\"https://api.replicate.com/v1/predictions/bjsilybbj7qrpwqh27gaw76ksi/cancel\"},\"version\":\"22d8c0a500c0faca9143d4cf55f4ff8e2f1140056af0821dbcfccd8f95cb9038\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"22d8c0a500c0faca9143d4cf55f4ff8e2f1140056af0821dbcfccd8f95cb9038\",\"created_at\":\"2023-10-01T01:02:40.851994Z\",\"cog_version\":\"0.8.6\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"required\":[\"prompt\",\"qr_code_content\"],\"properties\":{\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"default\":-1,\"x-order\":5,\"description\":\"Seed\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"x-order\":0,\"description\":\"The
+      prompt to guide QR Code generation.\"},\"strength\":{\"type\":\"number\",\"title\":\"Strength\",\"default\":0.9,\"maximum\":1,\"minimum\":0,\"x-order\":7,\"description\":\"Indicates
+      how much to transform the masked portion of the reference `image`. Must be between
+      0 and 1.\"},\"batch_size\":{\"type\":\"integer\",\"title\":\"Batch Size\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Batch
+      size for this prediction\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":30,\"minimum\":0.1,\"x-order\":4,\"description\":\"Scale
+      for classifier-free guidance\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"ugly, disfigured, low quality, blurry, nsfw\",\"x-order\":2,\"description\":\"The
+      negative prompt to guide image generation.\"},\"qr_code_content\":{\"type\":\"string\",\"title\":\"Qr
+      Code Content\",\"x-order\":1,\"description\":\"The website/content your QR Code
+      will point to.\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":40,\"maximum\":100,\"minimum\":20,\"x-order\":3,\"description\":\"Number
+      of diffusion steps\"},\"controlnet_conditioning_scale\":{\"type\":\"number\",\"title\":\"Controlnet
+      Conditioning Scale\",\"default\":1.5,\"maximum\":2,\"minimum\":1,\"x-order\":8,\"description\":\"The
+      outputs of the controlnet are multiplied by `controlnet_conditioning_scale`
+      before they are added to the residual in the original unet.\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"start\",\"output\",\"logs\",\"completed\"]}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}},{\"url\":\"https://replicate.com/galleri5/dada-collage\",\"owner\":\"galleri5\",\"name\":\"dada-collage\",\"description\":\"WIP
+      - Trained on Bing Dalle ( 2.5 ) generations with glitch collage aesthetic\",\"visibility\":\"public\",\"github_url\":null,\"paper_url\":null,\"license_url\":null,\"run_count\":137,\"cover_image_url\":\"https://tjzk.replicate.delivery/models_models_cover_image/0ca32507-fa6a-4b0f-a262-deefdb19c17f/BIDACOJ_11.jpg\",\"default_example\":{\"completed_at\":\"2023-09-30T18:01:24.872997Z\",\"created_at\":\"2023-09-30T18:01:09.099195Z\",\"error\":null,\"id\":\"flgw7glbygqehiv2txqtjgpx7q\",\"input\":{\"width\":1024,\"height\":1024,\"prompt\":\"In
+      the style of BIDACOJ, flower\",\"refine\":\"no_refiner\",\"scheduler\":\"K_EULER\",\"lora_scale\":0.63,\"num_outputs\":1,\"guidance_scale\":7.5,\"apply_watermark\":true,\"high_noise_frac\":0.8,\"negative_prompt\":\"pink\",\"prompt_strength\":0.8,\"num_inference_steps\":50},\"logs\":\"Using
+      seed: 60007\\nPrompt: In the style of BIDACOJ, flower\\ntxt2img mode\\n  0%|
+      \         | 0/50 [00:00<?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00<00:13,
+      \ 3.69it/s]\\n  4%|\u258D         | 2/50 [00:00<00:13,  3.67it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00<00:12,  3.67it/s]\\n  8%|\u258A         | 4/50 [00:01<00:12,
+      \ 3.67it/s]\\n 10%|\u2588         | 5/50 [00:01<00:12,  3.67it/s]\\n 12%|\u2588\u258F
+      \       | 6/50 [00:01<00:11,  3.67it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01<00:11,
+      \ 3.67it/s]\\n 16%|\u2588\u258C        | 8/50 [00:02<00:11,  3.67it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:02<00:11,  3.67it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02<00:10,
+      \ 3.67it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02<00:10,  3.67it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:03<00:10,  3.67it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:03<00:10,  3.67it/s]\\n 28%|\u2588\u2588\u258A       | 14/50
+      [00:03<00:09,  3.67it/s]\\n 30%|\u2588\u2588\u2588       | 15/50 [00:04<00:09,
+      \ 3.66it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50 [00:04<00:09,  3.67it/s]\\n
+      34%|\u2588\u2588\u2588\u258D      | 17/50 [00:04<00:09,  3.67it/s]\\n 36%|\u2588\u2588\u2588\u258C
+      \     | 18/50 [00:04<00:08,  3.66it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:05<00:08,  3.66it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:05<00:08,  3.66it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50 [00:05<00:07,
+      \ 3.66it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50 [00:06<00:07,
+      \ 3.66it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50 [00:06<00:07,
+      \ 3.65it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50 [00:06<00:07,
+      \ 3.65it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50 [00:06<00:06,
+      \ 3.65it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    | 26/50 [00:07<00:06,
+      \ 3.65it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D    | 27/50 [00:07<00:06,
+      \ 3.65it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C    | 28/50 [00:07<00:06,
+      \ 3.65it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A    | 29/50 [00:07<00:05,
+      \ 3.65it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 30/50 [00:08<00:05,
+      \ 3.65it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F   | 31/50 [00:08<00:05,
+      \ 3.65it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D   | 32/50 [00:08<00:04,
+      \ 3.65it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C   | 33/50 [00:09<00:04,
+      \ 3.65it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A   | 34/50 [00:09<00:04,
+      \ 3.65it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 35/50 [00:09<00:04,
+      \ 3.65it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F  | 36/50
+      [00:09<00:03,  3.65it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:10<00:03,  3.65it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:10<00:03,  3.65it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:10<00:03,  3.65it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:10<00:02,  3.65it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:11<00:02,  3.65it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:11<00:02,  3.65it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:11<00:01,  3.65it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:12<00:01,  3.65it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:12<00:01,  3.65it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:12<00:01,  3.64it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:12<00:00,  3.64it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:13<00:00,  3.64it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:13<00:00,  3.64it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:13<00:00,  3.64it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:13<00:00,  3.66it/s]\",\"metrics\":{\"predict_time\":15.776207},\"output\":[\"https://pbxt.replicate.delivery/jAImJfTODh20YKiA3pmzfvNM1ehFOvBfMTeZCesQO1se5ow0IA/out-0.png\"],\"started_at\":\"2023-09-30T18:01:09.096790Z\",\"status\":\"succeeded\",\"urls\":{\"get\":\"https://api.replicate.com/v1/predictions/flgw7glbygqehiv2txqtjgpx7q\",\"cancel\":\"https://api.replicate.com/v1/predictions/flgw7glbygqehiv2txqtjgpx7q/cancel\"},\"version\":\"b0eab059abf4f856e00dc780011af287dbbbd963fe8f7c8c0cbaaf57737c0e87\",\"webhook_completed\":null},\"latest_version\":{\"id\":\"fcca9c98d3381a4e5dbf767a80d02df799538086718808e1acf0ad7eb6899c43\",\"created_at\":\"2023-09-30T17:36:15.827632Z\",\"cog_version\":\"0.8.2\",\"openapi_schema\":{\"info\":{\"title\":\"Cog\",\"version\":\"0.1.0\"},\"paths\":{\"/\":{\"get\":{\"summary\":\"Root\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Root  Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"root__get\"}},\"/shutdown\":{\"post\":{\"summary\":\"Start
+      Shutdown\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Start Shutdown Shutdown Post\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"start_shutdown_shutdown_post\"}},\"/predictions\":{\"post\":{\"summary\":\"Predict\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model\",\"operationId\":\"predict_predictions_post\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionRequest\"}}}}}},\"/health-check\":{\"get\":{\"summary\":\"Healthcheck\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Healthcheck Health Check Get\"}}},\"description\":\"Successful Response\"}},\"operationId\":\"healthcheck_health_check_get\"}},\"/predictions/{prediction_id}\":{\"put\":{\"summary\":\"Predict
+      Idempotent\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/PredictionResponse\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true},{\"in\":\"header\",\"name\":\"prefer\",\"schema\":{\"type\":\"string\",\"title\":\"Prefer\"},\"required\":false}],\"description\":\"Run
+      a single prediction on the model (idempotent creation).\",\"operationId\":\"predict_idempotent_predictions__prediction_id__put\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"$ref\":\"#/components/schemas/PredictionRequest\"}],\"title\":\"Prediction
+      Request\"}}},\"required\":true}}},\"/predictions/{prediction_id}/cancel\":{\"post\":{\"summary\":\"Cancel\",\"responses\":{\"200\":{\"content\":{\"application/json\":{\"schema\":{\"title\":\"Response
+      Cancel Predictions  Prediction Id  Cancel Post\"}}},\"description\":\"Successful
+      Response\"},\"422\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/HTTPValidationError\"}}},\"description\":\"Validation
+      Error\"}},\"parameters\":[{\"in\":\"path\",\"name\":\"prediction_id\",\"schema\":{\"type\":\"string\",\"title\":\"Prediction
+      ID\"},\"required\":true}],\"description\":\"Cancel a running prediction\",\"operationId\":\"cancel_predictions__prediction_id__cancel_post\"}}},\"openapi\":\"3.0.2\",\"components\":{\"schemas\":{\"Input\":{\"type\":\"object\",\"title\":\"Input\",\"properties\":{\"mask\":{\"type\":\"string\",\"title\":\"Mask\",\"format\":\"uri\",\"x-order\":3,\"description\":\"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted.\"},\"seed\":{\"type\":\"integer\",\"title\":\"Seed\",\"x-order\":11,\"description\":\"Random
+      seed. Leave blank to randomize the seed\"},\"image\":{\"type\":\"string\",\"title\":\"Image\",\"format\":\"uri\",\"x-order\":2,\"description\":\"Input
+      image for img2img or inpaint mode\"},\"width\":{\"type\":\"integer\",\"title\":\"Width\",\"default\":1024,\"x-order\":4,\"description\":\"Width
+      of output image\"},\"height\":{\"type\":\"integer\",\"title\":\"Height\",\"default\":1024,\"x-order\":5,\"description\":\"Height
+      of output image\"},\"prompt\":{\"type\":\"string\",\"title\":\"Prompt\",\"default\":\"An
+      astronaut riding a rainbow unicorn\",\"x-order\":0,\"description\":\"Input prompt\"},\"refine\":{\"allOf\":[{\"$ref\":\"#/components/schemas/refine\"}],\"default\":\"no_refiner\",\"x-order\":12,\"description\":\"Which
+      refine style to use\"},\"scheduler\":{\"allOf\":[{\"$ref\":\"#/components/schemas/scheduler\"}],\"default\":\"K_EULER\",\"x-order\":7,\"description\":\"scheduler\"},\"lora_scale\":{\"type\":\"number\",\"title\":\"Lora
+      Scale\",\"default\":0.6,\"maximum\":1,\"minimum\":0,\"x-order\":16,\"description\":\"LoRA
+      additive scale. Only applicable on trained models.\"},\"num_outputs\":{\"type\":\"integer\",\"title\":\"Num
+      Outputs\",\"default\":1,\"maximum\":4,\"minimum\":1,\"x-order\":6,\"description\":\"Number
+      of images to output.\"},\"refine_steps\":{\"type\":\"integer\",\"title\":\"Refine
+      Steps\",\"x-order\":14,\"description\":\"For base_image_refiner, the number
+      of steps to refine, defaults to num_inference_steps\"},\"guidance_scale\":{\"type\":\"number\",\"title\":\"Guidance
+      Scale\",\"default\":7.5,\"maximum\":50,\"minimum\":1,\"x-order\":9,\"description\":\"Scale
+      for classifier-free guidance\"},\"apply_watermark\":{\"type\":\"boolean\",\"title\":\"Apply
+      Watermark\",\"default\":true,\"x-order\":15,\"description\":\"Applies a watermark
+      to enable determining if an image is generated in downstream applications. If
+      you have other provisions for generating or deploying images safely, you can
+      use this to disable watermarking.\"},\"high_noise_frac\":{\"type\":\"number\",\"title\":\"High
+      Noise Frac\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":13,\"description\":\"For
+      expert_ensemble_refiner, the fraction of noise to use\"},\"negative_prompt\":{\"type\":\"string\",\"title\":\"Negative
+      Prompt\",\"default\":\"\",\"x-order\":1,\"description\":\"Input Negative Prompt\"},\"prompt_strength\":{\"type\":\"number\",\"title\":\"Prompt
+      Strength\",\"default\":0.8,\"maximum\":1,\"minimum\":0,\"x-order\":10,\"description\":\"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image\"},\"num_inference_steps\":{\"type\":\"integer\",\"title\":\"Num
+      Inference Steps\",\"default\":50,\"maximum\":500,\"minimum\":1,\"x-order\":8,\"description\":\"Number
+      of denoising steps\"}}},\"Output\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"uri\"},\"title\":\"Output\"},\"Status\":{\"enum\":[\"starting\",\"processing\",\"succeeded\",\"canceled\",\"failed\"],\"type\":\"string\",\"title\":\"Status\",\"description\":\"An
+      enumeration.\"},\"refine\":{\"enum\":[\"no_refiner\",\"expert_ensemble_refiner\",\"base_image_refiner\"],\"type\":\"string\",\"title\":\"refine\",\"description\":\"An
+      enumeration.\"},\"scheduler\":{\"enum\":[\"DDIM\",\"DPMSolverMultistep\",\"HeunDiscrete\",\"KarrasDPM\",\"K_EULER_ANCESTRAL\",\"K_EULER\",\"PNDM\"],\"type\":\"string\",\"title\":\"scheduler\",\"description\":\"An
+      enumeration.\"},\"WebhookEvent\":{\"enum\":[\"start\",\"output\",\"logs\",\"completed\"],\"type\":\"string\",\"title\":\"WebhookEvent\",\"description\":\"An
+      enumeration.\"},\"ValidationError\":{\"type\":\"object\",\"title\":\"ValidationError\",\"required\":[\"loc\",\"msg\",\"type\"],\"properties\":{\"loc\":{\"type\":\"array\",\"items\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"title\":\"Location\"},\"msg\":{\"type\":\"string\",\"title\":\"Message\"},\"type\":{\"type\":\"string\",\"title\":\"Error
+      Type\"}}},\"PredictionRequest\":{\"type\":\"object\",\"title\":\"PredictionRequest\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"webhook\":{\"type\":\"string\",\"title\":\"Webhook\",\"format\":\"uri\",\"maxLength\":65536,\"minLength\":1},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"output_file_prefix\":{\"type\":\"string\",\"title\":\"Output
+      File Prefix\"},\"webhook_events_filter\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/WebhookEvent\"},\"default\":[\"completed\",\"output\",\"start\",\"logs\"],\"uniqueItems\":true}}},\"PredictionResponse\":{\"type\":\"object\",\"title\":\"PredictionResponse\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"Id\"},\"logs\":{\"type\":\"string\",\"title\":\"Logs\",\"default\":\"\"},\"error\":{\"type\":\"string\",\"title\":\"Error\"},\"input\":{\"$ref\":\"#/components/schemas/Input\"},\"output\":{\"$ref\":\"#/components/schemas/Output\"},\"status\":{\"$ref\":\"#/components/schemas/Status\"},\"metrics\":{\"type\":\"object\",\"title\":\"Metrics\"},\"version\":{\"type\":\"string\",\"title\":\"Version\"},\"created_at\":{\"type\":\"string\",\"title\":\"Created
+      At\",\"format\":\"date-time\"},\"started_at\":{\"type\":\"string\",\"title\":\"Started
+      At\",\"format\":\"date-time\"},\"completed_at\":{\"type\":\"string\",\"title\":\"Completed
+      At\",\"format\":\"date-time\"}}},\"HTTPValidationError\":{\"type\":\"object\",\"title\":\"HTTPValidationError\",\"properties\":{\"detail\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/components/schemas/ValidationError\"},\"title\":\"Detail\"}}}}}}}}]}"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 810c53e1ad0bc6cd-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 04 Oct 2023 09:16:43 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=9zcnw7UZlYCKcybRWGyZU%2FcsLVZOUpn9P7vbBkO5ZjKkYEpuy2%2BsZD7vKreDrHaAFgucszxOfK0FSEzZTlKShlYOQ%2B57JTqlH4Iow9ODk1wTYda838Z9dXP6EXftMJEdERc7"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      allow:
+      - GET, HEAD, OPTIONS
+      content-security-policy-report-only:
+      - 'default-src ''self''; worker-src ''none''; media-src ''report-sample'' ''self''
+        https://replicate.delivery https://*.replicate.delivery https://*.mux.com
+        https://*.sentry.io; img-src ''report-sample'' ''self'' data: https://replicate.delivery
+        https://*.replicate.delivery https://*.githubusercontent.com https://github.com;
+        script-src ''report-sample'' ''self'' https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js;
+        style-src ''report-sample'' ''self'' ''unsafe-inline''; font-src ''report-sample''
+        ''self'' data:; connect-src ''report-sample'' ''self'' https://replicate.delivery
+        https://*.replicate.delivery https://*.rudderlabs.com https://*.rudderstack.com
+        https://*.mux.com https://*.sentry.io; report-uri'
+      cross-origin-opener-policy:
+      - same-origin
+      ratelimit-remaining:
+      - '2999'
+      ratelimit-reset:
+      - '1'
+      referrer-policy:
+      - same-origin
+      vary:
+      - Cookie, origin
+      via:
+      - 1.1 vegur, 1.1 google
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,5 +9,6 @@ async def test_models_get(mock_replicate_api_token):
     model = replicate.models.get("stability-ai/sdxl")
 
     assert model is not None
-    assert model.username == "stability-ai"
+    assert model.owner == "stability-ai"
     assert model.name == "sdxl"
+    assert model.visibility == "public"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,3 +12,14 @@ async def test_models_get(mock_replicate_api_token):
     assert model.owner == "stability-ai"
     assert model.name == "sdxl"
     assert model.visibility == "public"
+
+
+@pytest.mark.vcr("models-list.yaml")
+@pytest.mark.asyncio
+async def test_models_list(mock_replicate_api_token):
+    models = replicate.models.list()
+
+    assert len(models) > 0
+    assert models[0].owner is not None
+    assert models[0].name is not None
+    assert models[0].visibility == "public"


### PR DESCRIPTION
See https://replicate.com/docs/reference/http#models.get
See https://replicate.com/docs/reference/http#models.list

Currently, the `Model` class has only `username` and `name`, and the `ModelCollection.get` method constructs a new instance with the provided username and name arguments.

This PR makes the following changes to bring it more in line with the [replicate-javascript](https://github.com/replicate/replicate-javascript) and the other official clients:

- Adds `url`, `description`, `visibility`, and other fields to `Model`
- Adds `owner` field and reimplements existing `username` field to deprecated property that aliases this field
- Updates `ModelCollection.get` to fetch information about the named model from Replicate's API
- Adds `ModelCollection.list` to fetch public models from Replicate's API
- Refactors `run` to avoid making an additional fetch for the model
- Updates `predictions.create` to support creating a prediction by version ID string