### PR TITLE
Fix signature of `create` methods

### DIFF
--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -1,6 +1,8 @@
 import abc
 from typing import TYPE_CHECKING, Dict, Generic, List, TypeVar, Union, cast
 
+from typing_extensions import TypedDict, Unpack
+
 if TYPE_CHECKING:
     from replicate.client import Client
 
@@ -8,9 +10,10 @@ from replicate.base_model import BaseModel
 from replicate.exceptions import ReplicateException
 
 Model = TypeVar("Model", bound=BaseModel)
+CreateParams = TypeVar("CreateParams", bound=TypedDict)
 
 
-class Collection(abc.ABC, Generic[Model]):
+class Collection(abc.ABC, Generic[Model, CreateParams]):
     """
     A base class for representing objects of a particular type on the server.
     """
@@ -32,7 +35,11 @@ class Collection(abc.ABC, Generic[Model]):
         pass
 
     @abc.abstractmethod
-    def create(self, **kwargs) -> Model:  # pylint: disable=missing-function-docstring
+    def create(  # pylint: disable=missing-function-docstring
+        self,
+        *args,
+        **kwargs: Unpack[CreateParams],  # type: ignore[misc]
+    ) -> Model:
         pass
 
     def prepare_model(self, attrs: Union[Model, Dict]) -> Model:

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -1,8 +1,6 @@
 import abc
 from typing import TYPE_CHECKING, Dict, Generic, List, TypeVar, Union, cast
 
-from typing_extensions import TypedDict, Unpack
-
 if TYPE_CHECKING:
     from replicate.client import Client
 
@@ -10,10 +8,9 @@ from replicate.base_model import BaseModel
 from replicate.exceptions import ReplicateException
 
 Model = TypeVar("Model", bound=BaseModel)
-CreateParams = TypeVar("CreateParams", bound=TypedDict)
 
 
-class Collection(abc.ABC, Generic[Model, CreateParams]):
+class Collection(abc.ABC, Generic[Model]):
     """
     A base class for representing objects of a particular type on the server.
     """
@@ -36,9 +33,7 @@ class Collection(abc.ABC, Generic[Model, CreateParams]):
 
     @abc.abstractmethod
     def create(  # pylint: disable=missing-function-docstring
-        self,
-        *args,
-        **kwargs: Unpack[CreateParams],  # type: ignore[misc]
+        self, *args, **kwargs
     ) -> Model:
         pass
 

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -145,7 +145,7 @@ class ModelCollection(Collection):
         **kwargs: Unpack[TypedDict],  # type: ignore[misc]
     ) -> Model:
         """
-        Creates a model.
+        Create a model.
 
         Raises:
             NotImplementedError: This method is not implemented.

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional, Union
 
-from typing_extensions import TypedDict, Unpack, deprecated
+from typing_extensions import deprecated
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
@@ -142,7 +142,7 @@ class ModelCollection(Collection):
     def create(
         self,
         *args,
-        **kwargs: Unpack[TypedDict],  # type: ignore[misc]
+        **kwargs,
     ) -> Model:
         """
         Create a model.

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Optional, Union
 
 from typing_extensions import TypedDict, Unpack, deprecated
 

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,6 +1,6 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TypedDict, Union
 
-from typing_extensions import deprecated
+from typing_extensions import TypedDict, Unpack, deprecated
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
@@ -139,9 +139,13 @@ class ModelCollection(Collection):
         resp = self._client._request("GET", f"/v1/models/{key}")
         return self.prepare_model(resp.json())
 
-    def create(self, **kwargs) -> Model:
+    def create(
+        self,
+        *args,
+        **kwargs: Unpack[TypedDict],  # type: ignore[misc]
+    ) -> Model:
         """
-        Create a model.
+        Creates a model.
 
         Raises:
             NotImplementedError: This method is not implemented.

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -3,6 +3,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from typing_extensions import TypedDict, Unpack
+
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
 from replicate.exceptions import ModelError
@@ -137,6 +139,16 @@ class PredictionCollection(Collection):
     Namespace for operations related to predictions.
     """
 
+    class CreateParams(TypedDict):
+        """Parameters for creating a prediction."""
+
+        version: Union[Version, str]
+        input: Dict[str, Any]
+        webhook: Optional[str]
+        webhook_completed: Optional[str]
+        webhook_events_filter: Optional[List[str]]
+        stream: Optional[bool]
+
     model = Prediction
 
     def list(self) -> List[Prediction]:
@@ -171,16 +183,10 @@ class PredictionCollection(Collection):
         del obj["version"]
         return self.prepare_model(obj)
 
-    def create(  # type: ignore
+    def create(
         self,
-        version: Union[Version, str],
-        input: Dict[str, Any],
-        webhook: Optional[str] = None,
-        webhook_completed: Optional[str] = None,
-        webhook_events_filter: Optional[List[str]] = None,
-        *,
-        stream: Optional[bool] = None,
-        **kwargs,
+        *args,
+        **kwargs: Unpack[CreateParams],  # type: ignore[misc]
     ) -> Prediction:
         """
         Create a new prediction for the specified model version.
@@ -197,19 +203,28 @@ class PredictionCollection(Collection):
             Prediction: The created prediction object.
         """
 
-        input = encode_json(input, upload_file=upload_file)
-        body: Dict[str, Any] = {
+        # Support positional arguments for backwards compatibility
+        version = args[0] if args else kwargs.get("version")
+        if version is None:
+            raise ValueError(
+                "A version identifier must be provided as a positional or keyword argument."
+            )
+
+        input = args[1] if len(args) > 1 else kwargs.get("input")
+        if input is None:
+            raise ValueError(
+                "An input must be provided as a positional or keyword argument."
+            )
+
+        body = {
             "version": version if isinstance(version, str) else version.id,
-            "input": input,
+            "input": encode_json(input, upload_file=upload_file),
         }
-        if webhook is not None:
-            body["webhook"] = webhook
-        if webhook_completed is not None:
-            body["webhook_completed"] = webhook_completed
-        if webhook_events_filter is not None:
-            body["webhook_events_filter"] = webhook_events_filter
-        if stream is True:
-            body["stream"] = True
+
+        for key in ["webhook", "webhook_completed", "webhook_events_filter", "stream"]:
+            value = kwargs.get(key)
+            if value is not None:
+                body[key] = value
 
         resp = self._client._request(
             "POST",

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -1,9 +1,9 @@
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, TypedDict, Union, overload
 
-from typing_extensions import TypedDict, Unpack
+from typing_extensions import Unpack
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
@@ -182,6 +182,32 @@ class PredictionCollection(Collection):
         # HACK: resolve this? make it lazy somehow?
         del obj["version"]
         return self.prepare_model(obj)
+
+    @overload
+    def create(  # pylint: disable=arguments-differ disable=too-many-arguments
+        self,
+        version: Union[Version, str],
+        input: Dict[str, Any],
+        *,
+        webhook: Optional[str] = None,
+        webhook_completed: Optional[str] = None,
+        webhook_events_filter: Optional[List[str]] = None,
+        stream: Optional[bool] = None,
+    ) -> Prediction:
+        ...
+
+    @overload
+    def create(  # pylint: disable=arguments-differ disable=too-many-arguments
+        self,
+        *,
+        version: Union[Version, str],
+        input: Dict[str, Any],
+        webhook: Optional[str] = None,
+        webhook_completed: Optional[str] = None,
+        webhook_events_filter: Optional[List[str]] = None,
+        stream: Optional[bool] = None,
+    ) -> Prediction:
+        ...
 
     def create(
         self,

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -79,7 +79,6 @@ class TrainingCollection(Collection):
         webhook: NotRequired[str]
         webhook_completed: NotRequired[str]
         webhook_events_filter: NotRequired[List[str]]
-        stream: NotRequired[bool]
 
     def list(self) -> List[Training]:
         """

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -1,7 +1,7 @@
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
-from typing_extensions import NotRequired, TypedDict, Unpack
+from typing_extensions import NotRequired, Unpack, overload
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
@@ -114,6 +114,32 @@ class TrainingCollection(Collection):
         # HACK: resolve this? make it lazy somehow?
         del obj["version"]
         return self.prepare_model(obj)
+
+    @overload
+    def create(  # pylint: disable=arguments-differ disable=too-many-arguments
+        self,
+        version: Union[Version, str],
+        input: Dict[str, Any],
+        destination: str,
+        *,
+        webhook: Optional[str] = None,
+        webhook_completed: Optional[str] = None,
+        webhook_events_filter: Optional[List[str]] = None,
+    ) -> Training:
+        ...
+
+    @overload
+    def create(  # pylint: disable=arguments-differ disable=too-many-arguments
+        self,
+        *,
+        version: Union[Version, str],
+        input: Dict[str, Any],
+        destination: str,
+        webhook: Optional[str] = None,
+        webhook_completed: Optional[str] = None,
+        webhook_events_filter: Optional[List[str]] = None,
+    ) -> Training:
+        ...
 
     def create(
         self,

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -1,5 +1,7 @@
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
+
+from typing_extensions import NotRequired, TypedDict, Unpack
 
 from replicate.base_model import BaseModel
 from replicate.collection import Collection
@@ -68,6 +70,17 @@ class TrainingCollection(Collection):
 
     model = Training
 
+    class CreateParams(TypedDict):
+        """Parameters for creating a prediction."""
+
+        version: Union[Version, str]
+        destination: str
+        input: Dict[str, Any]
+        webhook: NotRequired[str]
+        webhook_completed: NotRequired[str]
+        webhook_events_filter: NotRequired[List[str]]
+        stream: NotRequired[bool]
+
     def list(self) -> List[Training]:
         """
         List your trainings.
@@ -103,14 +116,10 @@ class TrainingCollection(Collection):
         del obj["version"]
         return self.prepare_model(obj)
 
-    def create(  # type: ignore
+    def create(
         self,
-        version: str,
-        input: Dict[str, Any],
-        destination: str,
-        webhook: Optional[str] = None,
-        webhook_events_filter: Optional[List[str]] = None,
-        **kwargs,
+        *args,
+        **kwargs: Unpack[CreateParams],  # type: ignore[misc]
     ) -> Training:
         """
         Create a new training using the specified model version as a base.
@@ -120,24 +129,45 @@ class TrainingCollection(Collection):
             input: The input to the training.
             destination: The desired model to push to in the format `{owner}/{model_name}`. This should be an existing model owned by the user or organization making the API request.
             webhook: The URL to send a POST request to when the training is completed. Defaults to None.
+            webhook_completed: The URL to receive a POST request when the prediction is completed.
             webhook_events_filter: The events to send to the webhook. Defaults to None.
         Returns:
             The training object.
         """
 
-        input = encode_json(input, upload_file=upload_file)
+        # Support positional arguments for backwards compatibility
+        version = args[0] if args else kwargs.get("version")
+        if version is None:
+            raise ValueError(
+                "A version identifier must be provided as a positional or keyword argument."
+            )
+
+        destination = args[1] if len(args) > 1 else kwargs.get("destination")
+        if destination is None:
+            raise ValueError(
+                "A destination must be provided as a positional or keyword argument."
+            )
+
+        input = args[2] if len(args) > 2 else kwargs.get("input")
+        if input is None:
+            raise ValueError(
+                "An input must be provided as a positional or keyword argument."
+            )
+
         body = {
-            "input": input,
+            "input": encode_json(input, upload_file=upload_file),
             "destination": destination,
         }
-        if webhook is not None:
-            body["webhook"] = webhook
-        if webhook_events_filter is not None:
-            body["webhook_events_filter"] = webhook_events_filter
+
+        for key in ["webhook", "webhook_completed", "webhook_events_filter"]:
+            value = kwargs.get(key)
+            if value is not None:
+                body[key] = value
 
         # Split version in format "username/model_name:version_id"
         match = re.match(
-            r"^(?P<username>[^/]+)/(?P<model_name>[^:]+):(?P<version_id>.+)$", version
+            r"^(?P<username>[^/]+)/(?P<model_name>[^:]+):(?P<version_id>.+)$",
+            version.id if isinstance(version, Version) else version,
         )
         if not match:
             raise ReplicateException(

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -2,6 +2,8 @@ import datetime
 import warnings
 from typing import TYPE_CHECKING, Any, Iterator, List, Union
 
+from typing_extensions import TypedDict, Unpack
+
 if TYPE_CHECKING:
     from replicate.client import Client
     from replicate.model import Model
@@ -94,7 +96,11 @@ class VersionCollection(Collection):
         )
         return self.prepare_model(resp.json())
 
-    def create(self, **kwargs) -> Version:
+    def create(
+        self,
+        *args,
+        **kwargs: Unpack[TypedDict],  # type: ignore[misc]
+    ) -> Version:
         """
         Create a model version.
 

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -2,8 +2,6 @@ import datetime
 import warnings
 from typing import TYPE_CHECKING, Any, Iterator, List, Union
 
-from typing_extensions import TypedDict, Unpack
-
 if TYPE_CHECKING:
     from replicate.client import Client
     from replicate.model import Model
@@ -99,7 +97,7 @@ class VersionCollection(Collection):
     def create(
         self,
         *args,
-        **kwargs: Unpack[TypedDict],  # type: ignore[misc]
+        **kwargs,
     ) -> Version:
         """
         Create a model version.

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -10,12 +10,28 @@ input_images_url = "https://replicate.delivery/pbxt/JMV5OrEWpBAC5gO8rre0tPOyJIOk
 @pytest.mark.asyncio
 async def test_trainings_create(mock_replicate_api_token):
     training = replicate.trainings.create(
-        "stability-ai/sdxl:a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5",
+        version="stability-ai/sdxl:a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5",
         input={
             "input_images": input_images_url,
             "use_face_detection_instead": True,
         },
         destination="replicate/dreambooth-sdxl",
+    )
+
+    assert training.id is not None
+    assert training.status == "starting"
+
+
+@pytest.mark.vcr("trainings-create.yaml")
+@pytest.mark.asyncio
+async def test_trainings_create_with_positional_argument(mock_replicate_api_token):
+    training = replicate.trainings.create(
+        "stability-ai/sdxl:a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5",
+        {
+            "input_images": input_images_url,
+            "use_face_detection_instead": True,
+        },
+        "replicate/dreambooth-sdxl",
     )
 
     assert training.id is not None
@@ -57,7 +73,7 @@ async def test_trainings_cancel(mock_replicate_api_token):
     destination = "replicate/dreambooth-sdxl"
 
     training = replicate.trainings.create(
-        "stability-ai/sdxl:a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5",
+        version="stability-ai/sdxl:a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5",
         destination=destination,
         input=input,
     )


### PR DESCRIPTION
Provides backwards-compatible migration to typed kwargs following [PEP 692](https://peps.python.org/pep-0692/).