### PR TITLE
Add `stream` method on `Prediction`

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -32,3 +32,24 @@ async def test_stream(async_flag, record_mode):
 
     assert len(events) > 0
     assert events[0].event == "output"
+
+
+@pytest.mark.asyncio
+async def test_stream_prediction(record_mode):
+    if record_mode == "none":
+        return
+
+    version = "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
+
+    input = {
+        "prompt": "Please write a haiku about llamas.",
+    }
+
+    prediction = replicate.predictions.create(version=version, input=input)
+
+    events = []
+    for event in prediction.stream():
+        events.append(event)
+
+    assert len(events) > 0
+    assert events[0].event == "output"


### PR DESCRIPTION
Follow-up to #204

This PR adds a `stream` method on `Prediction`. In most cases, you'll want to call `replicate.stream` to get the stream directly. But if you have an existing prediction object and want to stream its output, you can use this method instead. [^1]

[^1]: This rhymes with `run` being a shorthand for creating a prediction and calling `wait`.