### PR TITLE
Add Python 3.12 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     defaults:
       run:


### PR DESCRIPTION
[Python 3.12.0](https://www.python.org/downloads/release/python-3120/) was released on October 2, 2023. This PR updates our CI to test against this version.