### PR TITLE
Refactor `Collection` superclass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ disable = [
     "R0801", # Similar lines in N files
     "W0212", # Access to a protected member
     "W0622", # Redefining built-in
+    "R0903", # Too few public methods
 ]
 
 [tool.ruff]

--- a/replicate/__init__.py
+++ b/replicate/__init__.py
@@ -1,4 +1,4 @@
-from .client import Client
+from replicate.client import Client
 
 default_client = Client()
 run = default_client.run

--- a/replicate/base_model.py
+++ b/replicate/base_model.py
@@ -19,12 +19,3 @@ class BaseModel(pydantic.BaseModel):
 
     _client: "Client" = pydantic.PrivateAttr()
     _collection: "Collection" = pydantic.PrivateAttr()
-
-    def reload(self) -> None:
-        """
-        Load this object from the server again.
-        """
-
-        new_model = self._collection.get(self.id)  # pylint: disable=no-member
-        for k, v in new_model.dict().items():  # pylint: disable=invalid-name
-            setattr(self, k, v)

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -178,9 +178,10 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
     )
     MAX_BACKOFF_WAIT = 60
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         wrapped_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport],
+        *,
         max_attempts: int = 10,
         max_backoff_wait: float = MAX_BACKOFF_WAIT,
         backoff_factor: float = 0.1,

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -19,6 +19,7 @@ from .deployment import DeploymentCollection
 from .exceptions import ModelError, ReplicateError
 from .model import ModelCollection
 from .prediction import PredictionCollection
+from .schema import make_schema_backwards_compatible
 from .training import TrainingCollection
 from .version import Version
 
@@ -143,7 +144,9 @@ class Client:
             version = Version(**resp.json())
 
             # Return an iterator of the output
-            schema = version.get_transformed_schema()
+            schema = make_schema_backwards_compatible(
+                version.openapi_schema, version.cog_version
+            )
             output = schema["components"]["schemas"]["Output"]
             if (
                 output.get("type") == "array"

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -14,14 +14,14 @@ from typing import (
 
 import httpx
 
-from .__about__ import __version__
-from .deployment import DeploymentCollection
-from .exceptions import ModelError, ReplicateError
-from .model import ModelCollection
-from .prediction import PredictionCollection
-from .schema import make_schema_backwards_compatible
-from .training import TrainingCollection
-from .version import Version
+from replicate.__about__ import __version__
+from replicate.deployment import DeploymentCollection
+from replicate.exceptions import ModelError, ReplicateError
+from replicate.model import ModelCollection
+from replicate.prediction import PredictionCollection
+from replicate.schema import make_schema_backwards_compatible
+from replicate.training import TrainingCollection
+from replicate.version import Version
 
 
 class Client:

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Dict, Generic, List, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Dict, Generic, TypeVar, Union, cast
 
 if TYPE_CHECKING:
     from replicate.client import Client
@@ -21,20 +21,6 @@ class Collection(abc.ABC, Generic[Model]):
     @property
     @abc.abstractmethod
     def model(self) -> Model:  # pylint: disable=missing-function-docstring
-        pass
-
-    @abc.abstractmethod
-    def list(self) -> List[Model]:  # pylint: disable=missing-function-docstring
-        pass
-
-    @abc.abstractmethod
-    def get(self, key: str) -> Model:  # pylint: disable=missing-function-docstring
-        pass
-
-    @abc.abstractmethod
-    def create(  # pylint: disable=missing-function-docstring
-        self, *args, **kwargs
-    ) -> Model:
         pass
 
     def prepare_model(self, attrs: Union[Model, Dict]) -> Model:

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -23,7 +23,7 @@ class Collection(abc.ABC, Generic[Model]):
     def model(self) -> Model:  # pylint: disable=missing-function-docstring
         pass
 
-    def prepare_model(self, attrs: Union[Model, Dict]) -> Model:
+    def _prepare_model(self, attrs: Union[Model, Dict]) -> Model:
         """
         Create a model from a set of attributes.
         """

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -15,13 +15,11 @@ class Collection(abc.ABC, Generic[Model]):
     A base class for representing objects of a particular type on the server.
     """
 
+    _client: "Client"
+    model: Model
+
     def __init__(self, client: "Client") -> None:
         self._client = client
-
-    @property
-    @abc.abstractmethod
-    def model(self) -> Model:  # pylint: disable=missing-function-docstring
-        pass
 
     def _prepare_model(self, attrs: Union[Model, Dict]) -> Model:
         """

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -15,6 +15,8 @@ class Deployment(BaseModel):
     A deployment of a model hosted on Replicate.
     """
 
+    _collection: "DeploymentCollection"
+
     username: str
     """
     The name of the user or organization that owns the deployment.

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -41,15 +41,6 @@ class DeploymentCollection(Collection):
 
     model = Deployment
 
-    def list(self) -> List[Deployment]:
-        """
-        List deployments.
-
-        Raises:
-            NotImplementedError: This method is not implemented.
-        """
-        raise NotImplementedError()
-
     def get(self, name: str) -> Deployment:
         """
         Get a deployment by name.
@@ -65,19 +56,6 @@ class DeploymentCollection(Collection):
         username, name = name.split("/")
         return self.prepare_model({"username": username, "name": name})
 
-    def create(
-        self,
-        *args,
-        **kwargs,
-    ) -> Deployment:
-        """
-        Create a deployment.
-
-        Raises:
-            NotImplementedError: This method is not implemented.
-        """
-        raise NotImplementedError()
-
     def prepare_model(self, attrs: Union[Deployment, Dict]) -> Deployment:
         if isinstance(attrs, BaseModel):
             attrs.id = f"{attrs.username}/{attrs.name}"
@@ -92,15 +70,6 @@ class DeploymentPredictionCollection(Collection):
     def __init__(self, client: "Client", deployment: Deployment) -> None:
         super().__init__(client=client)
         self._deployment = deployment
-
-    def list(self) -> List[Prediction]:
-        """
-        List predictions in a deployment.
-
-        Raises:
-            NotImplementedError: This method is not implemented.
-        """
-        raise NotImplementedError()
 
     def get(self, id: str) -> Prediction:
         """

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -54,14 +54,14 @@ class DeploymentCollection(Collection):
         # TODO: fetch model from server
         # TODO: support permanent IDs
         username, name = name.split("/")
-        return self.prepare_model({"username": username, "name": name})
+        return self._prepare_model({"username": username, "name": name})
 
-    def prepare_model(self, attrs: Union[Deployment, Dict]) -> Deployment:
+    def _prepare_model(self, attrs: Union[Deployment, Dict]) -> Deployment:
         if isinstance(attrs, BaseModel):
             attrs.id = f"{attrs.username}/{attrs.name}"
         elif isinstance(attrs, dict):
             attrs["id"] = f"{attrs['username']}/{attrs['name']}"
-        return super().prepare_model(attrs)
+        return super()._prepare_model(attrs)
 
 
 class DeploymentPredictionCollection(Collection):
@@ -85,7 +85,7 @@ class DeploymentPredictionCollection(Collection):
         obj = resp.json()
         # HACK: resolve this? make it lazy somehow?
         del obj["version"]
-        return self.prepare_model(obj)
+        return self._prepare_model(obj)
 
     def create(
         self,
@@ -134,4 +134,4 @@ class DeploymentPredictionCollection(Collection):
         obj = resp.json()
         obj["deployment"] = self._deployment
         del obj["version"]
-        return self.prepare_model(obj)
+        return self._prepare_model(obj)

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -67,13 +67,17 @@ class DeploymentCollection(Collection):
 
 
 class DeploymentPredictionCollection(Collection):
+    """
+    Namespace for operations related to predictions in a deployment.
+    """
+
     model = Prediction
 
     def __init__(self, client: "Client", deployment: Deployment) -> None:
         super().__init__(client=client)
         self._deployment = deployment
 
-    def get(self, id: str) -> Prediction:
+    def get(self, id: str) -> Prediction:  # pylint: disable=invalid-name
         """
         Get a prediction by ID.
 

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -77,22 +77,6 @@ class DeploymentPredictionCollection(Collection):
         super().__init__(client=client)
         self._deployment = deployment
 
-    def get(self, id: str) -> Prediction:  # pylint: disable=invalid-name
-        """
-        Get a prediction by ID.
-
-        Args:
-            id: The ID of the prediction.
-        Returns:
-            Prediction: The prediction object.
-        """
-
-        resp = self._client._request("GET", f"/v1/predictions/{id}")
-        obj = resp.json()
-        # HACK: resolve this? make it lazy somehow?
-        del obj["version"]
-        return self._prepare_model(obj)
-
     def create(
         self,
         input: Dict[str, Any],

--- a/replicate/exceptions.py
+++ b/replicate/exceptions.py
@@ -1,5 +1,5 @@
 class ReplicateException(Exception):
-    pass
+    """A base class for all Replicate exceptions."""
 
 
 class ModelError(ReplicateException):

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -139,19 +139,6 @@ class ModelCollection(Collection):
         resp = self._client._request("GET", f"/v1/models/{key}")
         return self.prepare_model(resp.json())
 
-    def create(
-        self,
-        *args,
-        **kwargs,
-    ) -> Model:
-        """
-        Create a model.
-
-        Raises:
-            NotImplementedError: This method is not implemented.
-        """
-        raise NotImplementedError()
-
     def prepare_model(self, attrs: Union[Model, Dict]) -> Model:
         if isinstance(attrs, BaseModel):
             attrs.id = f"{attrs.owner}/{attrs.name}"

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -124,7 +124,7 @@ class ModelCollection(Collection):
         resp = self._client._request("GET", "/v1/models")
         # TODO: paginate
         models = resp.json()["results"]
-        return [self.prepare_model(obj) for obj in models]
+        return [self._prepare_model(obj) for obj in models]
 
     def get(self, key: str) -> Model:
         """
@@ -137,9 +137,9 @@ class ModelCollection(Collection):
         """
 
         resp = self._client._request("GET", f"/v1/models/{key}")
-        return self.prepare_model(resp.json())
+        return self._prepare_model(resp.json())
 
-    def prepare_model(self, attrs: Union[Model, Dict]) -> Model:
+    def _prepare_model(self, attrs: Union[Model, Dict]) -> Model:
         if isinstance(attrs, BaseModel):
             attrs.id = f"{attrs.owner}/{attrs.name}"
         elif isinstance(attrs, dict):
@@ -152,7 +152,7 @@ class ModelCollection(Collection):
                 if "latest_version" in attrs and attrs["latest_version"] == {}:
                     attrs.pop("latest_version")
 
-        model = super().prepare_model(attrs)
+        model = super()._prepare_model(attrs)
 
         if model.default_example is not None:
             model.default_example._client = self._client

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -14,6 +14,8 @@ class Model(BaseModel):
     A machine learning model hosted on Replicate.
     """
 
+    _collection: "ModelCollection"
+
     url: str
     """
     The URL of the model.

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -105,6 +105,15 @@ class Model(BaseModel):
 
         return VersionCollection(client=self._client, model=self)
 
+    def reload(self) -> None:
+        """
+        Load this object from the server.
+        """
+
+        obj = self._collection.get(f"{self.owner}/{self.name}")  # pylint: disable=no-member
+        for name, value in obj.dict().items():
+            setattr(self, name, value)
+
 
 class ModelCollection(Collection):
     """

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -131,6 +131,15 @@ class Prediction(BaseModel):
         """
         self._client._request("POST", f"/v1/predictions/{self.id}/cancel")  # pylint: disable=no-member
 
+    def reload(self) -> None:
+        """
+        Load this prediction from the server.
+        """
+
+        obj = self._collection.get(self.id)  # pylint: disable=no-member
+        for name, value in obj.dict().items():
+            setattr(self, name, value)
+
 
 class PredictionCollection(Collection):
     """

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -153,7 +153,7 @@ class PredictionCollection(Collection):
         for prediction in predictions:
             # HACK: resolve this? make it lazy somehow?
             del prediction["version"]
-        return [self.prepare_model(obj) for obj in predictions]
+        return [self._prepare_model(obj) for obj in predictions]
 
     def get(self, id: str) -> Prediction:
         """
@@ -169,7 +169,7 @@ class PredictionCollection(Collection):
         obj = resp.json()
         # HACK: resolve this? make it lazy somehow?
         del obj["version"]
-        return self.prepare_model(obj)
+        return self._prepare_model(obj)
 
     def create(
         self,
@@ -224,4 +224,4 @@ class PredictionCollection(Collection):
         else:
             del obj["version"]
 
-        return self.prepare_model(obj)
+        return self._prepare_model(obj)

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -16,6 +16,8 @@ class Prediction(BaseModel):
     A prediction made by a model hosted on Replicate.
     """
 
+    _collection: "PredictionCollection"
+
     id: str
     """The unique ID of the prediction."""
 

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -62,6 +62,10 @@ class Prediction(BaseModel):
 
     @dataclass
     class Progress:
+        """
+        The progress of a prediction.
+        """
+
         percentage: float
         """The percentage of the prediction that has completed."""
 
@@ -109,6 +113,10 @@ class Prediction(BaseModel):
             self.reload()
 
     def output_iterator(self) -> Iterator[Any]:
+        """
+        Return an iterator of the prediction output.
+        """
+
         # TODO: check output is list
         previous_output = self.output or []
         while self.status not in ["succeeded", "failed", "canceled"]:
@@ -166,7 +174,7 @@ class PredictionCollection(Collection):
             del prediction["version"]
         return [self._prepare_model(obj) for obj in predictions]
 
-    def get(self, id: str) -> Prediction:
+    def get(self, id: str) -> Prediction:  # pylint: disable=invalid-name
         """
         Get a prediction by ID.
 

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -62,6 +62,15 @@ class Training(BaseModel):
         """Cancel a running training"""
         self._client._request("POST", f"/v1/trainings/{self.id}/cancel")  # pylint: disable=no-member
 
+    def reload(self) -> None:
+        """
+        Load the training from the server.
+        """
+
+        obj = self._collection.get(self.id)  # pylint: disable=no-member
+        for name, value in obj.dict().items():
+            setattr(self, name, value)
+
 
 class TrainingCollection(Collection):
     """

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -16,6 +16,8 @@ class Training(BaseModel):
     A training made for a model hosted on Replicate.
     """
 
+    _collection: "TrainingCollection"
+
     id: str
     """The unique ID of the training."""
 

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -107,7 +107,7 @@ class TrainingCollection(Collection):
             del training["version"]
         return [self._prepare_model(obj) for obj in trainings]
 
-    def get(self, id: str) -> Training:
+    def get(self, id: str) -> Training:  # pylint: disable=invalid-name
         """
         Get a training by ID.
 

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -94,7 +94,7 @@ class TrainingCollection(Collection):
         for training in trainings:
             # HACK: resolve this? make it lazy somehow?
             del training["version"]
-        return [self.prepare_model(obj) for obj in trainings]
+        return [self._prepare_model(obj) for obj in trainings]
 
     def get(self, id: str) -> Training:
         """
@@ -113,7 +113,7 @@ class TrainingCollection(Collection):
         obj = resp.json()
         # HACK: resolve this? make it lazy somehow?
         del obj["version"]
-        return self.prepare_model(obj)
+        return self._prepare_model(obj)
 
     @overload
     def create(  # pylint: disable=arguments-differ disable=too-many-arguments
@@ -209,4 +209,4 @@ class TrainingCollection(Collection):
         )
         obj = resp.json()
         del obj["version"]
-        return self.prepare_model(obj)
+        return self._prepare_model(obj)

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -68,6 +68,15 @@ class Version(BaseModel):
         schema = make_schema_backwards_compatible(schema, self.cog_version)
         return schema
 
+    def reload(self) -> None:
+        """
+        Load this object from the server.
+        """
+
+        obj = self._collection.get(self.id)  # pylint: disable=no-member
+        for name, value in obj.dict().items():
+            setattr(self, name, value)
+
 
 class VersionCollection(Collection):
     """

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -50,7 +50,7 @@ class Version(BaseModel):
 
         prediction = self._client.predictions.create(version=self, input=kwargs)  # pylint: disable=no-member
         # Return an iterator of the output
-        schema = self.get_transformed_schema()
+        schema = make_schema_backwards_compatible(self.openapi_schema, self.cog_version)
         output = schema["components"]["schemas"]["Output"]
         if (
             output.get("type") == "array"
@@ -62,11 +62,6 @@ class Version(BaseModel):
         if prediction.status == "failed":
             raise ModelError(prediction.error)
         return prediction.output
-
-    def get_transformed_schema(self) -> dict:
-        schema = self.openapi_schema
-        schema = make_schema_backwards_compatible(schema, self.cog_version)
-        return schema
 
     def reload(self) -> None:
         """

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -18,6 +18,8 @@ class Version(BaseModel):
     A version of a model.
     """
 
+    _collection: "VersionCollection"
+
     id: str
     """The unique ID of the version."""
 

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -94,19 +94,6 @@ class VersionCollection(Collection):
         )
         return self.prepare_model(resp.json())
 
-    def create(
-        self,
-        *args,
-        **kwargs,
-    ) -> Version:
-        """
-        Create a model version.
-
-        Raises:
-            NotImplementedError: This method is not implemented.
-        """
-        raise NotImplementedError()
-
     def list(self) -> List[Version]:
         """
         Return a list of all versions for a model.

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -92,7 +92,7 @@ class VersionCollection(Collection):
         resp = self._client._request(
             "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions/{id}"
         )
-        return self.prepare_model(resp.json())
+        return self._prepare_model(resp.json())
 
     def list(self) -> List[Version]:
         """
@@ -104,4 +104,4 @@ class VersionCollection(Collection):
         resp = self._client._request(
             "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions"
         )
-        return [self.prepare_model(obj) for obj in resp.json()["results"]]
+        return [self._prepare_model(obj) for obj in resp.json()["results"]]

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -86,7 +86,7 @@ class VersionCollection(Collection):
         super().__init__(client=client)
         self._model = model
 
-    def get(self, id: str) -> Version:
+    def get(self, id: str) -> Version:  # pylint: disable=invalid-name
         """
         Get a specific model version.
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -10,6 +10,8 @@ from replicate.exceptions import ReplicateError
 @pytest.mark.vcr("run.yaml")
 @pytest.mark.asyncio
 async def test_run(mock_replicate_api_token):
+    replicate.default_client.poll_interval = 0.001
+
     version = "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
 
     input = {


### PR DESCRIPTION
This PR removes abstract methods from base collection, leaving each collection to define its own `get` / `create` / `list` methods on its own terms. 

The primary benefit to having abstract methods defined was to reuse shared logic for `reload`, but that method is short and required additional maneuvering to define an `id` field. The downside of this tight coupling was that resources were required to implement methods that would raise `NotImplemented`. And their signatures for `create` methods were inflexible, requiring either a mismatch with the parent class or an elaborate workaround with overloads and unpacked typed dict kwargs.