### PR TITLE
Add missing typing_extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,12 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Replicate, Inc." }]
 requires-python = ">=3.8"
-dependencies = ["packaging", "pydantic>1", "httpx>=0.21.0,<1"]
+dependencies = [
+    "httpx>=0.21.0,<1",
+    "packaging",
+    "pydantic>1",
+    "typing_extensions>=4.5.0",
+]
 optional-dependencies = { dev = [
     "mypy",
     "pylint",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -82,6 +82,7 @@ typing-extensions==4.7.1
     #   mypy
     #   pydantic
     #   pydantic-core
+    #   replicate (pyproject.toml)
 vcrpy==5.1.0
     # via pytest-recording
 wrapt==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ typing-extensions==4.7.1
     # via
     #   pydantic
     #   pydantic-core
+    #   replicate (pyproject.toml)


### PR DESCRIPTION
We're relying on a feature (`deprecated`) from version 4.5.0 of typing_extensions, but the version bundled with Python varies. Include it as an explicit dependency to avoid import errors for users.