### PR TITLE
Add async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ Some models, like [methexis-inc/img2prompt](https://replicate.com/methexis-inc/i
 "an astronaut riding a horse"
 ```
 
+> [!NOTE]
+> You can also call Replicate client methods asynchronously by prepending `async_` to the method name. 
+> 
+> Here's an example of how to run several predictions concurrently and wait for them all to complete:
+>
+> ```python
+> import asyncio
+> import replicate
+> 
+> # https://replicate.com/stability-ai/sdxl
+> model_version = "stability-ai/sdxl:39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"
+> prompts = [
+>     f"A chariot pulled by a team of {count} rainbow unicorns"
+>     for count in ["two", "four", "six", "eight"]
+> ]
+>
+> async with asyncio.TaskGroup() as tg:
+>     tasks = [
+>         tg.create_task(replicate.async_run(model_version, input={"prompt": prompt}))
+>         for prompt in prompts
+>     ]
+>
+> results = await asyncio.gather(*tasks)
+> print(results)
+> ```
+
 ## Run a model in the background
 
 You can start a model and run it in the background:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Some models, like [methexis-inc/img2prompt](https://replicate.com/methexis-inc/i
 ```
 
 > [!NOTE]
-> You can also call Replicate client methods asynchronously by prepending `async_` to the method name. 
+> You can also use the Replicate client asynchronously by prepending `async_` to the method name. 
 > 
 > Here's an example of how to run several predictions concurrently and wait for them all to complete:
 >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ packages = ["replicate"]
 [tool.mypy]
 plugins = "pydantic.mypy"
 exclude = ["tests/"]
+enable_incomplete_feature = ["Unpack"]
 
 [tool.pylint.main]
 disable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ disable = [
     "W0622", # Redefining built-in
     "R0903", # Too few public methods
 ]
+good-names = ["id"]
 
 [tool.ruff]
 select = [

--- a/replicate/__init__.py
+++ b/replicate/__init__.py
@@ -3,6 +3,7 @@ from replicate.client import Client
 default_client = Client()
 
 run = default_client.run
+async_run = default_client.async_run
 
 collections = default_client.collections
 hardware = default_client.hardware

--- a/replicate/__init__.py
+++ b/replicate/__init__.py
@@ -1,7 +1,9 @@
 from replicate.client import Client
 
 default_client = Client()
+
 run = default_client.run
+
 collections = default_client.collections
 hardware = default_client.hardware
 deployments = default_client.deployments

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -98,14 +98,8 @@ class Collections(Namespace):
 
         return self._prepare_model(resp.json())
 
-    def _prepare_model(self, attrs: Union[Collection, Dict]) -> Collection:
-        if isinstance(attrs, Resource):
-            if attrs.models is not None:
-                attrs.models = [self._models._prepare_model(m) for m in attrs.models]
-        elif isinstance(attrs, dict):
-            if "models" in attrs:
-                attrs["models"] = [
-                    self._models._prepare_model(m) for m in attrs["models"]
-                ]
+    def _prepare_model(self, attrs: Dict) -> Collection:
+        if "models" in attrs:
+            attrs["models"] = [self._models._prepare_model(m) for m in attrs["models"]]
 
         return super()._prepare_model(attrs)

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from typing_extensions import deprecated
 
@@ -97,9 +97,3 @@ class Collections(Namespace):
         resp = self._client._request("GET", f"/v1/collections/{slug}")
 
         return self._prepare_model(resp.json())
-
-    def _prepare_model(self, attrs: Dict) -> Collection:
-        if "models" in attrs:
-            attrs["models"] = [self._models._prepare_model(m) for m in attrs["models"]]
-
-        return super()._prepare_model(attrs)

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -74,7 +74,10 @@ class Collections(Namespace):
             "GET", "/v1/collections" if cursor is ... else cursor
         )
 
-        return Page[Collection](self._client, self, **resp.json())
+        obj = resp.json()
+        obj["results"] = [Collection(**result) for result in obj["results"]]
+
+        return Page[Collection](**obj)
 
     def get(self, slug: str) -> Collection:
         """Get a model by name.
@@ -87,4 +90,4 @@ class Collections(Namespace):
 
         resp = self._client._request("GET", f"/v1/collections/{slug}")
 
-        return self._prepare_model(resp.json())
+        return Collection(**resp.json())

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from typing_extensions import deprecated
 
@@ -73,7 +73,7 @@ class Collections(Namespace):
         )
 
         obj = resp.json()
-        obj["results"] = [Collection(**result) for result in obj["results"]]
+        obj["results"] = [self._json_to_collection(result) for result in obj["results"]]
 
         return Page[Collection](**obj)
 
@@ -88,4 +88,7 @@ class Collections(Namespace):
 
         resp = self._client._request("GET", f"/v1/collections/{slug}")
 
-        return Collection(**resp.json())
+        return self._json_to_collection(resp.json())
+
+    def _json_to_collection(self, json: Dict[str, Any]) -> Collection:
+        return Collection(**json)

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -1,13 +1,10 @@
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import List, Optional, Union
 
 from typing_extensions import deprecated
 
-from replicate.model import Model, Models
+from replicate.model import Model
 from replicate.pagination import Page
 from replicate.resource import Namespace, Resource
-
-if TYPE_CHECKING:
-    from replicate.client import Client
 
 
 class Collection(Resource):
@@ -57,12 +54,6 @@ class Collections(Namespace):
     """
 
     model = Collection
-
-    _models: Models
-
-    def __init__(self, client: "Client") -> None:
-        self._models = Models(client)
-        super().__init__(client)
 
     def list(self, cursor: Union[str, "ellipsis"] = ...) -> Page[Collection]:  # noqa: F821
         """

--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -53,8 +53,6 @@ class Collections(Namespace):
     A namespace for operations related to collections of models.
     """
 
-    model = Collection
-
     def list(self, cursor: Union[str, "ellipsis"] = ...) -> Page[Collection]:  # noqa: F821
         """
         List collections of models.

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -119,5 +119,4 @@ class DeploymentPredictions(Namespace):
         )
         obj = resp.json()
         obj["deployment"] = self._deployment
-        del obj["version"]
         return self._prepare_model(obj)

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -122,7 +122,9 @@ class DeploymentPredictions(Namespace):
             json=body,
         )
 
-        prediction = Prediction(**resp.json())
-        prediction._client = self._client
+        return self._json_to_prediction(resp.json())
 
+    def _json_to_prediction(self, json: Dict[str, Any]) -> Prediction:
+        prediction = Prediction(**json)
+        prediction._client = self._client
         return prediction

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -50,8 +50,6 @@ class Deployments(Namespace):
     Namespace for operations related to deployments.
     """
 
-    model = Deployment
-
     def get(self, name: str) -> Deployment:
         """
         Get a deployment by name.
@@ -74,8 +72,6 @@ class DeploymentPredictions(Namespace):
     """
     Namespace for operations related to predictions in a deployment.
     """
-
-    model = Prediction
 
     def __init__(self, client: "Client", deployment: Deployment) -> None:
         super().__init__(client=client)

--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict
 
-from typing_extensions import deprecated
+from typing_extensions import Unpack, deprecated
 
 from replicate.prediction import (
     Prediction,
@@ -17,6 +17,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from replicate.client import Client
+    from replicate.prediction import Predictions
 
 
 class Deployment(Resource):
@@ -78,7 +79,7 @@ class Deployments(Namespace):
             The model.
         """
 
-        owner, name = name.split("/")
+        owner, name = name.split("/", 1)
 
         deployment = Deployment(owner=owner, name=name)
         deployment._client = self._client
@@ -95,7 +96,7 @@ class Deployments(Namespace):
             The model.
         """
 
-        owner, name = name.split("/")
+        owner, name = name.split("/", 1)
 
         deployment = Deployment(owner=owner, name=name)
         deployment._client = self._client
@@ -117,34 +118,13 @@ class DeploymentPredictions(Namespace):
     def create(
         self,
         input: Dict[str, Any],
-        *,
-        webhook: Optional[str] = None,
-        webhook_completed: Optional[str] = None,
-        webhook_events_filter: Optional[List[str]] = None,
-        stream: Optional[bool] = None,
+        **params: Unpack["Predictions.CreatePredictionParams"],
     ) -> Prediction:
         """
         Create a new prediction with the deployment.
-
-        Args:
-            input: The input data for the prediction.
-            webhook: The URL to receive a POST request with prediction updates.
-            webhook_completed: The URL to receive a POST request when the prediction is completed.
-            webhook_events_filter: List of events to trigger webhooks.
-            stream: Set to True to enable streaming of prediction output.
-
-        Returns:
-            Prediction: The created prediction object.
         """
 
-        body = _create_prediction_body(
-            version=None,
-            input=input,
-            webhook=webhook,
-            webhook_completed=webhook_completed,
-            webhook_events_filter=webhook_events_filter,
-            stream=stream,
-        )
+        body = _create_prediction_body(version=None, input=input, **params)
 
         resp = self._client._request(
             "POST",
@@ -157,34 +137,13 @@ class DeploymentPredictions(Namespace):
     async def async_create(
         self,
         input: Dict[str, Any],
-        *,
-        webhook: Optional[str] = None,
-        webhook_completed: Optional[str] = None,
-        webhook_events_filter: Optional[List[str]] = None,
-        stream: Optional[bool] = None,
+        **params: Unpack["Predictions.CreatePredictionParams"],
     ) -> Prediction:
         """
         Create a new prediction with the deployment.
-
-        Args:
-            input: The input data for the prediction.
-            webhook: The URL to receive a POST request with prediction updates.
-            webhook_completed: The URL to receive a POST request when the prediction is completed.
-            webhook_events_filter: List of events to trigger webhooks.
-            stream: Set to True to enable streaming of prediction output.
-
-        Returns:
-            Prediction: The created prediction object.
         """
 
-        body = _create_prediction_body(
-            version=None,
-            input=input,
-            webhook=webhook,
-            webhook_completed=webhook_completed,
-            webhook_events_filter=webhook_events_filter,
-            stream=stream,
-        )
+        body = _create_prediction_body(version=None, input=input, **params)
 
         resp = await self._client._async_request(
             "POST",

--- a/replicate/hardware.py
+++ b/replicate/hardware.py
@@ -34,8 +34,6 @@ class Hardwares(Namespace):
     Namespace for operations related to hardware.
     """
 
-    model = Hardware
-
     def list(self) -> List[Hardware]:
         """
         List all hardware available for you to run models on Replicate.

--- a/replicate/hardware.py
+++ b/replicate/hardware.py
@@ -45,4 +45,6 @@ class Hardwares(Namespace):
         """
 
         resp = self._client._request("GET", "/v1/hardware")
-        return [self._prepare_model(obj) for obj in resp.json()]
+        obj = resp.json()
+
+        return [Hardware(**entry) for entry in obj]

--- a/replicate/hardware.py
+++ b/replicate/hardware.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, Dict, List
 
 from typing_extensions import deprecated
 
@@ -45,4 +45,7 @@ class Hardwares(Namespace):
         resp = self._client._request("GET", "/v1/hardware")
         obj = resp.json()
 
-        return [Hardware(**entry) for entry in obj]
+        return [self._json_to_hardware(entry) for entry in obj]
+
+    def _json_to_hardware(self, json: Dict[str, Any]) -> Hardware:
+        return Hardware(**json)

--- a/replicate/hardware.py
+++ b/replicate/hardware.py
@@ -1,8 +1,11 @@
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from typing_extensions import deprecated
 
 from replicate.resource import Namespace, Resource
+
+if TYPE_CHECKING:
+    pass
 
 
 class Hardware(Resource):
@@ -29,7 +32,7 @@ class Hardware(Resource):
         return self.sku
 
 
-class Hardwares(Namespace):
+class HardwareNamespace(Namespace):
     """
     Namespace for operations related to hardware.
     """
@@ -45,7 +48,21 @@ class Hardwares(Namespace):
         resp = self._client._request("GET", "/v1/hardware")
         obj = resp.json()
 
-        return [self._json_to_hardware(entry) for entry in obj]
+        return [_json_to_hardware(entry) for entry in obj]
 
-    def _json_to_hardware(self, json: Dict[str, Any]) -> Hardware:
-        return Hardware(**json)
+    async def async_list(self) -> List[Hardware]:
+        """
+        List all hardware available for you to run models on Replicate.
+
+        Returns:
+            List[Hardware]: A list of hardware.
+        """
+
+        resp = await self._client._async_request("GET", "/v1/hardware")
+        obj = resp.json()
+
+        return [_json_to_hardware(entry) for entry in obj]
+
+
+def _json_to_hardware(json: Dict[str, Any]) -> Hardware:
+    return Hardware(**json)

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from typing_extensions import deprecated
 
@@ -155,11 +155,7 @@ class Models(Namespace):
         resp = self._client._request("GET", "/v1/models" if cursor is ... else cursor)
 
         obj = resp.json()
-        obj["results"] = [Model(**result) for result in obj["results"]]
-        for model in obj["results"]:
-            model._client = self._client
-            if model.default_example is not None:
-                model.default_example._client = self._client
+        obj["results"] = [self._json_to_model(result) for result in obj["results"]]
 
         return Page[Model](**obj)
 
@@ -175,12 +171,7 @@ class Models(Namespace):
 
         resp = self._client._request("GET", f"/v1/models/{key}")
 
-        model = Model(**resp.json())
-        model._client = self._client
-        if model.default_example is not None:
-            model.default_example._client = self._client
-
-        return model
+        return self._json_to_model(resp.json())
 
     def create(  # pylint: disable=arguments-differ disable=too-many-arguments
         self,
@@ -237,9 +228,11 @@ class Models(Namespace):
 
         resp = self._client._request("POST", "/v1/models", json=body)
 
-        model = Model(**resp.json())
+        return self._json_to_model(resp.json())
+
+    def _json_to_model(self, json: Dict[str, Any]) -> Model:
+        model = Model(**json)
         model._client = self._client
         if model.default_example is not None:
             model.default_example._client = self._client
-
         return model

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -217,14 +217,6 @@ class Models(Namespace):
         return self._prepare_model(resp.json())
 
     def _prepare_model(self, attrs: Union[Model, Dict]) -> Model:
-        if isinstance(attrs, dict):
-            if attrs is not None:
-                if "default_example" in attrs and attrs["default_example"]:
-                    attrs["default_example"].pop("version")
-
-                if "latest_version" in attrs and attrs["latest_version"] == {}:
-                    attrs.pop("latest_version")
-
         model = super()._prepare_model(attrs)
 
         if model.default_example is not None:

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -216,7 +216,7 @@ class Models(Namespace):
 
         return self._prepare_model(resp.json())
 
-    def _prepare_model(self, attrs: Union[Model, Dict]) -> Model:
+    def _prepare_model(self, attrs: Dict) -> Model:
         model = super()._prepare_model(attrs)
 
         if model.default_example is not None:

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union
 
-from typing_extensions import deprecated
+from typing_extensions import NotRequired, TypedDict, Unpack, deprecated
 
 from replicate.exceptions import ReplicateException
 from replicate.pagination import Page
@@ -45,7 +45,7 @@ class Model(Resource):
     The description of the model.
     """
 
-    visibility: str
+    visibility: Literal["public", "private"]
     """
     The visibility of the model. Can be 'public' or 'private'.
     """
@@ -218,94 +218,55 @@ class Models(Namespace):
 
         return _json_to_model(self._client, resp.json())
 
-    def create(  # pylint: disable=arguments-differ disable=too-many-arguments
+    class CreateModelParams(TypedDict):
+        """Parameters for creating a model."""
+
+        hardware: str
+        """The SKU for the hardware used to run the model.
+
+        Possible values can be found by calling `replicate.hardware.list()`."""
+
+        visibility: Literal["public", "private"]
+        """Whether the model should be public or private."""
+
+        description: NotRequired[str]
+        """The description of the model."""
+
+        github_url: NotRequired[str]
+        """A URL for the model's source code on GitHub."""
+
+        paper_url: NotRequired[str]
+        """A URL for the model's paper."""
+
+        license_url: NotRequired[str]
+        """A URL for the model's license."""
+
+        cover_image_url: NotRequired[str]
+        """A URL for the model's cover image."""
+
+    def create(
         self,
         owner: str,
         name: str,
-        *,
-        visibility: str,
-        hardware: str,
-        description: Optional[str] = None,
-        github_url: Optional[str] = None,
-        paper_url: Optional[str] = None,
-        license_url: Optional[str] = None,
-        cover_image_url: Optional[str] = None,
+        **params: Unpack["Models.CreateModelParams"],
     ) -> Model:
         """
         Create a model.
-
-        Args:
-            owner: The name of the user or organization that will own the model.
-            name: The name of the model.
-            visibility: Whether the model should be public or private.
-            hardware: The SKU for the hardware used to run the model. Possible values can be found by calling `replicate.hardware.list()`.
-            description: A description of the model.
-            github_url: A URL for the model's source code on GitHub.
-            paper_url: A URL for the model's paper.
-            license_url: A URL for the model's license.
-            cover_image_url: A URL for the model's cover image.
-
-        Returns:
-            The created model.
         """
 
-        body = _create_model_body(
-            owner,
-            name,
-            visibility,
-            hardware,
-            description,
-            github_url,
-            paper_url,
-            license_url,
-            cover_image_url,
-        )
+        body = _create_model_body(owner, name, **params)
         resp = self._client._request("POST", "/v1/models", json=body)
 
         return _json_to_model(self._client, resp.json())
 
-    async def async_create(  # pylint: disable=too-many-arguments
-        self,
-        owner: str,
-        name: str,
-        *,
-        visibility: str,
-        hardware: str,
-        description: Optional[str] = None,
-        github_url: Optional[str] = None,
-        paper_url: Optional[str] = None,
-        license_url: Optional[str] = None,
-        cover_image_url: Optional[str] = None,
+    async def async_create(
+        self, owner: str, name: str, **params: Unpack["Models.CreateModelParams"]
     ) -> Model:
         """
         Create a model.
-
-        Args:
-            owner: The name of the user or organization that will own the model.
-            name: The name of the model.
-            visibility: Whether the model should be public or private.
-            hardware: The SKU for the hardware used to run the model. Possible values can be found by calling `replicate.hardware.list()`.
-            description: A description of the model.
-            github_url: A URL for the model's source code on GitHub.
-            paper_url: A URL for the model's paper.
-            license_url: A URL for the model's license.
-            cover_image_url: A URL for the model's cover image.
-
-        Returns:
-            The created model.
         """
 
-        body = body = _create_model_body(
-            owner,
-            name,
-            visibility,
-            hardware,
-            description,
-            github_url,
-            paper_url,
-            license_url,
-            cover_image_url,
-        )
+        body = body = _create_model_body(owner, name, **params)
         resp = await self._client._async_request("POST", "/v1/models", json=body)
 
         return _json_to_model(self._client, resp.json())
@@ -314,6 +275,7 @@ class Models(Namespace):
 def _create_model_body(  # pylint: disable=too-many-arguments
     owner: str,
     name: str,
+    *,
     visibility: str,
     hardware: str,
     description: Optional[str] = None,

--- a/replicate/pagination.py
+++ b/replicate/pagination.py
@@ -1,11 +1,9 @@
 from typing import (
     TYPE_CHECKING,
-    Dict,
     Generic,
     List,
     Optional,
     TypeVar,
-    Union,
 )
 
 try:
@@ -13,21 +11,18 @@ try:
 except ImportError:
     import pydantic  # type: ignore
 
-from replicate.resource import Namespace, Resource
+from replicate.resource import Resource
 
 T = TypeVar("T", bound=Resource)
 
 if TYPE_CHECKING:
-    from .client import Client
+    pass
 
 
 class Page(pydantic.BaseModel, Generic[T]):
     """
     A page of results from the API.
     """
-
-    _client: "Client" = pydantic.PrivateAttr()
-    _namespace: Namespace = pydantic.PrivateAttr()
 
     previous: Optional[str] = None
     """A pointer to the previous page of results"""
@@ -37,24 +32,6 @@ class Page(pydantic.BaseModel, Generic[T]):
 
     results: List[T]
     """The results on this page"""
-
-    def __init__(
-        self,
-        client: "Client",
-        namespace: Namespace[T],
-        *,
-        results: Optional[List[Union[T, Dict]]] = None,
-        **kwargs,
-    ) -> None:
-        self._client = client
-        self._namespace = namespace
-
-        super().__init__(
-            results=[self._namespace._prepare_model(r) for r in results]
-            if results
-            else None,
-            **kwargs,
-        )
 
     def __iter__(self):  # noqa: ANN204
         return iter(self.results)

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -187,9 +187,7 @@ class Predictions(Namespace):
         )
 
         obj = resp.json()
-        obj["results"] = [Prediction(**result) for result in obj["results"]]
-        for prediction in obj["results"]:
-            prediction._client = self._client
+        obj["results"] = [self._json_to_prediction(result) for result in obj["results"]]
 
         return Page[Prediction](**obj)
 
@@ -205,10 +203,7 @@ class Predictions(Namespace):
 
         resp = self._client._request("GET", f"/v1/predictions/{id}")
 
-        prediction = Prediction(**resp.json())
-        prediction._client = self._client
-
-        return prediction
+        return self._json_to_prediction(resp.json())
 
     def create(
         self,
@@ -258,10 +253,7 @@ class Predictions(Namespace):
             json=body,
         )
 
-        prediction = Prediction(**resp.json())
-        prediction._client = self._client
-
-        return prediction
+        return self._json_to_prediction(resp.json())
 
     def cancel(self, id: str) -> Prediction:
         """
@@ -278,7 +270,9 @@ class Predictions(Namespace):
             f"/v1/predictions/{id}/cancel",
         )
 
-        canceled = Prediction(**resp.json())
-        canceled._client = self._client
+        return self._json_to_prediction(resp.json())
 
-        return canceled
+    def _json_to_prediction(self, json: Dict[str, Any]) -> Prediction:
+        prediction = Prediction(**json)
+        prediction._client = self._client
+        return prediction

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -238,6 +238,5 @@ class Predictions(Namespace):
             "/v1/predictions",
             json=body,
         )
-        obj = resp.json()
 
-        return self._prepare_model(obj)
+        return self._prepare_model(resp.json())

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -167,8 +167,6 @@ class Predictions(Namespace):
     Namespace for operations related to predictions.
     """
 
-    model = Prediction
-
     def list(self, cursor: Union[str, "ellipsis"] = ...) -> Page[Prediction]:  # noqa: F821
         """
         List your predictions.

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -21,8 +21,8 @@ class Prediction(Resource):
     id: str
     """The unique ID of the prediction."""
 
-    version: Optional[Version]
-    """The version of the model used to create the prediction."""
+    version: str
+    """An identifier for the version of the model used to create the prediction."""
 
     status: str
     """The status of the prediction."""
@@ -189,10 +189,7 @@ class Predictions(Namespace):
         """
 
         resp = self._client._request("GET", f"/v1/predictions/{id}")
-        obj = resp.json()
-        # HACK: resolve this? make it lazy somehow?
-        del obj["version"]
-        return self._prepare_model(obj)
+        return self._prepare_model(resp.json())
 
     def create(
         self,
@@ -242,9 +239,5 @@ class Predictions(Namespace):
             json=body,
         )
         obj = resp.json()
-        if isinstance(version, Version):
-            obj["version"] = version
-        else:
-            del obj["version"]
 
         return self._prepare_model(obj)

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -271,7 +271,7 @@ class Predictions(Namespace):
         self,
         version: Union[Version, str],
         input: Optional[Dict[str, Any]],
-        **params: Unpack["CreatePredictionParams"],
+        **params: Unpack["Predictions.CreatePredictionParams"],
     ) -> Prediction:
         """
         Create a new prediction for the specified model version.
@@ -294,7 +294,7 @@ class Predictions(Namespace):
         self,
         version: Union[Version, str],
         input: Optional[Dict[str, Any]],
-        **params: Unpack["CreatePredictionParams"],
+        **params: Unpack["Predictions.CreatePredictionParams"],
     ) -> Prediction:
         """
         Create a new prediction for the specified model version.

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -362,7 +362,7 @@ def _create_prediction_body(  # pylint: disable=too-many-arguments
         body["input"] = encode_json(input, upload_file=upload_file)
 
     if version is not None:
-        body["version"] = version if isinstance(version, str) else version.id
+        body["version"] = version.id if isinstance(version, Version) else version
 
     if webhook is not None:
         body["webhook"] = webhook

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -351,7 +351,6 @@ class Predictions(Namespace):
 def _create_prediction_body(  # pylint: disable=too-many-arguments
     version: Optional[Union[Version, str]],
     input: Optional[Dict[str, Any]],
-    *,
     webhook: Optional[str] = None,
     webhook_completed: Optional[str] = None,
     webhook_events_filter: Optional[List[str]] = None,

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -270,7 +270,7 @@ class Predictions(Namespace):
     def create(
         self,
         version: Union[Version, str],
-        input: Dict[str, Any],
+        input: Optional[Dict[str, Any]],
         **params: Unpack["CreatePredictionParams"],
     ) -> Prediction:
         """
@@ -293,7 +293,7 @@ class Predictions(Namespace):
     async def async_create(
         self,
         version: Union[Version, str],
-        input: Dict[str, Any],
+        input: Optional[Dict[str, Any]],
         **params: Unpack["CreatePredictionParams"],
     ) -> Prediction:
         """
@@ -350,15 +350,17 @@ class Predictions(Namespace):
 
 def _create_prediction_body(  # pylint: disable=too-many-arguments
     version: Optional[Union[Version, str]],
-    input: Dict[str, Any],
+    input: Optional[Dict[str, Any]],
+    *,
     webhook: Optional[str] = None,
     webhook_completed: Optional[str] = None,
     webhook_events_filter: Optional[List[str]] = None,
     stream: Optional[bool] = None,
 ) -> Dict[str, Any]:
-    body = {
-        "input": encode_json(input, upload_file=upload_file),
-    }
+    body = {}
+
+    if input is not None:
+        body["input"] = encode_json(input, upload_file=upload_file)
 
     if version is not None:
         body["version"] = version if isinstance(version, str) else version.id

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -3,6 +3,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
+from typing_extensions import NotRequired, TypedDict, Unpack
+
 from replicate.exceptions import ModelError
 from replicate.files import upload_file
 from replicate.json import encode_json
@@ -250,38 +252,35 @@ class Predictions(Namespace):
 
         return _json_to_prediction(self._client, resp.json())
 
+    class CreatePredictionParams(TypedDict):
+        """Parameters for creating a prediction."""
+
+        webhook: NotRequired[str]
+        """The URL to receive a POST request with prediction updates."""
+
+        webhook_completed: NotRequired[str]
+        """The URL to receive a POST request when the prediction is completed."""
+
+        webhook_events_filter: NotRequired[List[str]]
+        """List of events to trigger webhooks."""
+
+        stream: NotRequired[bool]
+        """Enable streaming of prediction output."""
+
     def create(
         self,
         version: Union[Version, str],
         input: Dict[str, Any],
-        *,
-        webhook: Optional[str] = None,
-        webhook_completed: Optional[str] = None,
-        webhook_events_filter: Optional[List[str]] = None,
-        stream: Optional[bool] = None,
+        **params: Unpack["CreatePredictionParams"],
     ) -> Prediction:
         """
         Create a new prediction for the specified model version.
-
-        Args:
-            version: The model version to use for the prediction.
-            input: The input data for the prediction.
-            webhook: The URL to receive a POST request with prediction updates.
-            webhook_completed: The URL to receive a POST request when the prediction is completed.
-            webhook_events_filter: List of events to trigger webhooks.
-            stream: Set to True to enable streaming of prediction output.
-
-        Returns:
-            Prediction: The created prediction object.
         """
 
         body = _create_prediction_body(
             version,
             input,
-            webhook=webhook,
-            webhook_completed=webhook_completed,
-            webhook_events_filter=webhook_events_filter,
-            stream=stream,
+            **params,
         )
         resp = self._client._request(
             "POST",
@@ -295,34 +294,16 @@ class Predictions(Namespace):
         self,
         version: Union[Version, str],
         input: Dict[str, Any],
-        *,
-        webhook: Optional[str] = None,
-        webhook_completed: Optional[str] = None,
-        webhook_events_filter: Optional[List[str]] = None,
-        stream: Optional[bool] = None,
+        **params: Unpack["CreatePredictionParams"],
     ) -> Prediction:
         """
         Create a new prediction for the specified model version.
-
-        Args:
-            version: The model version to use for the prediction.
-            input: The input data for the prediction.
-            webhook: The URL to receive a POST request with prediction updates.
-            webhook_completed: The URL to receive a POST request when the prediction is completed.
-            webhook_events_filter: List of events to trigger webhooks.
-            stream: Set to True to enable streaming of prediction output.
-
-        Returns:
-            Prediction: The created prediction object.
         """
 
         body = _create_prediction_body(
             version,
             input,
-            webhook=webhook,
-            webhook_completed=webhook_completed,
-            webhook_events_filter=webhook_events_filter,
-            stream=stream,
+            **params,
         )
         resp = await self._client._async_request(
             "POST",

--- a/replicate/resource.py
+++ b/replicate/resource.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING
 
 try:
     from pydantic import v1 as pydantic  # type: ignore
@@ -16,16 +16,12 @@ class Resource(pydantic.BaseModel):
     """
 
 
-Model = TypeVar("Model", bound=Resource)
-
-
-class Namespace(abc.ABC, Generic[Model]):
+class Namespace(abc.ABC):
     """
     A base class for representing objects of a particular type on the server.
     """
 
     _client: "Client"
-    model: Model
 
     def __init__(self, client: "Client") -> None:
         self._client = client

--- a/replicate/resource.py
+++ b/replicate/resource.py
@@ -1,7 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Dict, Generic, TypeVar
-
-from replicate.exceptions import ReplicateException
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 try:
     from pydantic import v1 as pydantic  # type: ignore
@@ -17,9 +15,6 @@ class Resource(pydantic.BaseModel):
     A base class for representing a single object on the server.
     """
 
-    _client: "Client" = pydantic.PrivateAttr()
-    _namespace: "Namespace" = pydantic.PrivateAttr()
-
 
 Model = TypeVar("Model", bound=Resource)
 
@@ -34,16 +29,3 @@ class Namespace(abc.ABC, Generic[Model]):
 
     def __init__(self, client: "Client") -> None:
         self._client = client
-
-    def _prepare_model(self, attrs: Dict) -> Model:
-        """
-        Create a model from a set of attributes.
-        """
-        if isinstance(attrs, dict) and self.model is not None and callable(self.model):
-            model = self.model(**attrs)
-            model._client = self._client
-            model._namespace = self
-            return model
-
-        name = self.model.__name__ if hasattr(self.model, "__name__") else "model"
-        raise ReplicateException(f"Can't create {name} from {attrs}")

--- a/replicate/resource.py
+++ b/replicate/resource.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Dict, Generic, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Dict, Generic, TypeVar
 
 from replicate.exceptions import ReplicateException
 
@@ -35,15 +35,10 @@ class Namespace(abc.ABC, Generic[Model]):
     def __init__(self, client: "Client") -> None:
         self._client = client
 
-    def _prepare_model(self, attrs: Union[Model, Dict]) -> Model:
+    def _prepare_model(self, attrs: Dict) -> Model:
         """
         Create a model from a set of attributes.
         """
-        if isinstance(attrs, Resource):
-            attrs._client = self._client
-            attrs._namespace = self
-            return cast(Model, attrs)
-
         if isinstance(attrs, dict) and self.model is not None and callable(self.model):
             model = self.model(**attrs)
             model._client = self._client

--- a/replicate/run.py
+++ b/replicate/run.py
@@ -1,0 +1,112 @@
+import asyncio
+import re
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+
+from typing_extensions import Unpack
+
+from replicate.exceptions import ModelError, ReplicateError
+from replicate.schema import make_schema_backwards_compatible
+from replicate.version import Versions
+
+if TYPE_CHECKING:
+    from replicate.client import Client
+    from replicate.prediction import Predictions
+
+
+def run(
+    client: "Client",
+    ref: str,
+    input: Optional[Dict[str, Any]] = None,
+    **params: Unpack["Predictions.CreatePredictionParams"],
+) -> Union[Any, Iterator[Any]]:  # noqa: ANN401
+    """
+    Run a model and wait for its output.
+    """
+
+    # Split ref into owner, name, version in format owner/name:version
+    match = re.match(r"^(?P<owner>[^/]+)/(?P<name>[^:]+):(?P<version>.+)$", ref)
+    if not match:
+        raise ReplicateError(
+            f"Invalid reference to model version: {ref}. Expected format: owner/name:version"
+        )
+
+    owner = match.group("owner")
+    name = match.group("name")
+    version_id = match.group("version")
+
+    prediction = client.predictions.create(
+        version=version_id, input=input or {}, **params
+    )
+
+    if owner and name:
+        version = Versions(client, model=(owner, name)).get(version_id)
+
+        # Return an iterator of the output
+        schema = make_schema_backwards_compatible(
+            version.openapi_schema, version.cog_version
+        )
+        output = schema["components"]["schemas"]["Output"]
+        if (
+            output.get("type") == "array"
+            and output.get("x-cog-array-type") == "iterator"
+        ):
+            return prediction.output_iterator()
+
+    prediction.wait()
+
+    if prediction.status == "failed":
+        raise ModelError(prediction.error)
+
+    return prediction.output
+
+
+async def async_run(
+    client: "Client",
+    ref: str,
+    input: Optional[Dict[str, Any]] = None,
+    **params: Unpack["Predictions.CreatePredictionParams"],
+) -> Union[Any, Iterator[Any]]:  # noqa: ANN401
+    """
+    Run a model and wait for its output asynchronously.
+    """
+
+    # Split ref into owner, name, version in format owner/name:version
+    match = re.match(r"^(?P<owner>[^/]+)/(?P<name>[^:]+):(?P<version>.+)$", ref)
+    if not match:
+        raise ReplicateError(
+            f"Invalid reference to model version: {ref}. Expected format: owner/name:version"
+        )
+
+    owner = match.group("owner")
+    name = match.group("name")
+    version_id = match.group("version")
+
+    prediction = await client.predictions.async_create(
+        version=version_id, input=input or {}, **params
+    )
+
+    if owner and name:
+        version = await Versions(client, model=(owner, name)).async_get(version_id)
+
+        # Return an iterator of the output
+        schema = make_schema_backwards_compatible(
+            version.openapi_schema, version.cog_version
+        )
+        output = schema["components"]["schemas"]["Output"]
+        if (
+            output.get("type") == "array"
+            and output.get("x-cog-array-type") == "iterator"
+        ):
+            return prediction.output_iterator()
+
+    while prediction.status not in ["succeeded", "failed", "canceled"]:
+        await asyncio.sleep(client.poll_interval)
+        prediction = await client.predictions.async_get(prediction.id)
+
+    if prediction.status == "failed":
+        raise ModelError(prediction.error)
+
+    return prediction.output
+
+
+__all__: List = []

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -10,6 +10,11 @@ from replicate.pagination import Page
 from replicate.resource import Namespace, Resource
 from replicate.version import Version
 
+try:
+    from pydantic import v1 as pydantic  # type: ignore
+except ImportError:
+    pass  # type: ignore
+
 
 class Training(Resource):
     """
@@ -21,7 +26,7 @@ class Training(Resource):
     id: str
     """The unique ID of the training."""
 
-    version: Optional[Version]
+    version: Union[str, Version]
     """The version of the model used to create the training."""
 
     destination: Optional[str]
@@ -125,10 +130,7 @@ class Trainings(Namespace):
             "GET",
             f"/v1/trainings/{id}",
         )
-        obj = resp.json()
-        # HACK: resolve this? make it lazy somehow?
-        del obj["version"]
-        return self._prepare_model(obj)
+        return self._prepare_model(resp.json())
 
     @overload
     def create(  # pylint: disable=arguments-differ disable=too-many-arguments
@@ -222,6 +224,4 @@ class Trainings(Namespace):
             f"/v1/models/{username}/{model_name}/versions/{version_id}/trainings",
             json=body,
         )
-        obj = resp.json()
-        del obj["version"]
-        return self._prepare_model(obj)
+        return self._prepare_model(resp.json())

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -117,9 +117,7 @@ class Trainings(Namespace):
         )
 
         obj = resp.json()
-        obj["results"] = [Training(**result) for result in obj["results"]]
-        for training in obj["results"]:
-            training._client = self._client
+        obj["results"] = [self._json_to_training(result) for result in obj["results"]]
 
         return Page[Training](**obj)
 
@@ -138,10 +136,7 @@ class Trainings(Namespace):
             f"/v1/trainings/{id}",
         )
 
-        training = Training(**resp.json())
-        training._client = self._client
-
-        return training
+        return self._json_to_training(resp.json())
 
     @overload
     def create(  # pylint: disable=arguments-differ disable=too-many-arguments
@@ -235,10 +230,8 @@ class Trainings(Namespace):
             f"/v1/models/{username}/{model_name}/versions/{version_id}/trainings",
             json=body,
         )
-        training = Training(**resp.json())
-        training._client = self._client
 
-        return training
+        return self._json_to_training(resp.json())
 
     def cancel(self, id: str) -> Training:
         """
@@ -255,7 +248,9 @@ class Trainings(Namespace):
             f"/v1/trainings/{id}/cancel",
         )
 
-        canceled = Training(**resp.json())
-        canceled._client = self._client
+        return self._json_to_training(resp.json())
 
-        return canceled
+    def _json_to_training(self, json: Dict[str, Any]) -> Training:
+        training = Training(**json)
+        training._client = self._client
+        return training

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -87,8 +87,6 @@ class Trainings(Namespace):
     Namespace for operations related to trainings.
     """
 
-    model = Training
-
     class CreateParams(TypedDict):
         """Parameters for creating a prediction."""
 

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -193,7 +193,7 @@ class Trainings(Namespace):
         webhook_events_filter: NotRequired[List[str]]
 
     @overload
-    def create(
+    def create(  # pylint: disable=too-many-arguments
         self,
         version: str,
         input: Dict[str, Any],

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -150,7 +150,7 @@ class Trainings(Namespace):
 
         return Page[Training](**obj)
 
-    def get(self, id: str) -> Training:  # pylint: disable=invalid-name
+    def get(self, id: str) -> Training:
         """
         Get a training by ID.
 
@@ -167,7 +167,7 @@ class Trainings(Namespace):
 
         return _json_to_training(self._client, resp.json())
 
-    async def async_get(self, id: str) -> Training:  # pylint: disable=invalid-name
+    async def async_get(self, id: str) -> Training:
         """
         Get a training by ID.
 
@@ -257,7 +257,7 @@ class Trainings(Namespace):
 
         return _json_to_training(self._client, resp.json())
 
-    async def async_create(  # pylint: disable=arguments-differ disable=too-many-arguments
+    async def async_create(
         self,
         model: Union[str, Tuple[str, str], "Model"],
         version: Union[str, Version],

--- a/replicate/training.py
+++ b/replicate/training.py
@@ -210,7 +210,7 @@ class Trainings(Namespace):
         model: Union[str, Tuple[str, str], "Model"],
         version: Union[str, Version],
         input: Optional[Dict[str, Any]] = None,
-        **params: Unpack[CreateTrainingParams],
+        **params: Unpack["Trainings.CreateTrainingParams"],
     ) -> Training:
         ...
 
@@ -220,7 +220,7 @@ class Trainings(Namespace):
         model: Optional[Union[str, Tuple[str, str], "Model"]] = None,
         version: Optional[Union[str, Version]] = None,
         input: Optional[Dict[str, Any]] = None,
-        **params: Unpack[CreateTrainingParams],
+        **params: Unpack["Trainings.CreateTrainingParams"],
     ) -> Training:
         """
         Create a new training using the specified model version as a base.
@@ -262,7 +262,7 @@ class Trainings(Namespace):
         model: Union[str, Tuple[str, str], "Model"],
         version: Union[str, Version],
         input: Dict[str, Any],
-        **params: Unpack[CreateTrainingParams],
+        **params: Unpack["Trainings.CreateTrainingParams"],
     ) -> Training:
         """
         Create a new training using the specified model version as a base.

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -75,7 +75,6 @@ class Versions(Namespace):
     Namespace for operations related to model versions.
     """
 
-    model = Version
     _model: "Model"
 
     def __init__(self, client: "Client", model: "Model") -> None:

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -1,6 +1,6 @@
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Any, Iterator, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Union
 
 if TYPE_CHECKING:
     from replicate.client import Client
@@ -95,7 +95,7 @@ class Versions(Namespace):
             "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions/{id}"
         )
 
-        return Version(**resp.json())
+        return self._json_to_version(resp.json())
 
     def list(self) -> Page[Version]:
         """
@@ -108,5 +108,10 @@ class Versions(Namespace):
         resp = self._client._request(
             "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions"
         )
+        obj = resp.json()
+        obj["results"] = [self._json_to_version(result) for result in obj["results"]]
 
-        return Page[Version](**resp.json())
+        return Page[Version](**obj)
+
+    def _json_to_version(self, json: Dict[str, Any]) -> Version:
+        return Version(**json)

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -49,7 +49,7 @@ class Versions(Namespace):
         else:
             self.model = model
 
-    def get(self, id: str) -> Version:  # pylint: disable=invalid-name
+    def get(self, id: str) -> Version:
         """
         Get a specific model version.
 
@@ -65,7 +65,7 @@ class Versions(Namespace):
 
         return _json_to_version(resp.json())
 
-    async def async_get(self, id: str) -> Version:  # pylint: disable=invalid-name
+    async def async_get(self, id: str) -> Version:
         """
         Get a specific model version.
 

--- a/replicate/version.py
+++ b/replicate/version.py
@@ -1,16 +1,13 @@
 import datetime
-import warnings
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Union
+from typing import TYPE_CHECKING, Any, Dict
 
 if TYPE_CHECKING:
     from replicate.client import Client
     from replicate.model import Model
 
 
-from replicate.exceptions import ModelError
 from replicate.pagination import Page
 from replicate.resource import Namespace, Resource
-from replicate.schema import make_schema_backwards_compatible
 
 
 class Version(Resource):
@@ -30,56 +27,17 @@ class Version(Resource):
     openapi_schema: dict
     """An OpenAPI description of the model inputs and outputs."""
 
-    def predict(self, **kwargs) -> Union[Any, Iterator[Any]]:  # noqa: ANN401
-        """
-        DEPRECATED: Use `replicate.run()` instead.
-
-        Create a prediction using this model version.
-
-        Args:
-            kwargs: The input to the model.
-        Returns:
-            The output of the model.
-        """
-
-        warnings.warn(
-            "version.predict() is deprecated. Use replicate.run() instead. It will be removed before version 1.0.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-
-        prediction = self._client.predictions.create(version=self, input=kwargs)  # pylint: disable=no-member
-        # Return an iterator of the output
-        schema = make_schema_backwards_compatible(self.openapi_schema, self.cog_version)
-        output = schema["components"]["schemas"]["Output"]
-        if (
-            output.get("type") == "array"
-            and output.get("x-cog-array-type") == "iterator"
-        ):
-            return prediction.output_iterator()
-
-        prediction.wait()
-        if prediction.status == "failed":
-            raise ModelError(prediction.error)
-        return prediction.output
-
-    def reload(self) -> None:
-        """
-        Load this object from the server.
-        """
-        return
-
 
 class Versions(Namespace):
     """
     Namespace for operations related to model versions.
     """
 
-    _model: "Model"
+    model: "Model"
 
     def __init__(self, client: "Client", model: "Model") -> None:
         super().__init__(client=client)
-        self._model = model
+        self.model = model
 
     def get(self, id: str) -> Version:  # pylint: disable=invalid-name
         """
@@ -92,10 +50,26 @@ class Versions(Namespace):
         """
 
         resp = self._client._request(
-            "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions/{id}"
+            "GET", f"/v1/models/{self.model.owner}/{self.model.name}/versions/{id}"
         )
 
-        return self._json_to_version(resp.json())
+        return _json_to_version(resp.json())
+
+    async def async_get(self, id: str) -> Version:  # pylint: disable=invalid-name
+        """
+        Get a specific model version.
+
+        Args:
+            id: The version ID.
+        Returns:
+            The model version.
+        """
+
+        resp = await self._client._async_request(
+            "GET", f"/v1/models/{self.model.owner}/{self.model.name}/versions/{id}"
+        )
+
+        return _json_to_version(resp.json())
 
     def list(self) -> Page[Version]:
         """
@@ -106,12 +80,29 @@ class Versions(Namespace):
         """
 
         resp = self._client._request(
-            "GET", f"/v1/models/{self._model.owner}/{self._model.name}/versions"
+            "GET", f"/v1/models/{self.model.owner}/{self.model.name}/versions"
         )
         obj = resp.json()
-        obj["results"] = [self._json_to_version(result) for result in obj["results"]]
+        obj["results"] = [_json_to_version(result) for result in obj["results"]]
 
         return Page[Version](**obj)
 
-    def _json_to_version(self, json: Dict[str, Any]) -> Version:
-        return Version(**json)
+    async def async_list(self) -> Page[Version]:
+        """
+        Return a list of all versions for a model.
+
+        Returns:
+            List[Version]: A list of version objects.
+        """
+
+        resp = await self._client._async_request(
+            "GET", f"/v1/models/{self.model.owner}/{self.model.name}/versions"
+        )
+        obj = resp.json()
+        obj["results"] = [_json_to_version(result) for result in obj["results"]]
+
+        return Page[Version](**obj)
+
+
+def _json_to_version(json: Dict[str, Any]) -> Version:
+    return Version(**json)

--- a/tests/cassettes/run-concurrently.yaml
+++ b/tests/cassettes/run-concurrently.yaml
@@ -1,0 +1,8353 @@
+interactions:
+- request:
+    body: '{"input": {"prompt": "A chariot pulled by a team of two rainbow unicorns"},
+      "version": "39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '154'
+      content-type:
+      - application/json
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: POST
+    uri: https://api.replicate.com/v1/predictions
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136b11854c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '445'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:15 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=VjEoQdik3RT6c10%2FbDVqrZUOFke1PedlfT0tIL40WSKNXbcT8qNCCdOcNGbuQxgEDRVcJ5nJolE7mhRGtCPo3R2EnlBbmln1WbfFuT8cmu6NJ5cxEUnNTzMwLgtks3uZDPdG"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      ratelimit-remaining:
+      - '599'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 201
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/models/stability-ai/sdxl/versions/39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b
+  response:
+    content: '{"id":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","created_at":"2023-11-06T23:13:07.906314Z","cog_version":"0.8.6","openapi_schema":{"info":{"title":"Cog","version":"0.1.0"},"paths":{"/":{"get":{"summary":"Root","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Root  Get"}}},"description":"Successful Response"}},"operationId":"root__get"}},"/shutdown":{"post":{"summary":"Start
+      Shutdown","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Start Shutdown Shutdown Post"}}},"description":"Successful Response"}},"operationId":"start_shutdown_shutdown_post"}},"/predictions":{"post":{"summary":"Predict","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model","operationId":"predict_predictions_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionRequest"}}}}}},"/health-check":{"get":{"summary":"Healthcheck","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Healthcheck Health Check Get"}}},"description":"Successful Response"}},"operationId":"healthcheck_health_check_get"}},"/predictions/{prediction_id}":{"put":{"summary":"Predict
+      Idempotent","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true},{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model (idempotent creation).","operationId":"predict_idempotent_predictions__prediction_id__put","requestBody":{"content":{"application/json":{"schema":{"allOf":[{"$ref":"#/components/schemas/PredictionRequest"}],"title":"Prediction
+      Request"}}},"required":true}}},"/predictions/{prediction_id}/cancel":{"post":{"summary":"Cancel","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Cancel Predictions  Prediction Id  Cancel Post"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true}],"description":"Cancel a running prediction","operationId":"cancel_predictions__prediction_id__cancel_post"}}},"openapi":"3.0.2","components":{"schemas":{"Input":{"type":"object","title":"Input","properties":{"mask":{"type":"string","title":"Mask","format":"uri","x-order":3,"description":"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted."},"seed":{"type":"integer","title":"Seed","x-order":11,"description":"Random
+      seed. Leave blank to randomize the seed"},"image":{"type":"string","title":"Image","format":"uri","x-order":2,"description":"Input
+      image for img2img or inpaint mode"},"width":{"type":"integer","title":"Width","default":1024,"x-order":4,"description":"Width
+      of output image"},"height":{"type":"integer","title":"Height","default":1024,"x-order":5,"description":"Height
+      of output image"},"prompt":{"type":"string","title":"Prompt","default":"An astronaut
+      riding a rainbow unicorn","x-order":0,"description":"Input prompt"},"refine":{"allOf":[{"$ref":"#/components/schemas/refine"}],"default":"no_refiner","x-order":12,"description":"Which
+      refine style to use"},"scheduler":{"allOf":[{"$ref":"#/components/schemas/scheduler"}],"default":"K_EULER","x-order":7,"description":"scheduler"},"lora_scale":{"type":"number","title":"Lora
+      Scale","default":0.6,"maximum":1,"minimum":0,"x-order":16,"description":"LoRA
+      additive scale. Only applicable on trained models."},"num_outputs":{"type":"integer","title":"Num
+      Outputs","default":1,"maximum":4,"minimum":1,"x-order":6,"description":"Number
+      of images to output."},"refine_steps":{"type":"integer","title":"Refine Steps","x-order":14,"description":"For
+      base_image_refiner, the number of steps to refine, defaults to num_inference_steps"},"guidance_scale":{"type":"number","title":"Guidance
+      Scale","default":7.5,"maximum":50,"minimum":1,"x-order":9,"description":"Scale
+      for classifier-free guidance"},"apply_watermark":{"type":"boolean","title":"Apply
+      Watermark","default":true,"x-order":15,"description":"Applies a watermark to
+      enable determining if an image is generated in downstream applications. If you
+      have other provisions for generating or deploying images safely, you can use
+      this to disable watermarking."},"high_noise_frac":{"type":"number","title":"High
+      Noise Frac","default":0.8,"maximum":1,"minimum":0,"x-order":13,"description":"For
+      expert_ensemble_refiner, the fraction of noise to use"},"negative_prompt":{"type":"string","title":"Negative
+      Prompt","default":"","x-order":1,"description":"Input Negative Prompt"},"prompt_strength":{"type":"number","title":"Prompt
+      Strength","default":0.8,"maximum":1,"minimum":0,"x-order":10,"description":"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image"},"replicate_weights":{"type":"string","title":"Replicate
+      Weights","x-order":17,"description":"Replicate LoRA weights to use. Leave blank
+      to use the default weights."},"num_inference_steps":{"type":"integer","title":"Num
+      Inference Steps","default":50,"maximum":500,"minimum":1,"x-order":8,"description":"Number
+      of denoising steps"},"disable_safety_checker":{"type":"boolean","title":"Disable
+      Safety Checker","default":false,"x-order":18,"description":"Disable safety checker
+      for generated images. This feature is only available through the API. See https://replicate.com/docs/how-does-replicate-work#safety"}}},"Output":{"type":"array","items":{"type":"string","format":"uri"},"title":"Output"},"Status":{"enum":["starting","processing","succeeded","canceled","failed"],"type":"string","title":"Status","description":"An
+      enumeration."},"refine":{"enum":["no_refiner","expert_ensemble_refiner","base_image_refiner"],"type":"string","title":"refine","description":"An
+      enumeration."},"scheduler":{"enum":["DDIM","DPMSolverMultistep","HeunDiscrete","KarrasDPM","K_EULER_ANCESTRAL","K_EULER","PNDM"],"type":"string","title":"scheduler","description":"An
+      enumeration."},"WebhookEvent":{"enum":["start","output","logs","completed"],"type":"string","title":"WebhookEvent","description":"An
+      enumeration."},"ValidationError":{"type":"object","title":"ValidationError","required":["loc","msg","type"],"properties":{"loc":{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error
+      Type"}}},"PredictionRequest":{"type":"object","title":"PredictionRequest","properties":{"id":{"type":"string","title":"Id"},"input":{"$ref":"#/components/schemas/Input"},"webhook":{"type":"string","title":"Webhook","format":"uri","maxLength":65536,"minLength":1},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"output_file_prefix":{"type":"string","title":"Output
+      File Prefix"},"webhook_events_filter":{"type":"array","items":{"$ref":"#/components/schemas/WebhookEvent"},"default":["start","output","logs","completed"]}}},"PredictionResponse":{"type":"object","title":"PredictionResponse","properties":{"id":{"type":"string","title":"Id"},"logs":{"type":"string","title":"Logs","default":""},"error":{"type":"string","title":"Error"},"input":{"$ref":"#/components/schemas/Input"},"output":{"$ref":"#/components/schemas/Output"},"status":{"$ref":"#/components/schemas/Status"},"metrics":{"type":"object","title":"Metrics"},"version":{"type":"string","title":"Version"},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"started_at":{"type":"string","title":"Started At","format":"date-time"},"completed_at":{"type":"string","title":"Completed
+      At","format":"date-time"}}},"HTTPValidationError":{"type":"object","title":"HTTPValidationError","properties":{"detail":{"type":"array","items":{"$ref":"#/components/schemas/ValidationError"},"title":"Detail"}}}}}}}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136b1f8fac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:15 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      content-security-policy-report-only:
+      - 'font-src ''report-sample'' ''self'' data:; media-src ''report-sample'' ''self''
+        https://replicate.delivery https://*.replicate.delivery https://*.mux.com
+        https://*.sentry.io; script-src ''report-sample'' ''self'' https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js;
+        img-src ''report-sample'' ''self'' data: https://replicate.delivery https://*.replicate.delivery
+        https://*.githubusercontent.com https://github.com; default-src ''self'';
+        connect-src ''report-sample'' ''self'' https://replicate.delivery https://*.replicate.delivery
+        https://*.rudderlabs.com https://*.rudderstack.com https://*.mux.com https://*.sentry.io;
+        style-src ''report-sample'' ''self'' ''unsafe-inline''; worker-src ''none'';
+        report-uri'
+      cross-origin-opener-policy:
+      - same-origin
+      nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      ratelimit-remaining:
+      - '2999'
+      ratelimit-reset:
+      - '1'
+      referrer-policy:
+      - same-origin
+      report-to:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1699482135&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=1BG2TDL6m46CofBAHnCRDggHNxEqGkC%2BM%2FjX2VrGQ8U%3D"}]}'
+      reporting-endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1699482135&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=1BG2TDL6m46CofBAHnCRDggHNxEqGkC%2BM%2FjX2VrGQ8U%3D
+      vary:
+      - Cookie, origin
+      via:
+      - 1.1 vegur, 1.1 google
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136b5fca7c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:16 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=pY4%2FgcbD1rjD7GdlUxQyHMxtge8jf2ZBTgtE1fB1m1660W%2BCbLvC41UgJFvPf9VnVyzU%2Fo0YEbEk7UG0wM9o9fZ%2BndQutChK7zznS1CpKCG60Bk%2BKWuND8dmIURbWt1DDNg8"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136b9dff7c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:16 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=WFqbLxDFKXkj9MtJJS%2B%2Fweea5rsazN54PCbK3VmNqtTwFyIKRrw0EZQ7JPnK8VLuLycd2Mg1pEvWAZZs3x8WouZok35%2BvY877vRlJFCBlyYjJIf%2BTpFS07XWlcqgtEYPJGQr"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136bdcb77c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:17 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Uc2XdgP%2BT8qBnOCF%2Fmo%2B8pfqcOpkznArmIDzUJoHKp5a3Vq%2BTK%2F91%2BZ5IYc2Ie2UQk77LezMZvUoLGbt8uPmAud5nn6KwR%2BEbuUEE83JGsiXP3JBgCjX0%2FjEYEC96Gj4eXhA"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136c19f30c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:17 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=NAgIdkMzVl22uWY692m%2BiTPd0I1WmmBTouYFP8wuo2FjEFx1AJvRGAL6B5VH8Kxtdfp%2Bz2FziktW5ZEAg%2BJ82n0wUvi9AhG0wVIz6KSSj%2BllFoj7LCAduEy4062hmVMr6n8t"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136c56af7c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:18 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=GMIONovXhSfsaZ%2Bzo9yejLrUiI5OXeBcJVHflasuYxCEIr0QCsXFypZW3caM7PIV4zPD6xlOUkpsOuikXul8PW7b2nKdC9JzejddbAg1QzI9WbpDka%2FHSaJFc86wQKhl9dlX"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136c95eafc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:19 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3yD9hhSwviFiWFMXTMrDhy%2FVohInKDvhn%2FGU4jjn1CE9gc6PTVqYihAjsGpu3OwLubRqBeMmgVVx8CZJ3bsdqsHL%2BdTMZD%2B5VkMBLiOW8v3DcUu2%2B81mcgEBcTaq7nldLmIE"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136cd3a17c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:19 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=rpUUZn4LnOamdtd%2FFPKZvGib2wOo9CBRT%2FgMbPPXYYUvZ9i47yyqBpaqRQneDRdjPutcy84yKRXnpuKrkXcGLqupSRPv%2BF24YBjZJ9ZHWtbgmEtUJyfGr4jd3FL7bx%2FO7zeW"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136d10e15c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:20 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=UBkviJTTj1d8w17u9sI5gPQqGVd379umwJlDVeOSvoShjb9phJby99GREJRK9EIToevN3UHFeuPMDlcWXuA6hMX6nNPa1ofrVcVs36qgVCFc73W%2F5NBkzSBGcnWnT01w1x6O"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136d4e96cc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:21 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=7Dx3G24pzsxICTCLwc0qj3g20yLbz8CGWFIw9tIeoNtg15Z6O8s3MRt8ZR24CMPx7NH6AEa%2FtpXXPRLinhPlZBd88EYPrXRXKzTfR2wUFDROrIMWk03e1DhQMcS4WqnIqM8j"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136d8bcb3c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:21 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=VTBXC497XgL4fflH74sNHRnFOJwjKro6INb3XaU9webszrvqDsGNCNlOiJBXSQ0%2BPjS134UhhN1X10cRfGltx9rg5c8kOkyorHhCuPS%2B5cTKLvXnRXOHQpMk5kjaeJT6QH4B"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136dc986ec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:22 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=BN4nlcG7nkHy6eQXWNIMcGliX3juATKxYQTIb3TY5idTCxkA%2FT3HU9Qj0XtT3srbnZNFef2%2FZJytAz37I8jBAWzseTZsTKodznqkBPrAjjMgQ81m%2B9ogmadIp%2FtsMqcTAjLz"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136e06bdbc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:22 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=49Hazz75qGuUeSQj31aG4l3U9%2B4f%2BujxNkGws333VXyExefrSIUCY3Sp3%2FfPvccvpHv9sVEbr2jm3p7G5NnGe209qUEgeNfH0EtWm22q1YmdISQdJJF%2B4mjzIBJGM%2FsFJslp"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:15.305024023Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136e448bec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:23 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=5ebk3%2FLj3qgf6KipU0VDGjj6Aegp3Yp%2BFft3ZkyYE44vi%2FmIy6PvqH3VISP7jPyhyokr5NPkRbtB%2BAwaZnkHWz6YDo%2F5KqpVXDZtPePIlSL1CI6g5R4Jh0MBT5cT3L4i1Luq"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: '{"id":"ppn6sy3bpvltiyk3hsquxuvmee","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of two rainbow unicorns"},"logs":"","error":null,"status":"processing","created_at":"2023-11-08T22:22:15.305024Z","started_at":"2023-11-08T22:22:23.852217Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel","get":"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136e82e0cc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:24 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=e56rDV9QXVbQw4F846CJ9t7xLBkFXueFZXByYa8PNAO7cKIGEEThF%2FDCVf8obqUEzFTSWJY4xLWZQsmGfpRjxRqBzFs1CsRij%2BpiLwlV21G1n88afZG8yobfUHwJCNX%2BW8Xx"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136ec19d8c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:24 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=IWkq78HJCSB%2F99sizG%2BwLVN6VA0NWfeP26n%2B2F3iz21B52E%2But4Jo%2Fy7SARpf7XnZxzwG%2FZo8CK3zWFmjkU4PH%2Fp5w1LuXgMixkEJ%2FRks4n3DQJjC81fbm3VcZmYBaC9GCfd"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136f03da7c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:25 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=zYbkGTN7Pw90jHb1aeVicG9a0GWBI1ziUjOy96%2Fzs5rxqdRMRwkjAF0xo3lnrGFbO7L0bcvOW7K%2FchwfYTBc5rMhJNCDcC6RkfvlzxoFVmsf6daLmjPo1mIYQ%2Fs13AM2%2BIxt"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136f4295ac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:26 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Qppu6a6dc5LFlxkDakW84BkParWnb2y%2FMoZGa0czRDsLisq7OdRRKzUSLpzqaUCJtM53gX60g1hCNWdOoSYI1y%2Bg9fey6%2B%2BYeWiJ2fMXhKIdN4RJ8pgCUnmLz8Ercoj3msSR"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136f80d33c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:26 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=rwvTVV5rjkVQpeJ9e3BXpu7s3EQPk8PBlRqbLEVNIYPWY90Jv%2Fel8JVV7asD6shicjX1JRS3Hv6OxMXUntDmZaunhYzgcq0qws%2BQYc5ixurEZ28n20smC8awM777cvEm7fi5"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136fbd8dbc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:27 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=5jAhTsVYV7L1VNsxIgVcqyNDjTZl7ElmZcBg2BVgYRApZi61UUlBIVbwMda8%2Fq4MIncMLWV2euA%2BxzfaV%2BMiuEHeqL2SySNQriPhwSHBzXDo1AjpW%2FWCtGMr4TEY0hYwwwZA"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823136ffac5ac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:27 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=MpLn%2FMn%2FLifgQVQv%2BCWtdeHSUWxqTKL%2Brc9aamPHD4qDuDvwls1iNrhnc67DIlF%2FGgxXpME%2BSVPYZMmByvBpPQA%2BrguyWky%2FXaZl%2BgL83560sht9CyPMq0FjomVD2rvzzGzg"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313703783ec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:28 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=LaIZ00VV8bBF0nC6M1oVyV35%2F6kwxURIvXepoCNl4zi6BiWgKeEyXMj7POjj0m%2FlfF2tYIOLUbSpoqS%2FeTpRn31%2B6L%2Fk7Ku8XwPQlEzK%2BPZ%2BceIQUbjHrUmhrYX1WNAeThj5"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137076c64c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:29 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Vhv0nUGP8WcTXM4MbYxmascB1Hsi0HkSojoj5Wmqg8e4PlFsT%2FL3TcZC5FZH6fHGhUIzHmRjFmJAWZhB%2Fm5FHpU2yCCUYgoI2N0QGlF4amoIp9V1Dhv8fMFNKxPcMv7%2FhVnD"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231370b48e0c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:29 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=hanqezq9%2FCcN0yotw4LZZ8TZanoBP0faeOaSll%2FaAgWcv4NXKuP8J2WDfkE19%2FT2PoEKEF7Kj2HZ0l%2BPjsDAGJwNh16TfBFY2pkEdDQew7YisMOMQ8VO5PBspt50gVDHJkhs"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231370f0cb7c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:30 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=LX9q1Jn2jT8FXjHz2UBa5zT8vYCMjKf%2FlYA3TN2jKE3H0%2FY4VV%2FZbVMmbmbwfQ4u7DERncOWayFr2HznqCpm9XVH9i53ulrrlpK9BL%2FKT5lF4XPADA6IxmVBy%2Bj8aiFV5Ii4"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313712f882c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:30 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=2EetLOmD82AR04WBx%2Ft1ucNVG5adDY3fffhXtFKdfz42H1jLFg%2BxFeOtVD1KgX55vWgzUjaFH46N7%2BkR8cMgjrfGCnAwKA%2BAGGRa7Pl5ttfXkodgGQrEp1cVQ5qpKT0XtUd3"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313716cc15c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:31 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=6aUXpyrnx%2Ft4Jik8nu1mpknq%2BZIPc9RbD%2BCzo5VT2O8XYuksbjqIwPBew7ZFy%2FghQwaxizCNGp6lIAR8H3bIbfx4RucJZLA4TiqytAd2vM1Zr6Rv07ru4MFnV6%2FgLDldBSFA"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231371aafd8c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:32 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=1UB1AgJsRSU5P5VrLADWEBgzqaSHNCzbrZmTiRr5VRyEtGyVfo2MhOpobWwx8wkYC0s%2BrIB0nsoESpl12McoYKqmNfIJoT2fzxQ1TdjNtDcouOErYbo0GV65L2Qsc0taTR4F"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231371e8ba2c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:32 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=nbCk%2F%2F4aeSs9%2FRV5Tn4qp7gV%2FTnPbq9IrDvYN2rQTTL5ltZ9%2Bs5%2B2JJYb0Q6RTV4eiSna8B52EHT5wLANrLcgUPvTzntdkMYmLGSa7FQaqPrfSmi3tG5wVuEqX1SGc6MluGc"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.82it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137226f4bc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:33 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=A4uGilQxZP05msgmwZ20G330V5wfcA1d6xQLICY8iz5sLPuzVW69hD2%2FsFOzrSpg4%2Bwm%2FFaPq8TynLdEiJUrM2PGHQbTw4Npgsex8VkECTtCbdD9Li6FwAW5NKOFI4ggsX6z"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.82it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.82it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137264acac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:34 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=ZNZXCceEzeAwuJ0bWhzTPySRNlmU3ggAoRED2wDBQsLd4CpVvqBXIibGewtIMS8R98W1M%2Bd%2BFebnNBuyevhC7C9PcdOQ9X2ul6rLrVWnD3N6lhSFFGRmiMD5GLx%2FxKs0NyQi"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.82it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.82it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231372a2e4ec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:34 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=2aV2UFFvocbaN5lJ4560O1IzW3A3OvsiBX%2BPNMee83BerGe1tDBzYiQ3pBWQ3Kgmx4NvbIUu4jEBSGp5X5uXmDrKLs%2BlqLHjwRuzedQGDvc2NzxHza5iaJV8ACo4QeBqs5Uv"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.82it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.82it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231372df9bcc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:35 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=kKDdTlgEBgnEN56YmNi%2Bx88%2BciOyFyhF0Mz82AF4lXdVMG1KDF5GxXN%2Fb3mS76u8ghEiuqWnRYVg4hkZg9LNbA2vCLYJIgH%2BPAG9KwIb84qOTuAuVyDvzJBz9spOs%2ByCkC8D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.82it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.82it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313731dd61c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:35 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=I0OxxA49KP6KpWrtVWyYBuCqnTC0NLsJec0tDMHB3eYiqMQrnsPfvLux0nJGBdiWg6dEBgMj7LBfGUIGq3B9XzL2fcd2ujrMw54klOhLCDeI2aQCyLydElEkVsNpUcWdT4FO"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.82it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.82it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313735b912c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:36 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=dzkupF%2FhMAQ4YisrLS7%2B9cWm3hRnkPdGQTyC8Zbu8lJy9vJCIY7sc8qn8q3QzdaKgl09RsE4%2B1o1Lcd078B2YS1g4vID3hP4JHaB%2FILfvaxlrshSWvpv%2BiL6lsrhqGc4gyvR"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee
+  response:
+    content: "{\"id\":\"ppn6sy3bpvltiyk3hsquxuvmee\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of two rainbow unicorns\"},\"logs\":\"Using seed: 45437\\nPrompt:
+      A chariot pulled by a team of two rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:09,
+      \ 4.92it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.88it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.87it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.85it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.83it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.83it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.83it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.83it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.83it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.82it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.82it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.82it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.82it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.82it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.81it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.82it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.81it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.81it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.82it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.82it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.82it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:09\\u003c00:00,  4.82it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:10\\u003c00:00,  4.82it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.82it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.82it/s]\\n\",\"output\":[\"https://replicate.delivery/pbxt/aUXdtMj38cKzANKnzXKjexZZFccFe8jWKiPqRiSSoANrwb2RA/out-0.png\"],\"error\":null,\"status\":\"succeeded\",\"created_at\":\"2023-11-08T22:22:15.305024Z\",\"started_at\":\"2023-11-08T22:22:23.852217Z\",\"completed_at\":\"2023-11-08T22:22:36.758863Z\",\"metrics\":{\"predict_time\":12.906646},\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/ppn6sy3bpvltiyk3hsquxuvmee\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137398cd5c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:37 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=j1xA9oO5MI8ZGeXORxl3RK2o%2BZF1RdqOHr1k%2FBU6zjQZBCLU2NinJamyW0yQWUx%2BCyTOLy0IIeBuarik325p%2B3SfhYx0LRYpoCOXl8SAe%2Ff4T6WpvI63XMaeHTI2G9%2FJR%2F6Z"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"input": {"prompt": "A chariot pulled by a team of four rainbow unicorns"},
+      "version": "39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '155'
+      content-type:
+      - application/json
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: POST
+    uri: https://api.replicate.com/v1/predictions
+  response:
+    content: '{"id":"jrj4p3dbqlgs373oia75kvzeaq","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of four rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:37.242367482Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel","get":"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231373a3d94c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '446'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:37 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=cB0b7mL8eK57mSCWafQy6nAAhpwKSrTw6sJUtdZUtrrpA6nx%2BV2Y%2Fa6lXnffSfvc17gnoqSBMEh8FYDJTZ2nDosCIZb%2FefjGjdDA%2FBQ6QH70BpNtv8fY6d6XBBDamAc8nl2T"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      ratelimit-remaining:
+      - '599'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 201
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/models/stability-ai/sdxl/versions/39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b
+  response:
+    content: '{"id":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","created_at":"2023-11-06T23:13:07.906314Z","cog_version":"0.8.6","openapi_schema":{"info":{"title":"Cog","version":"0.1.0"},"paths":{"/":{"get":{"summary":"Root","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Root  Get"}}},"description":"Successful Response"}},"operationId":"root__get"}},"/shutdown":{"post":{"summary":"Start
+      Shutdown","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Start Shutdown Shutdown Post"}}},"description":"Successful Response"}},"operationId":"start_shutdown_shutdown_post"}},"/predictions":{"post":{"summary":"Predict","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model","operationId":"predict_predictions_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionRequest"}}}}}},"/health-check":{"get":{"summary":"Healthcheck","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Healthcheck Health Check Get"}}},"description":"Successful Response"}},"operationId":"healthcheck_health_check_get"}},"/predictions/{prediction_id}":{"put":{"summary":"Predict
+      Idempotent","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true},{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model (idempotent creation).","operationId":"predict_idempotent_predictions__prediction_id__put","requestBody":{"content":{"application/json":{"schema":{"allOf":[{"$ref":"#/components/schemas/PredictionRequest"}],"title":"Prediction
+      Request"}}},"required":true}}},"/predictions/{prediction_id}/cancel":{"post":{"summary":"Cancel","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Cancel Predictions  Prediction Id  Cancel Post"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true}],"description":"Cancel a running prediction","operationId":"cancel_predictions__prediction_id__cancel_post"}}},"openapi":"3.0.2","components":{"schemas":{"Input":{"type":"object","title":"Input","properties":{"mask":{"type":"string","title":"Mask","format":"uri","x-order":3,"description":"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted."},"seed":{"type":"integer","title":"Seed","x-order":11,"description":"Random
+      seed. Leave blank to randomize the seed"},"image":{"type":"string","title":"Image","format":"uri","x-order":2,"description":"Input
+      image for img2img or inpaint mode"},"width":{"type":"integer","title":"Width","default":1024,"x-order":4,"description":"Width
+      of output image"},"height":{"type":"integer","title":"Height","default":1024,"x-order":5,"description":"Height
+      of output image"},"prompt":{"type":"string","title":"Prompt","default":"An astronaut
+      riding a rainbow unicorn","x-order":0,"description":"Input prompt"},"refine":{"allOf":[{"$ref":"#/components/schemas/refine"}],"default":"no_refiner","x-order":12,"description":"Which
+      refine style to use"},"scheduler":{"allOf":[{"$ref":"#/components/schemas/scheduler"}],"default":"K_EULER","x-order":7,"description":"scheduler"},"lora_scale":{"type":"number","title":"Lora
+      Scale","default":0.6,"maximum":1,"minimum":0,"x-order":16,"description":"LoRA
+      additive scale. Only applicable on trained models."},"num_outputs":{"type":"integer","title":"Num
+      Outputs","default":1,"maximum":4,"minimum":1,"x-order":6,"description":"Number
+      of images to output."},"refine_steps":{"type":"integer","title":"Refine Steps","x-order":14,"description":"For
+      base_image_refiner, the number of steps to refine, defaults to num_inference_steps"},"guidance_scale":{"type":"number","title":"Guidance
+      Scale","default":7.5,"maximum":50,"minimum":1,"x-order":9,"description":"Scale
+      for classifier-free guidance"},"apply_watermark":{"type":"boolean","title":"Apply
+      Watermark","default":true,"x-order":15,"description":"Applies a watermark to
+      enable determining if an image is generated in downstream applications. If you
+      have other provisions for generating or deploying images safely, you can use
+      this to disable watermarking."},"high_noise_frac":{"type":"number","title":"High
+      Noise Frac","default":0.8,"maximum":1,"minimum":0,"x-order":13,"description":"For
+      expert_ensemble_refiner, the fraction of noise to use"},"negative_prompt":{"type":"string","title":"Negative
+      Prompt","default":"","x-order":1,"description":"Input Negative Prompt"},"prompt_strength":{"type":"number","title":"Prompt
+      Strength","default":0.8,"maximum":1,"minimum":0,"x-order":10,"description":"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image"},"replicate_weights":{"type":"string","title":"Replicate
+      Weights","x-order":17,"description":"Replicate LoRA weights to use. Leave blank
+      to use the default weights."},"num_inference_steps":{"type":"integer","title":"Num
+      Inference Steps","default":50,"maximum":500,"minimum":1,"x-order":8,"description":"Number
+      of denoising steps"},"disable_safety_checker":{"type":"boolean","title":"Disable
+      Safety Checker","default":false,"x-order":18,"description":"Disable safety checker
+      for generated images. This feature is only available through the API. See https://replicate.com/docs/how-does-replicate-work#safety"}}},"Output":{"type":"array","items":{"type":"string","format":"uri"},"title":"Output"},"Status":{"enum":["starting","processing","succeeded","canceled","failed"],"type":"string","title":"Status","description":"An
+      enumeration."},"refine":{"enum":["no_refiner","expert_ensemble_refiner","base_image_refiner"],"type":"string","title":"refine","description":"An
+      enumeration."},"scheduler":{"enum":["DDIM","DPMSolverMultistep","HeunDiscrete","KarrasDPM","K_EULER_ANCESTRAL","K_EULER","PNDM"],"type":"string","title":"scheduler","description":"An
+      enumeration."},"WebhookEvent":{"enum":["start","output","logs","completed"],"type":"string","title":"WebhookEvent","description":"An
+      enumeration."},"ValidationError":{"type":"object","title":"ValidationError","required":["loc","msg","type"],"properties":{"loc":{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error
+      Type"}}},"PredictionRequest":{"type":"object","title":"PredictionRequest","properties":{"id":{"type":"string","title":"Id"},"input":{"$ref":"#/components/schemas/Input"},"webhook":{"type":"string","title":"Webhook","format":"uri","maxLength":65536,"minLength":1},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"output_file_prefix":{"type":"string","title":"Output
+      File Prefix"},"webhook_events_filter":{"type":"array","items":{"$ref":"#/components/schemas/WebhookEvent"},"default":["start","output","logs","completed"]}}},"PredictionResponse":{"type":"object","title":"PredictionResponse","properties":{"id":{"type":"string","title":"Id"},"logs":{"type":"string","title":"Logs","default":""},"error":{"type":"string","title":"Error"},"input":{"$ref":"#/components/schemas/Input"},"output":{"$ref":"#/components/schemas/Output"},"status":{"$ref":"#/components/schemas/Status"},"metrics":{"type":"object","title":"Metrics"},"version":{"type":"string","title":"Version"},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"started_at":{"type":"string","title":"Started At","format":"date-time"},"completed_at":{"type":"string","title":"Completed
+      At","format":"date-time"}}},"HTTPValidationError":{"type":"object","title":"HTTPValidationError","properties":{"detail":{"type":"array","items":{"$ref":"#/components/schemas/ValidationError"},"title":"Detail"}}}}}}}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231373b5edcc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:37 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      content-security-policy-report-only:
+      - 'img-src ''report-sample'' ''self'' data: https://replicate.delivery https://*.replicate.delivery
+        https://*.githubusercontent.com https://github.com; style-src ''report-sample''
+        ''self'' ''unsafe-inline''; font-src ''report-sample'' ''self'' data:; connect-src
+        ''report-sample'' ''self'' https://replicate.delivery https://*.replicate.delivery
+        https://*.rudderlabs.com https://*.rudderstack.com https://*.mux.com https://*.sentry.io;
+        default-src ''self''; script-src ''report-sample'' ''self'' https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js;
+        worker-src ''none''; media-src ''report-sample'' ''self'' https://replicate.delivery
+        https://*.replicate.delivery https://*.mux.com https://*.sentry.io; report-uri'
+      cross-origin-opener-policy:
+      - same-origin
+      nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      ratelimit-remaining:
+      - '2999'
+      ratelimit-reset:
+      - '1'
+      referrer-policy:
+      - same-origin
+      report-to:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1699482157&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=4%2FiiCka9%2BLuDwvZrF44HRPPoa8gUoVDJXn%2B%2FLT4cAW4%3D"}]}'
+      reporting-endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1699482157&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=4%2FiiCka9%2BLuDwvZrF44HRPPoa8gUoVDJXn%2B%2FLT4cAW4%3D
+      vary:
+      - Cookie, origin
+      via:
+      - 1.1 vegur, 1.1 google
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231373f4c16c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:38 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=kr%2B%2FZH1VPUc0v7jqhVyqa9IWnPr6sdAmLJmOF2JBOzArLmLfWTq1ocpTexqLsEVJgpmQx911QXVwhBEE7TGPOerU1Ni8d11OI%2B0M05s54n7MgMIzPaseyJOAWBe92oJq%2BAFB"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137433811c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:38 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=nGlPDHcs0YK0CWell0v%2F%2FBMA2gLPa1j0xSruj%2FljMpNXBv%2B6zrTCegN64c2RUJWoW9isiZslyrDUntAZ5zSCKRgdRqT0oR%2B7%2BcHp9GkTBkXFiXQNr%2BbL6QR9T%2Fhp3JbVuRLZ"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137470c0ac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:39 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=JYQhSQx4HWraWXyut54LJRiiVxnVR23NJOEqSFcoEbHm4va0VNx2HmmXv6rmrWaUW7IhclJTalDeygb4W9WXSXA9wwzBMTap83bHvSo1grfVlaqZ9Btq1VqIEFqHSyKSqa1u"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231374ad80fc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:39 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=a4ruZSgRespi68Mkfzdu4H5N8nvgF%2BSMsi6J0olURVoGXih8YnHpdFnmpJ3I1wfKGu%2Fr2RIDVUnubUAXAOylzIhR1NYLQPdhI32T0Xy0yi4NwyElW4zWa9ymYx55AT4JYE3j"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231374ebbf0c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:40 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=TiToe2D3f%2FIU%2BgxVqs3%2BgQRe3FIpb1p4ZzaT2MIJsWGfWcizLterqB%2FmgwMpOGbRIdvv5qCTvaCmU921FecMFp8tEvWXTREyAWniVkdfZiQo2uB2AKZydEFHvSekAHftpWHA"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137528fa8c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:41 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=mciuaJtnaiISh4ZZH%2FgQQugI2Z%2BPyNYnBidSagngXhIgHNEckHBBavh5PqMmREW6kIBAqYRF4e3SuOeuBY8AYp5ky%2BHpohdR%2Fl99XNvRegiy7HDJ0UefrvVoc%2BMxFCkA1ujU"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137566b64c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:41 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=7TLK5WHLOsHWngcYXBDu6l7t%2BJEUeV2OiFLy5BJgqwnWcLuEuKt0nwLynWkCHy5GOF65EIX1cPpwpH0GISYZ2T1yINDgSuvSKbJsbRaQp8dg1AtuLmK6stMwUFGARkCumxjl"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231375a3f1bc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:42 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=J%2FyvujVFlszb1dswZiXfDvyDeQuqy61rltmNZdj99xA1uQne0RuzDnaY3z7feFDZWBLT7JPUD9tv9QX6rQ6DPCQ7yE%2BAnX%2F5xT7HG1NZd4aQoLjpTn0sRZI4v7skJJMCjZwW"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231375e1b2ac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:42 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=08sjsquTA7Z2RkRTulT8lK2qtSDnUsNX5nDD8M6iFEmv9%2Bv8ckpNtgdQ8%2FGbqjjcCsdzBkNya5lX%2BT2Lq6B9oR4xplIJ%2FxBxpQjimrcKQt6f4GqcozXeCXKNVT4jwOMiv%2Fr8"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313761fed4c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:43 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=yqIDdfQZK3psXWn0p9pXS%2ByCEXdi%2BvqG%2Bc6Ty%2BpmvDrNA%2Fi2US9xEsNCORmS43PWsVEi71C303x%2FWHaKrUsrQK1BlVMjsQ7T%2FJOdGS%2Ba87tiMe31ZF6FA2i7hL4H%2BKrsfBTO"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313765fb6cc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:44 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3h2P6ii4ZBUfmLenDtWjHnOAnCZIYgg1i37AfoJoqmDKoTgRI9nWS5LSlRYnckSRoQ8v2cHfG4kaKTA42fcR%2Fax1XHShgkCvBYiQLIqEcTEuP9TqdIDVMtt%2BeUl7hP3WAeJs"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313769df89c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:44 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=onA%2FZxYGdfWCqFcLQM6Wyh0qMz6DyCCsC3Iv1Yutqj7SNMe0qtPbRSyFdzg9iNFKEpGx7gz8oKVJvWXdFN9w8M85YLCNzZJdVPDFbWVy2GbDQchBQh7FcOFVK1fJL34s1LWd"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231376dbbe9c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:45 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=d%2B6%2BsSdvglT%2FBysfAbk9Pcm6xDHd3%2FXFoxDfP6uPgpXsYAgVMsh6cep0LKTofAurZBWk%2FX%2FDgTY7lrj6DSH%2FjrGMn%2BIBDpPd9e%2FCSKyPgeg%2FVtAuDK%2B12Ys1b7Z1TfMYEzWc"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137719f6cc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:46 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=gTS0JLhJY067WhXNtxFqa4mdnwbq1WL7RTo3yhIdKUdsXIIYoT5x%2B%2FTix3PBICQKYAhSyRRIlwg7FpVdQoLD7rVN%2BHZqO2KjA2qUviht%2F%2FnoO9WUqBaFN5X1vhG73r7jtL%2BS"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.82it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.82it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137757b6cc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:46 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=vjRdj7dWuJVvllbflKkV4D7nWzrCU8dm0DYp8ZEFPAGk8gaVCbolC%2BhElSEDYCaXPMfMOUU3d3OFKnq6PKXQJ7bEMmcCprnIsY1agxMsmkJlTVY%2F%2Bm9bUIRzQmHti7msRjkt"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.82it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.82it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.80it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137795f0ac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:47 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=F2zsBjUL0lQyVFi5apKQLqMI7gT%2Bov%2BJo52STeuW3O4%2BiOSP01sjjjpHs1%2F1KaUo0%2B7eFKzW%2FHuqQJt1Kvu36Ipw2jE2p%2BQLtzY8c5JL7A34WD8KzXAmdqCHZGm6XBaaNxed"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.82it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.82it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.80it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.75it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.77it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.78it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231377d2b3dc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:47 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=pFquTQc%2F5iP%2BZ8Tpjq%2F6eagn9ZRgliAMN19IYRCT3%2B%2F%2FrPf1HRtpWn3ip9rTh%2Bgbg5fVzU0563bAWWe%2BGazsHEXUAzl2ImHDcWR1Z39nHs7cHQsrO73m8SrvU4oCFu%2F%2FgL%2Fd"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.82it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.82it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.80it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.75it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.77it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.78it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137811f4dc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:48 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=sxKk7cvvZEGEPVu0eMJ%2FknvKIDd6juWYaMBo4pgWKbwWZYNzuIrfZ2vFnl5l9Fu1FH9jeRPJIh2RnLq%2FEDeqJItknjEZMQvARm6rNQZ2YBIr6JRsQNnsjK8%2Bts0BoGbxrwit"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.82it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.82it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.80it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.75it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.77it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.78it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313784fba0c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:49 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=VpDzd2NtL6%2BoSYzJIPNzyfkHsTZn%2FrQaOfVmU2AKZrhKQW9tJujTUpQldkukHGAj8hQtXt5KVVsQCSbps9%2B1HdiEuIM0Kn6CD%2FAoZautJEnOnMyfBpboi0s9uO%2BVJr5OISpA"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.82it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.82it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.80it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.75it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.77it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.78it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313788df9dc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:49 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=usZEOuCbeN2IW1CFGV85fare4pfENW5eJjkAKV5wPvkUNjKD1db0P3SH8lGVm1edlgRLZWDrNk7sptbRQzHSFrdLh0mw3lkLCwVSJ4puvm3IK0LLLTYGrF2Q4JoD%2FpG5OEwz"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq
+  response:
+    content: "{\"id\":\"jrj4p3dbqlgs373oia75kvzeaq\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of four rainbow unicorns\"},\"logs\":\"Using seed:
+      52722\\nPrompt: A chariot pulled by a team of four rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.90it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.86it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.84it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.83it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.80it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.81it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.81it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.81it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.82it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:06,  4.80it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.80it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.80it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.80it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.81it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.82it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.82it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.82it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.82it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.82it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.82it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.82it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.82it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.80it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.75it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.77it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.78it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:09\\u003c00:00,  4.80it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:10\\u003c00:00,  4.80it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.80it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.81it/s]\\n\",\"output\":[\"https://replicate.delivery/pbxt/cWmLJH3R15JEDNyc6lER64deaZHRNSi1W5CsCJluDne5wb2RA/out-0.png\"],\"error\":null,\"status\":\"succeeded\",\"created_at\":\"2023-11-08T22:22:37.242367Z\",\"started_at\":\"2023-11-08T22:22:37.276093Z\",\"completed_at\":\"2023-11-08T22:22:50.195436Z\",\"metrics\":{\"predict_time\":12.919343},\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/jrj4p3dbqlgs373oia75kvzeaq\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231378cbbb6c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:50 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=DiY2sVZ%2F6WdgWysFvzh4qWL11dTZ3RQizAP2WnhqjpP27psi%2B8Yg5ejko1k3aB7%2BXBjNx2jKIWIO0wbj2UEc1hOzlC5QaU%2BGv1mBpw2PdMikDyA%2FJeeOP7yPu5%2BOeuxdsjBJ"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"input": {"prompt": "A chariot pulled by a team of six rainbow unicorns"},
+      "version": "39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '154'
+      content-type:
+      - application/json
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: POST
+    uri: https://api.replicate.com/v1/predictions
+  response:
+    content: '{"id":"7lh23g3bqljwbc5dkrtxsftc7y","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of six rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:22:50.562749247Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel","get":"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231378d7c5bc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '445'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:50 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=1EuhEwl5wHlFsIc5YJ%2FxxTO0chGpB3r28A%2FXvvGzGyFZKM2%2BLivFfa1WoMDg0KVwpVWom3DfFLghEe8b66pcpqj7yI1gUtGqhfOCadYqy0rNz%2FdxSei8z%2BV%2FVuqnBhurEMVK"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      ratelimit-remaining:
+      - '599'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 201
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/models/stability-ai/sdxl/versions/39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b
+  response:
+    content: '{"id":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","created_at":"2023-11-06T23:13:07.906314Z","cog_version":"0.8.6","openapi_schema":{"info":{"title":"Cog","version":"0.1.0"},"paths":{"/":{"get":{"summary":"Root","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Root  Get"}}},"description":"Successful Response"}},"operationId":"root__get"}},"/shutdown":{"post":{"summary":"Start
+      Shutdown","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Start Shutdown Shutdown Post"}}},"description":"Successful Response"}},"operationId":"start_shutdown_shutdown_post"}},"/predictions":{"post":{"summary":"Predict","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model","operationId":"predict_predictions_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionRequest"}}}}}},"/health-check":{"get":{"summary":"Healthcheck","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Healthcheck Health Check Get"}}},"description":"Successful Response"}},"operationId":"healthcheck_health_check_get"}},"/predictions/{prediction_id}":{"put":{"summary":"Predict
+      Idempotent","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true},{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model (idempotent creation).","operationId":"predict_idempotent_predictions__prediction_id__put","requestBody":{"content":{"application/json":{"schema":{"allOf":[{"$ref":"#/components/schemas/PredictionRequest"}],"title":"Prediction
+      Request"}}},"required":true}}},"/predictions/{prediction_id}/cancel":{"post":{"summary":"Cancel","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Cancel Predictions  Prediction Id  Cancel Post"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true}],"description":"Cancel a running prediction","operationId":"cancel_predictions__prediction_id__cancel_post"}}},"openapi":"3.0.2","components":{"schemas":{"Input":{"type":"object","title":"Input","properties":{"mask":{"type":"string","title":"Mask","format":"uri","x-order":3,"description":"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted."},"seed":{"type":"integer","title":"Seed","x-order":11,"description":"Random
+      seed. Leave blank to randomize the seed"},"image":{"type":"string","title":"Image","format":"uri","x-order":2,"description":"Input
+      image for img2img or inpaint mode"},"width":{"type":"integer","title":"Width","default":1024,"x-order":4,"description":"Width
+      of output image"},"height":{"type":"integer","title":"Height","default":1024,"x-order":5,"description":"Height
+      of output image"},"prompt":{"type":"string","title":"Prompt","default":"An astronaut
+      riding a rainbow unicorn","x-order":0,"description":"Input prompt"},"refine":{"allOf":[{"$ref":"#/components/schemas/refine"}],"default":"no_refiner","x-order":12,"description":"Which
+      refine style to use"},"scheduler":{"allOf":[{"$ref":"#/components/schemas/scheduler"}],"default":"K_EULER","x-order":7,"description":"scheduler"},"lora_scale":{"type":"number","title":"Lora
+      Scale","default":0.6,"maximum":1,"minimum":0,"x-order":16,"description":"LoRA
+      additive scale. Only applicable on trained models."},"num_outputs":{"type":"integer","title":"Num
+      Outputs","default":1,"maximum":4,"minimum":1,"x-order":6,"description":"Number
+      of images to output."},"refine_steps":{"type":"integer","title":"Refine Steps","x-order":14,"description":"For
+      base_image_refiner, the number of steps to refine, defaults to num_inference_steps"},"guidance_scale":{"type":"number","title":"Guidance
+      Scale","default":7.5,"maximum":50,"minimum":1,"x-order":9,"description":"Scale
+      for classifier-free guidance"},"apply_watermark":{"type":"boolean","title":"Apply
+      Watermark","default":true,"x-order":15,"description":"Applies a watermark to
+      enable determining if an image is generated in downstream applications. If you
+      have other provisions for generating or deploying images safely, you can use
+      this to disable watermarking."},"high_noise_frac":{"type":"number","title":"High
+      Noise Frac","default":0.8,"maximum":1,"minimum":0,"x-order":13,"description":"For
+      expert_ensemble_refiner, the fraction of noise to use"},"negative_prompt":{"type":"string","title":"Negative
+      Prompt","default":"","x-order":1,"description":"Input Negative Prompt"},"prompt_strength":{"type":"number","title":"Prompt
+      Strength","default":0.8,"maximum":1,"minimum":0,"x-order":10,"description":"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image"},"replicate_weights":{"type":"string","title":"Replicate
+      Weights","x-order":17,"description":"Replicate LoRA weights to use. Leave blank
+      to use the default weights."},"num_inference_steps":{"type":"integer","title":"Num
+      Inference Steps","default":50,"maximum":500,"minimum":1,"x-order":8,"description":"Number
+      of denoising steps"},"disable_safety_checker":{"type":"boolean","title":"Disable
+      Safety Checker","default":false,"x-order":18,"description":"Disable safety checker
+      for generated images. This feature is only available through the API. See https://replicate.com/docs/how-does-replicate-work#safety"}}},"Output":{"type":"array","items":{"type":"string","format":"uri"},"title":"Output"},"Status":{"enum":["starting","processing","succeeded","canceled","failed"],"type":"string","title":"Status","description":"An
+      enumeration."},"refine":{"enum":["no_refiner","expert_ensemble_refiner","base_image_refiner"],"type":"string","title":"refine","description":"An
+      enumeration."},"scheduler":{"enum":["DDIM","DPMSolverMultistep","HeunDiscrete","KarrasDPM","K_EULER_ANCESTRAL","K_EULER","PNDM"],"type":"string","title":"scheduler","description":"An
+      enumeration."},"WebhookEvent":{"enum":["start","output","logs","completed"],"type":"string","title":"WebhookEvent","description":"An
+      enumeration."},"ValidationError":{"type":"object","title":"ValidationError","required":["loc","msg","type"],"properties":{"loc":{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error
+      Type"}}},"PredictionRequest":{"type":"object","title":"PredictionRequest","properties":{"id":{"type":"string","title":"Id"},"input":{"$ref":"#/components/schemas/Input"},"webhook":{"type":"string","title":"Webhook","format":"uri","maxLength":65536,"minLength":1},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"output_file_prefix":{"type":"string","title":"Output
+      File Prefix"},"webhook_events_filter":{"type":"array","items":{"$ref":"#/components/schemas/WebhookEvent"},"default":["start","output","logs","completed"]}}},"PredictionResponse":{"type":"object","title":"PredictionResponse","properties":{"id":{"type":"string","title":"Id"},"logs":{"type":"string","title":"Logs","default":""},"error":{"type":"string","title":"Error"},"input":{"$ref":"#/components/schemas/Input"},"output":{"$ref":"#/components/schemas/Output"},"status":{"$ref":"#/components/schemas/Status"},"metrics":{"type":"object","title":"Metrics"},"version":{"type":"string","title":"Version"},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"started_at":{"type":"string","title":"Started At","format":"date-time"},"completed_at":{"type":"string","title":"Completed
+      At","format":"date-time"}}},"HTTPValidationError":{"type":"object","title":"HTTPValidationError","properties":{"detail":{"type":"array","items":{"$ref":"#/components/schemas/ValidationError"},"title":"Detail"}}}}}}}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231378e5d62c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:50 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      content-security-policy-report-only:
+      - 'img-src ''report-sample'' ''self'' data: https://replicate.delivery https://*.replicate.delivery
+        https://*.githubusercontent.com https://github.com; script-src ''report-sample''
+        ''self'' https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js; worker-src
+        ''none''; font-src ''report-sample'' ''self'' data:; default-src ''self'';
+        style-src ''report-sample'' ''self'' ''unsafe-inline''; media-src ''report-sample''
+        ''self'' https://replicate.delivery https://*.replicate.delivery https://*.mux.com
+        https://*.sentry.io; connect-src ''report-sample'' ''self'' https://replicate.delivery
+        https://*.replicate.delivery https://*.rudderlabs.com https://*.rudderstack.com
+        https://*.mux.com https://*.sentry.io; report-uri'
+      cross-origin-opener-policy:
+      - same-origin
+      nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      ratelimit-remaining:
+      - '2999'
+      ratelimit-reset:
+      - '1'
+      referrer-policy:
+      - same-origin
+      report-to:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1699482170&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=PyvZqRPZLJmt52YxZwGTbjYsQxZjp%2FuWgqPRfvMwWjY%3D"}]}'
+      reporting-endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1699482170&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=PyvZqRPZLJmt52YxZwGTbjYsQxZjp%2FuWgqPRfvMwWjY%3D
+      vary:
+      - Cookie, origin
+      via:
+      - 1.1 vegur, 1.1 google
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: '{"id":"7lh23g3bqljwbc5dkrtxsftc7y","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of six rainbow unicorns"},"logs":"","error":null,"status":"processing","created_at":"2023-11-08T22:22:50.562749Z","started_at":"2023-11-08T22:22:50.596672Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel","get":"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137924998c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:51 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=arSTvw4F0mgHSEnyA2ho9XFUM0aoNHT6a4WIypFeX7UFfGrjRQzDJi4vFnz8SXGGLyqq8P7QbxsX4XoDb4yMZxPkmEKScbh%2F3i%2F9MGiWZBvIa7ALCCfv0jVw4PUi3tphYndN"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137962daac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:51 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=mhOVBBwt3BCl8ybxLB9vi7vcW%2FPKj%2FBK8%2BnPLvOPjY5i0pMt%2BN9eDzMX4eUH5TL6BnPI%2F%2FtQCGxfOz%2FCy8lx4t7d6DzFZNf9LGfawhRVIGiahTbMIoEdhpS%2FJz3FVMm8qR2G"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231379a1a48c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:52 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=yciUS0dR3ZTitmRfdpNSgi6guoEdwS2k7zyE0Fr1Vs2w8hdFFwXxd4iL40ZTPb87bPifjwd%2FF8vhPLwj5yTwCE9CDr4bze43UGFBo6Mcw9O727BNziwENgvaOJuh5%2BMf7TO3"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231379e0e24c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:53 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=j2ES5JHw88%2BtqWRVbVyxnKeRNlqfwTpPzOyBHYMinY03TedApdQQ5HFzHTgN0lt%2FP0gdvQuKMyUnw51Ds%2Fw1x%2FWn%2BUb9WWvk3e2nmuqSaWgzCtGL6Uh4Hn7HQxTQMFLpLW0N"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137a1d9aac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:53 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=bOi%2FeTDTU4VAqcdcogPOi%2FkmUTjGAZ01cUrdcgI0cdrNcS7esUdvMKwcojcYCUgAySI8vXCHXbM5LmK4CmWW2kehBruDwfOPfkYgVbyjNj30bInleYceKZnaOq%2BavKbUESpB"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137a5cd40c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:54 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=8Y4w9cg7WRuosCRT7wCgHgBqBR9LCj%2F%2F9%2Fd2IonWC0NK71g2hL18I9fN6DMXMxbYsQNlouVKovlWm9euo5DOAs1GdPbRm6xThUpEgobRToGlor8Ri29NA59KlKzF5Cdpczis"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137a9a9a9c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:55 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=tsI9R52WbXOdWGeJK3b6I2SD8aTAxSCqIXN8czNEb%2ByU2aBnx%2B5MfmfcYMpAbGQze1cG6iuT1z6oWtFHS1ZR%2FamPe2IEZZxUqlDNO5VAS0IHZAxrMU8MdvlXJlnkGXH8wfoj"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137ad8e36c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:55 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=SKHGgDeQzmhvD%2B9AlM9glNpOL8ozntmjzkQnZQlVLxDoDRC82F78HytthN3IgJiU1C%2BJlozoN3grjvB1FYC6kg2vUh4vgcu8yUByr2UpRlDiyvXgHShQJfuRA2wO%2BwGn1QmK"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137b16a50c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:56 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=FdQpBHikQTYz%2FpN9TqM24eCwCjzDZ6AkD%2BpWZCU6YDSnQtzHP5yHT3nzPB1Mmh6P%2BonE0zsBb5lwVqEnzzdwZqO6DswuzPv4ev53JviJ3HDqrllb6zEHQ4hsGu3Zoxw4gy34"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137b54df7c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:56 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=nrs%2Fyqnwq%2BD%2FG98RzNiSHuf8b85P3oy3u%2FIncNybTT0cCO%2FpCHjABIEsk%2FdlrhzTqvBp7cP%2FMvfP1COdrz%2BJQrV9qm0MWmnCJ6%2BT%2FrH4p7575EqXQQ%2FWpacMX1icTS5Ip0a0"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137b929a2c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:57 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=b1D8RrgwyeYflGsg9I0vHbdXE6Y1XSABzfR168QiB51GFhpwh4VQv%2BqC9zNgMWNBch5Rq28zpdveX1pG21Wp3KnITSmZlvV60nQ4j7cwMveWnVnb40Mpqh9j8zC31U5PQqsu"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137bd0d64c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:58 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=z9Hkc2IAbbecPRjhjcutoCtIwscP5rfaGhwtXA%2BuJuSqpBV%2Bk38kkToo%2B%2FOUZCXh9CXYx0ufuph3RgLLgR9Qsfe0o7rbhzSBf%2FuJj08u07duq9IMxIL3g65hYsZ9ktdFk%2F8T"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137c0fa51c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:58 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=xnharOn0ICGvk16zEtmpCnHcIPYwQ27S9vZTxKnsR4z7sFBAnHVj%2FphZ0fyaRR%2BsSTS3hzPKvhUK9KjyUGIOImS8Uq9yW4diMjzLZTHtegmFGgSq%2FP5Yw6%2FQwEVv36RxEDkD"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137c4de59c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:22:59 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=yh%2Fi2upZWz5vXPFQS9Fb4xP2lD6xs%2FAvSCB7mgyhQRJwF%2FjPZsC15hckuc8PDcxpKBY2BF9%2FR0zefsZa5p1hnGHr29bxjikkVCTGfuA%2B%2BOoRYxOvHbpq1rrS%2Fsj%2FaWp0ycbS"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.80it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137c8ba5dc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:00 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=g%2B2TSTLofeV2qbgRO5Qn0tGh3q2mJd9LqnaIfGDfnDri87%2F1Hcp4QSEDMOYQXzsipdTXARNq8kQkURrVbt8N%2Fo2KvRJlkmIy2LHadFalx1xfclvFNoNOojwmHIvtu61%2FB7XL"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.80it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137ccad6cc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:00 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=0jWEbI%2BYt8Yj3TM5%2FtolFccOokXKmUJhGUoZ1ex%2Fe0Hr7qIh7H1L21V3r%2BPvxN2h7YZZ2vQ%2BSrWXcrPK%2FLxWjD5ZFdfVkL%2BERJBOVqj6wXc7cbCg7tsDPiJyufXYVjR8%2FVw3"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.80it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.81it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137d078ccc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:01 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=lBVjqRWbO%2BRz1TxaUxaBx8b6Resnq8b8cPSJQpDcHR0%2FN%2FJKTs00YPYOB7QDcwsM07zu%2Fhb8W0Toys4r0ZXyGi0hWc87YPf0zj2gydGD309SfSfy2bg1vz5YH4n6EYZbmY98"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.80it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.81it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137d45c86c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:01 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=iOkddxmxSPZP%2FlRVGHffiSY8EyI6zxbxixJcp1suqmJfLN%2F%2ByTpUFReIc9lRxFGjG1ZIQpWeJRZTq15ogOcdN98xUTFa5XnPIgC9i4QQbvjbVItu7mil3y0Y%2B1fabBmkThru"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.80it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.81it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137d83829c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:02 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=KePN9Q9ojmfokHziANCZ%2FFQLZXGhE%2F5HT4XHN4OtvWywQBs7wnARfaaajYaBL5GzMLaySsou3ru91DSgpnWNWLu58eweRMyK6IsD1vS2BinCfoSDnqB7KvLM2b6TSAzVXiDY"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.80it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.81it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.81it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137dc0badc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:03 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Iy5FIGYmt0%2FlOCZcxHYpN359KMH7Jp92TZt%2FjPpBrquVRkGYnZ8huem6%2BFR1O1NQ8zK8Cc2tXuup3Nsnko9Fx4QXQxn9bK9Lc7zdCCpyfWXpG6SzobSprCXlThubvfFVbZRW"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y
+  response:
+    content: "{\"id\":\"7lh23g3bqljwbc5dkrtxsftc7y\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of six rainbow unicorns\"},\"logs\":\"Using seed: 45927\\nPrompt:
+      A chariot pulled by a team of six rainbow unicorns\\ntxt2img mode\\n  0%|          |
+      0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         | 1/50 [00:00\\u003c00:10,
+      \ 4.89it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,  4.86it/s]\\n  6%|\u258C
+      \        | 3/50 [00:00\\u003c00:09,  4.85it/s]\\n  8%|\u258A         | 4/50
+      [00:00\\u003c00:09,  4.84it/s]\\n 10%|\u2588         | 5/50 [00:01\\u003c00:09,
+      \ 4.81it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:09,  4.81it/s]\\n
+      14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.81it/s]\\n 16%|\u2588\u258C
+      \       | 8/50 [00:01\\u003c00:08,  4.82it/s]\\n 18%|\u2588\u258A        | 9/50
+      [00:01\\u003c00:08,  4.82it/s]\\n 20%|\u2588\u2588        | 10/50 [00:02\\u003c00:08,
+      \ 4.80it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:08,  4.80it/s]\\n
+      24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.80it/s]\\n 26%|\u2588\u2588\u258C
+      \      | 13/50 [00:02\\u003c00:07,  4.81it/s]\\n 28%|\u2588\u2588\u258A       |
+      14/50 [00:02\\u003c00:07,  4.81it/s]\\n 30%|\u2588\u2588\u2588       | 15/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 32%|\u2588\u2588\u2588\u258F      | 16/50
+      [00:03\\u003c00:07,  4.81it/s]\\n 34%|\u2588\u2588\u2588\u258D      | 17/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 36%|\u2588\u2588\u2588\u258C      | 18/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 38%|\u2588\u2588\u2588\u258A      | 19/50
+      [00:03\\u003c00:06,  4.81it/s]\\n 40%|\u2588\u2588\u2588\u2588      | 20/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     | 21/50
+      [00:04\\u003c00:06,  4.81it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     | 22/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     | 23/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     | 24/50
+      [00:04\\u003c00:05,  4.81it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     | 25/50
+      [00:05\\u003c00:05,  4.80it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F    |
+      26/50 [00:05\\u003c00:04,  4.80it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.81it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.81it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:06\\u003c00:04,  4.81it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.81it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.81it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.81it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.81it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:07\\u003c00:03,  4.81it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.81it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.80it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.81it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.81it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:08\\u003c00:02,  4.81it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.80it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.81it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.81it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.81it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.82it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.81it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.82it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.81it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:09\\u003c00:00,  4.81it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:10\\u003c00:00,  4.81it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.81it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.81it/s]\\n\",\"output\":[\"https://replicate.delivery/pbxt/Q9zsJBibfekPgUeebEEkUDYieBCOqB6x9pN16f5eqEDWj4N7IA/out-0.png\"],\"error\":null,\"status\":\"succeeded\",\"created_at\":\"2023-11-08T22:22:50.562749Z\",\"started_at\":\"2023-11-08T22:22:50.596672Z\",\"completed_at\":\"2023-11-08T22:23:03.529653Z\",\"metrics\":{\"predict_time\":12.932981},\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/7lh23g3bqljwbc5dkrtxsftc7y\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137dfef18c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:03 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3yj77AQ4XRwHEL52L3XHLUcqGNhKC7SQH1KpTUePk0CpbZjRdMArG413t94QEWdVGS2zydTcAvP3LcmLnkzGuiPd30BcutnbJNZh8BS%2B4Tm3adouDYZTyS4AVCipiXCiOcdu"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"input": {"prompt": "A chariot pulled by a team of eight rainbow unicorns"},
+      "version": "39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '156'
+      content-type:
+      - application/json
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: POST
+    uri: https://api.replicate.com/v1/predictions
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137e0bfbac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '447'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:03 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=s3BH8S0pH6iU459p6IHisvAYhAhsZapwauELImpjhyOYoxeSH78orTFM83uIoaWv8VbR8TYYT7SpyFbnHuUu7PwJhTByasXI2aKmQ1H4iRoBeVzhnM6y%2BzcFEEEKf224XvSh"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      ratelimit-remaining:
+      - '599'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 201
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/models/stability-ai/sdxl/versions/39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b
+  response:
+    content: '{"id":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","created_at":"2023-11-06T23:13:07.906314Z","cog_version":"0.8.6","openapi_schema":{"info":{"title":"Cog","version":"0.1.0"},"paths":{"/":{"get":{"summary":"Root","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Root  Get"}}},"description":"Successful Response"}},"operationId":"root__get"}},"/shutdown":{"post":{"summary":"Start
+      Shutdown","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Start Shutdown Shutdown Post"}}},"description":"Successful Response"}},"operationId":"start_shutdown_shutdown_post"}},"/predictions":{"post":{"summary":"Predict","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model","operationId":"predict_predictions_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionRequest"}}}}}},"/health-check":{"get":{"summary":"Healthcheck","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Healthcheck Health Check Get"}}},"description":"Successful Response"}},"operationId":"healthcheck_health_check_get"}},"/predictions/{prediction_id}":{"put":{"summary":"Predict
+      Idempotent","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PredictionResponse"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true},{"in":"header","name":"prefer","schema":{"type":"string","title":"Prefer"},"required":false}],"description":"Run
+      a single prediction on the model (idempotent creation).","operationId":"predict_idempotent_predictions__prediction_id__put","requestBody":{"content":{"application/json":{"schema":{"allOf":[{"$ref":"#/components/schemas/PredictionRequest"}],"title":"Prediction
+      Request"}}},"required":true}}},"/predictions/{prediction_id}/cancel":{"post":{"summary":"Cancel","responses":{"200":{"content":{"application/json":{"schema":{"title":"Response
+      Cancel Predictions  Prediction Id  Cancel Post"}}},"description":"Successful
+      Response"},"422":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}},"description":"Validation
+      Error"}},"parameters":[{"in":"path","name":"prediction_id","schema":{"type":"string","title":"Prediction
+      ID"},"required":true}],"description":"Cancel a running prediction","operationId":"cancel_predictions__prediction_id__cancel_post"}}},"openapi":"3.0.2","components":{"schemas":{"Input":{"type":"object","title":"Input","properties":{"mask":{"type":"string","title":"Mask","format":"uri","x-order":3,"description":"Input
+      mask for inpaint mode. Black areas will be preserved, white areas will be inpainted."},"seed":{"type":"integer","title":"Seed","x-order":11,"description":"Random
+      seed. Leave blank to randomize the seed"},"image":{"type":"string","title":"Image","format":"uri","x-order":2,"description":"Input
+      image for img2img or inpaint mode"},"width":{"type":"integer","title":"Width","default":1024,"x-order":4,"description":"Width
+      of output image"},"height":{"type":"integer","title":"Height","default":1024,"x-order":5,"description":"Height
+      of output image"},"prompt":{"type":"string","title":"Prompt","default":"An astronaut
+      riding a rainbow unicorn","x-order":0,"description":"Input prompt"},"refine":{"allOf":[{"$ref":"#/components/schemas/refine"}],"default":"no_refiner","x-order":12,"description":"Which
+      refine style to use"},"scheduler":{"allOf":[{"$ref":"#/components/schemas/scheduler"}],"default":"K_EULER","x-order":7,"description":"scheduler"},"lora_scale":{"type":"number","title":"Lora
+      Scale","default":0.6,"maximum":1,"minimum":0,"x-order":16,"description":"LoRA
+      additive scale. Only applicable on trained models."},"num_outputs":{"type":"integer","title":"Num
+      Outputs","default":1,"maximum":4,"minimum":1,"x-order":6,"description":"Number
+      of images to output."},"refine_steps":{"type":"integer","title":"Refine Steps","x-order":14,"description":"For
+      base_image_refiner, the number of steps to refine, defaults to num_inference_steps"},"guidance_scale":{"type":"number","title":"Guidance
+      Scale","default":7.5,"maximum":50,"minimum":1,"x-order":9,"description":"Scale
+      for classifier-free guidance"},"apply_watermark":{"type":"boolean","title":"Apply
+      Watermark","default":true,"x-order":15,"description":"Applies a watermark to
+      enable determining if an image is generated in downstream applications. If you
+      have other provisions for generating or deploying images safely, you can use
+      this to disable watermarking."},"high_noise_frac":{"type":"number","title":"High
+      Noise Frac","default":0.8,"maximum":1,"minimum":0,"x-order":13,"description":"For
+      expert_ensemble_refiner, the fraction of noise to use"},"negative_prompt":{"type":"string","title":"Negative
+      Prompt","default":"","x-order":1,"description":"Input Negative Prompt"},"prompt_strength":{"type":"number","title":"Prompt
+      Strength","default":0.8,"maximum":1,"minimum":0,"x-order":10,"description":"Prompt
+      strength when using img2img / inpaint. 1.0 corresponds to full destruction of
+      information in image"},"replicate_weights":{"type":"string","title":"Replicate
+      Weights","x-order":17,"description":"Replicate LoRA weights to use. Leave blank
+      to use the default weights."},"num_inference_steps":{"type":"integer","title":"Num
+      Inference Steps","default":50,"maximum":500,"minimum":1,"x-order":8,"description":"Number
+      of denoising steps"},"disable_safety_checker":{"type":"boolean","title":"Disable
+      Safety Checker","default":false,"x-order":18,"description":"Disable safety checker
+      for generated images. This feature is only available through the API. See https://replicate.com/docs/how-does-replicate-work#safety"}}},"Output":{"type":"array","items":{"type":"string","format":"uri"},"title":"Output"},"Status":{"enum":["starting","processing","succeeded","canceled","failed"],"type":"string","title":"Status","description":"An
+      enumeration."},"refine":{"enum":["no_refiner","expert_ensemble_refiner","base_image_refiner"],"type":"string","title":"refine","description":"An
+      enumeration."},"scheduler":{"enum":["DDIM","DPMSolverMultistep","HeunDiscrete","KarrasDPM","K_EULER_ANCESTRAL","K_EULER","PNDM"],"type":"string","title":"scheduler","description":"An
+      enumeration."},"WebhookEvent":{"enum":["start","output","logs","completed"],"type":"string","title":"WebhookEvent","description":"An
+      enumeration."},"ValidationError":{"type":"object","title":"ValidationError","required":["loc","msg","type"],"properties":{"loc":{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error
+      Type"}}},"PredictionRequest":{"type":"object","title":"PredictionRequest","properties":{"id":{"type":"string","title":"Id"},"input":{"$ref":"#/components/schemas/Input"},"webhook":{"type":"string","title":"Webhook","format":"uri","maxLength":65536,"minLength":1},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"output_file_prefix":{"type":"string","title":"Output
+      File Prefix"},"webhook_events_filter":{"type":"array","items":{"$ref":"#/components/schemas/WebhookEvent"},"default":["start","output","logs","completed"]}}},"PredictionResponse":{"type":"object","title":"PredictionResponse","properties":{"id":{"type":"string","title":"Id"},"logs":{"type":"string","title":"Logs","default":""},"error":{"type":"string","title":"Error"},"input":{"$ref":"#/components/schemas/Input"},"output":{"$ref":"#/components/schemas/Output"},"status":{"$ref":"#/components/schemas/Status"},"metrics":{"type":"object","title":"Metrics"},"version":{"type":"string","title":"Version"},"created_at":{"type":"string","title":"Created
+      At","format":"date-time"},"started_at":{"type":"string","title":"Started At","format":"date-time"},"completed_at":{"type":"string","title":"Completed
+      At","format":"date-time"}}},"HTTPValidationError":{"type":"object","title":"HTTPValidationError","properties":{"detail":{"type":"array","items":{"$ref":"#/components/schemas/ValidationError"},"title":"Detail"}}}}}}}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137e1c8aec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:04 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      content-security-policy-report-only:
+      - 'connect-src ''report-sample'' ''self'' https://replicate.delivery https://*.replicate.delivery
+        https://*.rudderlabs.com https://*.rudderstack.com https://*.mux.com https://*.sentry.io;
+        font-src ''report-sample'' ''self'' data:; style-src ''report-sample'' ''self''
+        ''unsafe-inline''; script-src ''report-sample'' ''self'' https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js;
+        img-src ''report-sample'' ''self'' data: https://replicate.delivery https://*.replicate.delivery
+        https://*.githubusercontent.com https://github.com; media-src ''report-sample''
+        ''self'' https://replicate.delivery https://*.replicate.delivery https://*.mux.com
+        https://*.sentry.io; worker-src ''none''; default-src ''self''; report-uri'
+      cross-origin-opener-policy:
+      - same-origin
+      nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      ratelimit-remaining:
+      - '2999'
+      ratelimit-reset:
+      - '1'
+      referrer-policy:
+      - same-origin
+      report-to:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1699482184&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=h%2BhGo3UnAFBe1rJ0zxWMZC2Ynm7wxNve0gnVyr6k6JI%3D"}]}'
+      reporting-endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1699482184&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=h%2BhGo3UnAFBe1rJ0zxWMZC2Ynm7wxNve0gnVyr6k6JI%3D
+      vary:
+      - Cookie, origin
+      via:
+      - 1.1 vegur, 1.1 google
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137e5bcb5c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:04 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=5nV2Wd63zo%2BvVDHpBqqfGU2wnGYRYp4WcPqVEWIrqUFsMHHDplooN83uL5jgJnrn3%2FK%2B2hIqLHRdQE%2Frd5f6TFvrBLxJHwZJor6PKzl82NTl9d91JSzDffQaT5E%2BwOdMYfra"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137e99869c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:05 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=sv0V3Jvit8O6aP3NBCn8COQyTv0xkEYlkC%2FImspBFt%2BfPE1G1miQ4kLm%2FaksokqCYolcAR8XkVRWeNeY3PgdbeelWKUxKjT26f%2BNTcRf%2Fsg%2Fc6ISOY4kYnthDTEILBZ17use"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137ed7c05c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:05 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=jossDlEYeZkrA2%2Bmfz9s0MhGpCoGzzNnKy1RaAR40sThvdSHv1xZXaG7hE8K0N2BRtIWLtaDfLfKOPSvhpDcuqHNWXoq3UUXTtC1mOmDFUllA9yr%2FHo99nZLtENutCygkxjZ"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137f15881c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:06 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=WqRiJmXeE%2FTF9uWtpqZJi6EqMgG9x9Ake%2B6HoqdRuVTAAf0ek5Xz7YU4rRjumPRiRMF57aIOlMaUWSUpHy30GA7FFoI2ra6Nqrg%2FlgnPUvdxZE3ZqghN81a4NoocBdAVt2S2"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137f52c3bc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:07 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=8PiVUfUcjtySuci58GqYBVkT21ujKNXhLXumGCk0HeArEgK9Y%2By9p64N0o2y7m3fBt9ETbJIXvHQ6uugqt%2Bk2kqtCmRGFmEu3%2BY5POgcqjU7GhbLuZ98Ew6w9xxj%2BId4Lg%2Bs"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137f8f83cc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:07 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Nw4HOCNLddVICOGPr6oeALR3QlV79VFEakuDWNzlQbDGQUFZVl5iyne6SigFxzRTxVsUFb29AfiOrABVNg9j%2FlmHBzTangCLDgDxi4x%2FShTzDu3webXuLwAZQpycdfZFHbZ%2B"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"starting","created_at":"2023-11-08T22:23:03.871442506Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823137fcdc31c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:08 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=5n8KAAP6%2BheW1BgDQpxUmi9PRovCOAVrkCrgPhpVt%2B6SWpUpgz2JDg9lWNGzgRB3B6vumceAItrLgXbNFc89aKzllx8hLFmvldij4q7c3wmPICOuiv86SFdpcB1sDFnxH%2BqW"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: '{"id":"6wkzy7dbkn3lkwslgdrjqtcjf4","version":"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b","input":{"prompt":"A
+      chariot pulled by a team of eight rainbow unicorns"},"logs":"","error":null,"status":"processing","created_at":"2023-11-08T22:23:03.871442Z","started_at":"2023-11-08T22:23:08.587986Z","urls":{"cancel":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel","get":"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4"}}
+
+      '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313800cfb9c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:09 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=l2yUQLYYjmRBKtfoTbHg3yQS%2Fh3zQfh6TXx1%2Bq8dVEdhBzEYVKtHlc7tK1BVvcOUGNNQgRQDore51Jpm7%2FzD5hB%2BQPI9XIvsEZGu7jag69UahY8JhTHmXToiQVu4c59irppf"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313804abfcc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:09 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Z4Goqjtsnd3TIXFOS4ZGG2%2B5zjR1JzRzic%2FQqrrjV11I%2B4AU08VzxScLioX%2BxxPMI9Ww4GO9YA4o67qzV5AS6sK5qZYYdCBggXFlruFCqZf%2FQLqQxAsSk5VsNeZwjn9jwWhS"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138088800c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:10 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=4X6Alq60d3QXix6q%2FsiPyqNsm9XaJaLmSN4DAkSIth1%2F2JuQj%2F%2FSOn2P1Ll%2FRoBVmMhF2lcm%2Blz8AcN%2B7emswXO0JTb3BnPg2F%2FjTgDTDKhFYC01e5Hcaz1Tno1n4RXsXsuZ"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231380c5c68c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:10 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=ELN6dZbralDfTNH4fL%2BVQEnme6ZgFLhwgYk2EAW8Uu4GYcOf2W70eJxCCB19Daou%2BZlY2Xbfzk2ugonzRZef5N7mCh%2F2NCCYSgYAC5M%2FpFWCZd%2FsfS5zLMrPvAY%2FCgENLa7Y"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138102fd3c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:11 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=%2FcVSLuQaNiqCJ9%2Bma1rqnSasBjBSKe116x6o5iQzXzW1TrEBR2a5x97WOFn9t%2FHuBbNtlQcfOYDAgDCJbNqqGMjCwIAg6E%2FW4FpyRyKpwnaLS1jtq%2BxPrViRYNvCmfEt8het"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138140b7fc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:12 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=C9z4ajDGCTDRjb1PFKoIFxmQFaNnBGQKkvwgPcYYhGjMnAkQ0116kiqlPLHgIkS16fYab5ODQB3fva2nr%2FWHYeUnX2iL%2BOgUzlHevw%2BcKHzOJTCFg7LAhFAWiuURhsQBnlVU"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313817ef3dc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:12 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=QD9io85DUkkgtbf%2B%2BOdVgq0XoGCLmRGL84rs2nBZdBX%2B1ImIZEx3Bz7I0DwC%2FdJfb2dMKy8RvsVt0OCR6GmeOmxowWJnOuzTuJk9BVltyc2t5315oYCNuL3CMwr4Wvmk8ON6"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231381bcc56c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:13 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=1QAXg7f9UFFHDEn%2BX%2FQEqAg7QcyN0sybc%2FCm6H8nTKi5fnJe4dbPeVfd75R0pI0SPaDjW7WQJirlmnaDVbH7wt7vGa1jhyaQS41Q4RirNfD27X3YZdijhw34qGtYXeC6vHI1"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231381fa804c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:13 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=uBCTYP5TMiPLh5VhePJ9%2BCS5k5Ykb9hVlF4u83FbrxvT%2BcmShIMx9sWqIz9TNNcYLhyPaw40sRjd6r97QtI0MfnKhF1ouRlszxFFR1gvdAVsTbPu0HocnFA0SBEsB0Vuihn6"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138238bebc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:14 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=60Ql08xPcwGD1%2Fnv2LZosOlwDLHQOaji2uzKXgTigdxQX9YnD7L4PapZnb9L7Ha1sdrE2IvZSoAxiBQiO1zgXoomrXacPeEJMCxJncfY37%2B%2BpOViHl1%2Fx9cV04yuSHhRs6IR"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138276fa1c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:15 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=dtV%2B55awbaC6KA1GkHQhv4o88nMUNOol53e8VTIUMaE9J%2BpkErgo67eaHBCPtPJEXYjvViwTerxcJ%2FzUknyNJfOm8lOXVFnR9pAuT4vASXgcyCvsVEnNPC79Nr4Gw%2BJAlTWX"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231382b5bcec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:15 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=HxXGUz0inh%2Bf6Pz5fUTEzLIbQM%2B9AHx9dDwFiVxuCdU%2BcqdIhRsWAHDl2OzQ1%2FIt56QqvK1Y65W6FMjcMCNIMNA9DriOR91GIHxgt3IHD1mzu9Q70SmV9d96WdnUbYjmwyf5"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231382f485fc6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:16 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=6l8OxKcoWTke7StJ0vyYgipXFNYtEpFbh0UQrwHRBPW%2BD1%2BGdl65z0icoyGLaE6S6RYsNUEpFdBmPcYg%2BQZIasipBFkYiFUNR9wJUdD%2FOloBqUhmaxuRJB%2BZ2x6jwnqWG1Zc"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138331c15c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:17 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=TLJ08qPGv4cn51QjHp4nlLu4cglnKGg2BjOs4M3IKCxrU9UdW8%2BTHpFcY39Pq4M7dftu0XD6Vho6HyTmo35YbogHulvfes5LPEog05m7%2Fg7q75FrBedPsTl%2BMJFIY01mnVBH"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313836fff9c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:17 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=UE%2Bb5IR%2F7HzLmO2IvVbtiLO9cHhjyd7v8lZDxuxEx5ydJcKchQcUFE8u2Ou4OHIEF8fJOjtHBsbqkEJKAZXNCQhfmmH5b9aSo0vBJgh6yt%2Fjk3C4Kfd7bDnvmLaz8R0xb2Oy"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.88it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.88it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.88it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231383aebe9c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:18 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=KBpq0%2F6bSWmpI7YI%2B2vEbi9Tq4bRd6dKELpIu50%2B3pv2TvIQx%2FOrTzJ0T01Wp9TPA4Pjg873KZJq1uElIORcbmUxrDO3NH9M5WQrnjBuKbw40vAW%2BZGrqUI3inPTJ234CHlk"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.88it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.88it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.88it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.87it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.87it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.85it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231383ecf9ec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:18 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=sxQB7BjJF7NW7ShD81Jk93YmIVzsEfos2OFh3%2BP2NUC5%2FdmH4%2B03Uk0dnAKbp4Fd4HOnr4FSiuoC5%2FikvDP3wcYuBUzD1BsDiEZDjyiQvOrBdBQsCuuBHdVcvUQp9qdlwkK1"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.88it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.88it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.88it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.87it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.87it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.85it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 82313842abcac6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:19 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=VOHkJuWBvFHKOA%2BFltoFJcZ301X1lOjHCBtAJdWm8Ssp92ph2BEGgWEZP8jTrkLA5q0nuMf4zxTqiOjgig%2FWa92FD6etFgUd2wdJA6UBlVdyIeyRBAhPn74Ixuhf27qPaMWy"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.88it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.88it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.88it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.87it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.87it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.85it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138468fe6c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:20 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=83nMtHAksAPz590u4Lfe1gwaemD8MgBrfoKVqlCXXl5lH6KgLAn0zoxkfCyDRiksxbVk1wf1jltLbXUT7P7br1oNCLtHW9mrnaV4aQ9Vr0%2FHD0k7OSNLrleYlDq2Vo4ospOK"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.88it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.88it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.88it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.87it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.87it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.85it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231384a6ccec6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:20 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=MhdLcM6%2FAV5GSKPTwG5OvbipYKJc6OZ9En8FYWC46BNYaqost0EfRydK8RTxvfmiJugSAZAhTxruRcJ3Qc21QaxXSb%2F3dMnHdqt4dVW6KuTL0YnlGKCIRwtpDaalZj6eD24g"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.88it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.88it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.88it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.87it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.87it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.85it/s]\\n\",\"error\":null,\"status\":\"processing\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8231384e4889c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:21 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=b%2FfJOUM1CQvnBwIsVcFwHVYm0MdyHjcC3J371NlyCb%2F3k%2F44cCwsNz%2FLBCa%2FP2VUewMhSJzNwjYlbDPksayaBLab09VBfW4Bu4Fpr7Wk%2Ff9ZNPfsavg1VHpZ5DwtHLnwrPtJ"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.replicate.com
+      user-agent:
+      - replicate-python/0.15.6
+    method: GET
+    uri: https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4
+  response:
+    content: "{\"id\":\"6wkzy7dbkn3lkwslgdrjqtcjf4\",\"version\":\"39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b\",\"input\":{\"prompt\":\"A
+      chariot pulled by a team of eight rainbow unicorns\"},\"logs\":\"Using seed:
+      12846\\nPrompt: A chariot pulled by a team of eight rainbow unicorns\\ntxt2img
+      mode\\n  0%|          | 0/50 [00:00\\u003c?, ?it/s]\\n  2%|\u258F         |
+      1/50 [00:00\\u003c00:09,  4.96it/s]\\n  4%|\u258D         | 2/50 [00:00\\u003c00:09,
+      \ 4.94it/s]\\n  6%|\u258C         | 3/50 [00:00\\u003c00:09,  4.93it/s]\\n  8%|\u258A
+      \        | 4/50 [00:00\\u003c00:09,  4.92it/s]\\n 10%|\u2588         | 5/50
+      [00:01\\u003c00:09,  4.88it/s]\\n 12%|\u2588\u258F        | 6/50 [00:01\\u003c00:08,
+      \ 4.89it/s]\\n 14%|\u2588\u258D        | 7/50 [00:01\\u003c00:08,  4.90it/s]\\n
+      16%|\u2588\u258C        | 8/50 [00:01\\u003c00:08,  4.90it/s]\\n 18%|\u2588\u258A
+      \       | 9/50 [00:01\\u003c00:08,  4.89it/s]\\n 20%|\u2588\u2588        | 10/50
+      [00:02\\u003c00:08,  4.88it/s]\\n 22%|\u2588\u2588\u258F       | 11/50 [00:02\\u003c00:07,
+      \ 4.88it/s]\\n 24%|\u2588\u2588\u258D       | 12/50 [00:02\\u003c00:07,  4.89it/s]\\n
+      26%|\u2588\u2588\u258C       | 13/50 [00:02\\u003c00:07,  4.89it/s]\\n 28%|\u2588\u2588\u258A
+      \      | 14/50 [00:02\\u003c00:07,  4.89it/s]\\n 30%|\u2588\u2588\u2588       |
+      15/50 [00:03\\u003c00:07,  4.89it/s]\\n 32%|\u2588\u2588\u2588\u258F      |
+      16/50 [00:03\\u003c00:06,  4.89it/s]\\n 34%|\u2588\u2588\u2588\u258D      |
+      17/50 [00:03\\u003c00:06,  4.90it/s]\\n 36%|\u2588\u2588\u2588\u258C      |
+      18/50 [00:03\\u003c00:06,  4.89it/s]\\n 38%|\u2588\u2588\u2588\u258A      |
+      19/50 [00:03\\u003c00:06,  4.89it/s]\\n 40%|\u2588\u2588\u2588\u2588      |
+      20/50 [00:04\\u003c00:06,  4.88it/s]\\n 42%|\u2588\u2588\u2588\u2588\u258F     |
+      21/50 [00:04\\u003c00:05,  4.88it/s]\\n 44%|\u2588\u2588\u2588\u2588\u258D     |
+      22/50 [00:04\\u003c00:05,  4.88it/s]\\n 46%|\u2588\u2588\u2588\u2588\u258C     |
+      23/50 [00:04\\u003c00:05,  4.88it/s]\\n 48%|\u2588\u2588\u2588\u2588\u258A     |
+      24/50 [00:04\\u003c00:05,  4.88it/s]\\n 50%|\u2588\u2588\u2588\u2588\u2588     |
+      25/50 [00:05\\u003c00:05,  4.88it/s]\\n 52%|\u2588\u2588\u2588\u2588\u2588\u258F
+      \   | 26/50 [00:05\\u003c00:04,  4.88it/s]\\n 54%|\u2588\u2588\u2588\u2588\u2588\u258D
+      \   | 27/50 [00:05\\u003c00:04,  4.88it/s]\\n 56%|\u2588\u2588\u2588\u2588\u2588\u258C
+      \   | 28/50 [00:05\\u003c00:04,  4.89it/s]\\n 58%|\u2588\u2588\u2588\u2588\u2588\u258A
+      \   | 29/50 [00:05\\u003c00:04,  4.88it/s]\\n 60%|\u2588\u2588\u2588\u2588\u2588\u2588
+      \   | 30/50 [00:06\\u003c00:04,  4.88it/s]\\n 62%|\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \  | 31/50 [00:06\\u003c00:03,  4.88it/s]\\n 64%|\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \  | 32/50 [00:06\\u003c00:03,  4.88it/s]\\n 66%|\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \  | 33/50 [00:06\\u003c00:03,  4.88it/s]\\n 68%|\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \  | 34/50 [00:06\\u003c00:03,  4.88it/s]\\n 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \  | 35/50 [00:07\\u003c00:03,  4.88it/s]\\n 72%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      \ | 36/50 [00:07\\u003c00:02,  4.88it/s]\\n 74%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      \ | 37/50 [00:07\\u003c00:02,  4.88it/s]\\n 76%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      \ | 38/50 [00:07\\u003c00:02,  4.88it/s]\\n 78%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      \ | 39/50 [00:07\\u003c00:02,  4.88it/s]\\n 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      \ | 40/50 [00:08\\u003c00:02,  4.88it/s]\\n 82%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F
+      | 41/50 [00:08\\u003c00:01,  4.88it/s]\\n 84%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D
+      | 42/50 [00:08\\u003c00:01,  4.88it/s]\\n 86%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C
+      | 43/50 [00:08\\u003c00:01,  4.88it/s]\\n 88%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A
+      | 44/50 [00:09\\u003c00:01,  4.88it/s]\\n 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588
+      | 45/50 [00:09\\u003c00:01,  4.87it/s]\\n 92%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258F|
+      46/50 [00:09\\u003c00:00,  4.87it/s]\\n 94%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258D|
+      47/50 [00:09\\u003c00:00,  4.85it/s]\\n 96%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258C|
+      48/50 [00:09\\u003c00:00,  4.85it/s]\\n 98%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258A|
+      49/50 [00:10\\u003c00:00,  4.86it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.86it/s]\\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588|
+      50/50 [00:10\\u003c00:00,  4.88it/s]\\n\",\"output\":[\"https://replicate.delivery/pbxt/JRyK1ykmUT7lLhM6nAMKx9MlJZPrkiBhxy78jIEPyUCW8mdE/out-0.png\"],\"error\":null,\"status\":\"succeeded\",\"created_at\":\"2023-11-08T22:23:03.871442Z\",\"started_at\":\"2023-11-08T22:23:08.587986Z\",\"completed_at\":\"2023-11-08T22:23:21.45132Z\",\"metrics\":{\"predict_time\":12.863334},\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/6wkzy7dbkn3lkwslgdrjqtcjf4\"}}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 823138521c30c6c5-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 22:23:22 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=wMOScwNRMuRtutjxy%2B6dDiIGpNlRcPzd1HRC%2FHONsWciYitzJt5CvCqbfrQiQG%2BZIekfX%2Bb2GLa0EBYztvSyCRCEeufwM4B1DGlrM7mmjTVFOwTkJ%2BQq5lSjdOccyOXOWE7K"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000
+      Transfer-Encoding:
+      - chunked
+      ratelimit-remaining:
+      - '59999'
+      ratelimit-reset:
+      - '1'
+      via:
+      - 1.1 google
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ import respx
 
 @pytest.mark.asyncio
 async def test_authorization_when_setting_environ_after_import():
-    import replicate  # pylint disable=import-outside-toplevel
+    import replicate
 
     router = respx.Router()
     router.route(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,11 +3,24 @@ from unittest import mock
 
 import httpx
 import pytest
+import respx
 
 
 @pytest.mark.asyncio
 async def test_authorization_when_setting_environ_after_import():
-    import replicate
+    import replicate  # pylint disable=import-outside-toplevel
+
+    router = respx.Router()
+    router.route(
+        method="GET",
+        url="https://api.replicate.com/",
+        headers={"Authorization": "Token test-set-after-import"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={},
+        )
+    )
 
     token = "test-set-after-import"  # noqa: S105
 
@@ -15,6 +28,6 @@ async def test_authorization_when_setting_environ_after_import():
         os.environ,
         {"REPLICATE_API_TOKEN": token},
     ):
-        client: httpx.Client = replicate.default_client._client
-        assert "Authorization" in client.headers
-        assert client.headers["Authorization"] == f"Token {token}"
+        client = replicate.Client(transport=httpx.MockTransport(router.handler))
+        resp = client._request("GET", "/")
+        assert resp.status_code == 200

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -5,14 +5,18 @@ import replicate
 
 @pytest.mark.vcr("collections-list.yaml")
 @pytest.mark.asyncio
-async def test_collections_list():
-    page = replicate.collections.list()
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_models_get(async_flag):
+    if async_flag:
+        page = await replicate.collections.async_list()
+    else:
+        page = replicate.collections.list()
 
     assert page.next is None
     assert page.previous is None
 
     found = False
-    for collection in page:
+    for collection in page.results:
         if collection.slug == "text-to-image":
             found = True
             break
@@ -22,8 +26,12 @@ async def test_collections_list():
 
 @pytest.mark.vcr("collections-get.yaml")
 @pytest.mark.asyncio
-async def test_collections_get():
-    collection = replicate.collections.get("text-to-image")
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_collections_get(async_flag):
+    if async_flag:
+        collection = await replicate.collections.async_get("text-to-image")
+    else:
+        collection = replicate.collections.get("text-to-image")
 
     assert collection.slug == "text-to-image"
     assert collection.name == "Text to image"
@@ -31,7 +39,7 @@ async def test_collections_get():
     assert len(collection.models) > 0
 
     found = False
-    for model in collection:
+    for model in collection.models:
         if model.name == "stable-diffusion":
             found = True
             break

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -5,8 +5,12 @@ import replicate
 
 @pytest.mark.vcr("hardware-list.yaml")
 @pytest.mark.asyncio
-async def test_hardware_list(mock_replicate_api_token):
-    hardware = replicate.hardware.list()
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_hardware_list(async_flag):
+    if async_flag:
+        hardware = await replicate.hardware.async_list()
+    else:
+        hardware = replicate.hardware.list()
 
     assert hardware is not None
     assert isinstance(hardware, list)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,23 +5,34 @@ import replicate
 
 @pytest.mark.vcr("models-get.yaml")
 @pytest.mark.asyncio
-async def test_models_get(mock_replicate_api_token):
-    sdxl = replicate.models.get("stability-ai/sdxl")
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_models_get(async_flag):
+    if async_flag:
+        sdxl = await replicate.models.async_get("stability-ai/sdxl")
+    else:
+        sdxl = replicate.models.get("stability-ai/sdxl")
 
     assert sdxl is not None
     assert sdxl.owner == "stability-ai"
     assert sdxl.name == "sdxl"
     assert sdxl.visibility == "public"
 
-    empty = replicate.models.get("mattt/empty")
+    if async_flag:
+        empty = await replicate.models.async_get("mattt/empty")
+    else:
+        empty = replicate.models.get("mattt/empty")
 
     assert empty.default_example is None
 
 
 @pytest.mark.vcr("models-list.yaml")
 @pytest.mark.asyncio
-async def test_models_list(mock_replicate_api_token):
-    models = replicate.models.list()
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_models_list(async_flag):
+    if async_flag:
+        models = await replicate.models.async_list()
+    else:
+        models = replicate.models.list()
 
     assert len(models) > 0
     assert models[0].owner is not None
@@ -31,26 +42,43 @@ async def test_models_list(mock_replicate_api_token):
 
 @pytest.mark.vcr("models-list.yaml")
 @pytest.mark.asyncio
-async def test_models_list_pagination(mock_replicate_api_token):
-    page1 = replicate.models.list()
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_models_list_pagination(async_flag):
+    if async_flag:
+        page1 = await replicate.models.async_list()
+    else:
+        page1 = replicate.models.list()
     assert len(page1) > 0
     assert page1.next is not None
 
-    page2 = replicate.models.list(cursor=page1.next)
+    if async_flag:
+        page2 = await replicate.models.async_list(cursor=page1.next)
+    else:
+        page2 = replicate.models.list(cursor=page1.next)
     assert len(page2) > 0
     assert page2.previous is not None
 
 
 @pytest.mark.vcr("models-create.yaml")
 @pytest.mark.asyncio
-async def test_models_create(mock_replicate_api_token):
-    model = replicate.models.create(
-        owner="test",
-        name="python-example",
-        visibility="private",
-        hardware="cpu",
-        description="An example model",
-    )
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_models_create(async_flag):
+    if async_flag:
+        model = await replicate.models.async_create(
+            owner="test",
+            name="python-example",
+            visibility="private",
+            hardware="cpu",
+            description="An example model",
+        )
+    else:
+        model = replicate.models.create(
+            owner="test",
+            name="python-example",
+            visibility="private",
+            hardware="cpu",
+            description="An example model",
+        )
 
     assert model.owner == "test"
     assert model.name == "python-example"
@@ -59,13 +87,22 @@ async def test_models_create(mock_replicate_api_token):
 
 @pytest.mark.vcr("models-create.yaml")
 @pytest.mark.asyncio
-async def test_models_create_with_positional_arguments(mock_replicate_api_token):
-    model = replicate.models.create(
-        "test",
-        "python-example",
-        visibility="private",
-        hardware="cpu",
-    )
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_models_create_with_positional_arguments(async_flag):
+    if async_flag:
+        model = await replicate.models.async_create(
+            "test",
+            "python-example",
+            visibility="private",
+            hardware="cpu",
+        )
+    else:
+        model = replicate.models.create(
+            "test",
+            "python-example",
+            visibility="private",
+            hardware="cpu",
+        )
 
     assert model.owner == "test"
     assert model.name == "python-example"

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -23,7 +23,7 @@ async def test_predictions_create(mock_replicate_api_token):
     )
 
     assert prediction.id is not None
-    assert prediction.version == version
+    assert prediction.version == version.id
     assert prediction.status == "starting"
 
 
@@ -81,7 +81,7 @@ async def test_predictions_stream(mock_replicate_api_token):
     )
 
     assert prediction.id is not None
-    assert prediction.version == version
+    assert prediction.version == version.id
     assert prediction.status == "starting"
     assert prediction.urls["stream"] is not None
 

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -38,6 +38,35 @@ async def test_predictions_create(async_flag):
     assert prediction.status == "starting"
 
 
+@pytest.mark.vcr("predictions-create.yaml")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_predictions_create_with_positional_argument(async_flag):
+    version = "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
+
+    input = {
+        "prompt": "a studio photo of a rainbow colored corgi",
+        "width": 512,
+        "height": 512,
+        "seed": 42069,
+    }
+
+    if async_flag:
+        prediction = await replicate.predictions.async_create(
+            version,
+            input,
+        )
+    else:
+        prediction = replicate.predictions.create(
+            version,
+            input,
+        )
+
+    assert prediction.id is not None
+    assert prediction.version == version
+    assert prediction.status == "starting"
+
+
 @pytest.mark.vcr("predictions-get.yaml")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("async_flag", [True, False])

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -5,7 +5,8 @@ import replicate
 
 @pytest.mark.vcr("predictions-create.yaml")
 @pytest.mark.asyncio
-async def test_predictions_create(mock_replicate_api_token):
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_predictions_create(async_flag):
     input = {
         "prompt": "a studio photo of a rainbow colored corgi",
         "width": 512,
@@ -13,14 +14,24 @@ async def test_predictions_create(mock_replicate_api_token):
         "seed": 42069,
     }
 
-    model = replicate.models.get("stability-ai/sdxl")
-    version = model.versions.get(
-        "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
-    )
-    prediction = replicate.predictions.create(
-        version=version,
-        input=input,
-    )
+    if async_flag:
+        model = await replicate.models.async_get("stability-ai/sdxl")
+        version = await model.versions.async_get(
+            "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
+        )
+        prediction = await replicate.predictions.async_create(
+            version=version,
+            input=input,
+        )
+    else:
+        model = replicate.models.get("stability-ai/sdxl")
+        version = model.versions.get(
+            "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
+        )
+        prediction = replicate.predictions.create(
+            version=version,
+            input=input,
+        )
 
     assert prediction.id is not None
     assert prediction.version == version.id
@@ -29,17 +40,22 @@ async def test_predictions_create(mock_replicate_api_token):
 
 @pytest.mark.vcr("predictions-get.yaml")
 @pytest.mark.asyncio
-async def test_predictions_get(mock_replicate_api_token):
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_predictions_get(async_flag):
     id = "vgcm4plb7tgzlyznry5d5jkgvu"
 
-    prediction = replicate.predictions.get(id)
+    if async_flag:
+        prediction = await replicate.predictions.async_get(id)
+    else:
+        prediction = replicate.predictions.get(id)
 
     assert prediction.id == id
 
 
 @pytest.mark.vcr("predictions-cancel.yaml")
 @pytest.mark.asyncio
-async def test_predictions_cancel(mock_replicate_api_token):
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_predictions_cancel(async_flag):
     input = {
         "prompt": "a studio photo of a rainbow colored corgi",
         "width": 512,
@@ -47,14 +63,24 @@ async def test_predictions_cancel(mock_replicate_api_token):
         "seed": 42069,
     }
 
-    model = replicate.models.get("stability-ai/sdxl")
-    version = model.versions.get(
-        "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
-    )
-    prediction = replicate.predictions.create(
-        version=version,
-        input=input,
-    )
+    if async_flag:
+        model = await replicate.models.async_get("stability-ai/sdxl")
+        version = await model.versions.async_get(
+            "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
+        )
+        prediction = await replicate.predictions.async_create(
+            version=version,
+            input=input,
+        )
+    else:
+        model = replicate.models.get("stability-ai/sdxl")
+        version = model.versions.get(
+            "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
+        )
+        prediction = replicate.predictions.create(
+            version=version,
+            input=input,
+        )
 
     # id = prediction.id
     assert prediction.status == "starting"
@@ -65,20 +91,32 @@ async def test_predictions_cancel(mock_replicate_api_token):
 
 @pytest.mark.vcr("predictions-stream.yaml")
 @pytest.mark.asyncio
-async def test_predictions_stream(mock_replicate_api_token):
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_predictions_stream(async_flag):
     input = {
         "prompt": "write a sonnet about camelids",
     }
 
-    model = replicate.models.get("meta/llama-2-70b-chat")
-    version = model.versions.get(
-        "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
-    )
-    prediction = replicate.predictions.create(
-        version=version,
-        input=input,
-        stream=True,
-    )
+    if async_flag:
+        model = await replicate.models.async_get("meta/llama-2-70b-chat")
+        version = await model.versions.async_get(
+            "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
+        )
+        prediction = await replicate.predictions.async_create(
+            version=version,
+            input=input,
+            stream=True,
+        )
+    else:
+        model = replicate.models.get("meta/llama-2-70b-chat")
+        version = model.versions.get(
+            "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
+        )
+        prediction = replicate.predictions.create(
+            version=version,
+            input=input,
+            stream=True,
+        )
 
     assert prediction.id is not None
     assert prediction.version == version.id

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -13,8 +13,9 @@ from replicate.exceptions import ReplicateError
 @pytest.mark.vcr("run.yaml")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("async_flag", [True, False])
-async def test_run(async_flag):
-    replicate.default_client.poll_interval = 0.001
+async def test_run(async_flag, record_mode):
+    if record_mode == "none":
+        replicate.default_client.poll_interval = 0.001
 
     version = "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
 
@@ -47,8 +48,9 @@ async def test_run(async_flag):
 @pytest.mark.skipif(
     sys.version_info < (3, 11), reason="asyncio.TaskGroup requires Python 3.11"
 )
-async def test_run_concurrently(mock_replicate_api_token):
-    replicate.default_client.poll_interval = 0.001
+async def test_run_concurrently(mock_replicate_api_token, record_mode):
+    if record_mode == "none":
+        replicate.default_client.poll_interval = 0.001
 
     # https://replicate.com/stability-ai/sdxl
     model_version = "stability-ai/sdxl:39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"
@@ -171,6 +173,7 @@ async def test_run_version_with_invalid_cog_version(mock_replicate_api_token):
     client = Client(
         api_token="test-token", transport=httpx.MockTransport(router.handler)
     )
+    client.poll_interval = 0.001
 
     output = client.run(
         "test/example:invalid",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import httpx
 import pytest
@@ -43,6 +44,9 @@ async def test_run(async_flag):
 
 @pytest.mark.vcr("run-concurrently.yaml")
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="asyncio.TaskGroup requires Python 3.11"
+)
 async def test_run_concurrently(mock_replicate_api_token):
     replicate.default_client.poll_interval = 0.001
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -9,7 +9,8 @@ from replicate.exceptions import ReplicateError
 
 @pytest.mark.vcr("run.yaml")
 @pytest.mark.asyncio
-async def test_run(mock_replicate_api_token):
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_run(async_flag):
     replicate.default_client.poll_interval = 0.001
 
     version = "a00d0b7dcbb9c3fbb34ba87d2d5b46c56969c84a628bf778a7fdaec30b1b99c5"
@@ -21,10 +22,16 @@ async def test_run(mock_replicate_api_token):
         "seed": 42069,
     }
 
-    output = replicate.run(
-        f"stability-ai/sdxl:{version}",
-        input=input,
-    )
+    if async_flag:
+        output = await replicate.async_run(
+            f"stability-ai/sdxl:{version}",
+            input=input,
+        )
+    else:
+        output = replicate.run(
+            f"stability-ai/sdxl:{version}",
+            input=input,
+        )
 
     assert output is not None
     assert isinstance(output, list)


### PR DESCRIPTION
This PR adds support for async operations to the Replicate client. Namespace operations like `predictions.list` and `models.create` now have async variants with the `async_` prefix (`predictions.async_list` and `models.async_create`). 

Here's an example of what that looks like in practice:

```python
import replicate

model = await replicate.models.async_get("stability-ai/sdxl")

input = {
  "prompt": "A chariot pulled by a team of rainbow unicorns, driven by an astronaut, dramatic lighting",
}

output = await replicate.async_run(f"stability-ai/sdxl:{model.latest_version.id}", input)
```

<details>

<summary>Output</summary>

<img src="https://github.com/replicate/replicate-python/assets/7659/6927f8b4-5f92-495d-a87c-135f31aa1847"/>


</details>

One of the most common questions I hear is how to run a bunch of predictions in parallel. The async functionality provided by this PR makes it really straightforward:

```python
import asyncio
import replicate

# https://replicate.com/stability-ai/sdxl
model_version = "stability-ai/sdxl:39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"
prompts = [
    f"A chariot pulled by a team of {count} rainbow unicorns"
    for count in ["two", "four", "six", "eight"]
]

async with asyncio.TaskGroup() as tg:
    tasks = [
        tg.create_task(replicate.async_run(model_version, input={"prompt": prompt}))
        for prompt in prompts
    ]

results = await asyncio.gather(*tasks)
print(results)
```

Under the hood, `Client` manages an `httpx.Client` and an `httpx.AsyncClient`, which handle calls to `_request` and `_async_request`, respectively. Both are created lazily, so API consumers using only sync or only async functionality won't be affected by functionality they aren't using.

Implementation-wise, sync and async variants have separate code paths. This creates nontrivial amounts of duplication, but its benefits to clarity and performance justify those costs. For instance, it'd have been nice if the sync variant were implemented as a blocking call to the async variant, but that would require starting an event loop, which has additional overhead and causes problems if done within an existing event loop.

Alternative to https://github.com/replicate/replicate-python/pull/76
Resolves https://github.com/replicate/replicate-python/issues/145
Resolves https://github.com/replicate/replicate-python/issues/107
Resolves https://github.com/replicate/replicate-python/issues/74