### PR TITLE
Remove `id` field from `Resource`

### DIFF
--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -25,6 +25,13 @@ class Collection(Resource):
     models: Optional[List[Model]] = None
     """The models in the collection."""
 
+    @property
+    def id(self) -> str:
+        """
+        DEPRECATED: Use `slug` instead.
+        """
+        return self.slug
+
     def __iter__(self):  # noqa: ANN204
         return iter(self.models)
 
@@ -90,13 +97,9 @@ class Collections(Namespace):
 
     def _prepare_model(self, attrs: Union[Collection, Dict]) -> Collection:
         if isinstance(attrs, Resource):
-            attrs.id = attrs.slug
-
             if attrs.models is not None:
                 attrs.models = [self._models._prepare_model(m) for m in attrs.models]
         elif isinstance(attrs, dict):
-            attrs["id"] = attrs["slug"]
-
             if "models" in attrs:
                 attrs["models"] = [
                     self._models._prepare_model(m) for m in attrs["models"]

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+from typing_extensions import deprecated
+
 from replicate.model import Model, Models
 from replicate.pagination import Page
 from replicate.resource import Namespace, Resource
@@ -26,6 +28,7 @@ class Collection(Resource):
     """The models in the collection."""
 
     @property
+    @deprecated("Use `slug` instead of `id`")
     def id(self) -> str:
         """
         DEPRECATED: Use `slug` instead.

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from replicate.files import upload_file
 from replicate.json import encode_json
@@ -25,6 +25,10 @@ class Deployment(Resource):
     """
     The name of the deployment.
     """
+
+    @property
+    def id(self) -> str:
+        return f"{self.username}/{self.name}"
 
     @property
     def predictions(self) -> "DeploymentPredictions":
@@ -56,13 +60,6 @@ class Deployments(Namespace):
         # TODO: support permanent IDs
         username, name = name.split("/")
         return self._prepare_model({"username": username, "name": name})
-
-    def _prepare_model(self, attrs: Union[Deployment, Dict]) -> Deployment:
-        if isinstance(attrs, Resource):
-            attrs.id = f"{attrs.username}/{attrs.name}"
-        elif isinstance(attrs, dict):
-            attrs["id"] = f"{attrs['username']}/{attrs['name']}"
-        return super()._prepare_model(attrs)
 
 
 class DeploymentPredictions(Namespace):

--- a/replicate/hardware.py
+++ b/replicate/hardware.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from typing_extensions import deprecated
+
 from replicate.resource import Namespace, Resource
 
 
@@ -19,6 +21,7 @@ class Hardware(Resource):
     """
 
     @property
+    @deprecated("Use `sku` instead of `id`")
     def id(self) -> str:
         """
         DEPRECATED: Use `sku` instead.

--- a/replicate/hardware.py
+++ b/replicate/hardware.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import List
 
 from replicate.resource import Namespace, Resource
 
@@ -18,6 +18,13 @@ class Hardware(Resource):
     The name of the hardware.
     """
 
+    @property
+    def id(self) -> str:
+        """
+        DEPRECATED: Use `sku` instead.
+        """
+        return self.sku
+
 
 class Hardwares(Namespace):
     """
@@ -36,11 +43,3 @@ class Hardwares(Namespace):
 
         resp = self._client._request("GET", "/v1/hardware")
         return [self._prepare_model(obj) for obj in resp.json()]
-
-    def _prepare_model(self, attrs: Union[Hardware, Dict]) -> Hardware:
-        if isinstance(attrs, Resource):
-            attrs.id = attrs.sku
-        elif isinstance(attrs, dict):
-            attrs["id"] = attrs["sku"]
-
-        return super()._prepare_model(attrs)

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -77,6 +77,10 @@ class Model(Resource):
     """
 
     @property
+    def id(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+    @property
     @deprecated("Use `model.owner` instead.")
     def username(self) -> str:
         """
@@ -213,11 +217,7 @@ class Models(Namespace):
         return self._prepare_model(resp.json())
 
     def _prepare_model(self, attrs: Union[Model, Dict]) -> Model:
-        if isinstance(attrs, Resource):
-            attrs.id = f"{attrs.owner}/{attrs.name}"
-        elif isinstance(attrs, dict):
-            attrs["id"] = f"{attrs['owner']}/{attrs['name']}"
-
+        if isinstance(attrs, dict):
             if attrs is not None:
                 if "default_example" in attrs and attrs["default_example"]:
                     attrs["default_example"].pop("version")

--- a/replicate/resource.py
+++ b/replicate/resource.py
@@ -17,8 +17,6 @@ class Resource(pydantic.BaseModel):
     A base class for representing a single object on the server.
     """
 
-    id: str
-
     _client: "Client" = pydantic.PrivateAttr()
     _namespace: "Namespace" = pydantic.PrivateAttr()
 


### PR DESCRIPTION
Related to #188 

API resources define a common `id` field, which requires additional bookkeeping in `_prepare_model`. However, these fields aren't used, and either shadow a field on the resource or can be computed. This PR removes `id` from the base model, adds properties for subclasses that don't have an `id` field (like `Hardware` and `Collection`), and marks them as deprecated, for anyone who is relying on that behavior.