### PR TITLE
Update README to provide instructions for base64-encoding image inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ Some models, like [methexis-inc/img2prompt](https://replicate.com/methexis-inc/i
 > print(results)
 > ```
 
+To run a model that takes a file input, pass a URL to a publicly accessible file. Or, for smaller files (<10MB), you can convert file data into a base64-encoded data URI and pass that directly:
+
+```
+# Run andreasjansson/blip-2:f677695e by providing a base64 encoded image from local file system
+import replicate
+import base64
+
+# Download `gg_bridge.jpeg` from https://replicate.delivery/pbxt/IJEPmgAlL2zNBNDoRRKFegTEcxnlRhoQxlNjPHSZEy0pSIKn/gg_bridge.jpeg
+# This reads example image `gg_bridge.jpeg` from current working directory into a buffer
+with open("gg_bridge.jpeg", "rb") as image_file:
+    # Then encodes the buffer into a base64 string
+    encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
+    # Finally, sets the MIME type and adds the data URI scheme to the encoded string
+    encoded_string = f"data:image/jpeg;base64,{encoded_string}"
+
+output = replicate.run(
+    "andreasjansson/blip-2:f677695e5e89f8b236e52ecd1d3f01beb44c34606419bcc19345e046d8f786f9",
+    input={
+        "image": encoded_string,
+        "caption": False,
+        "question": "what body of water does this bridge cross?",
+        "temperature": 1,
+        "use_nucleus_sampling": False
+    }
+)
+print(output)
+```
+
 ## Run a model and stream its output
 
 Replicate’s API supports server-sent event streams (SSEs) for language models. 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,15 @@ Create a new Python file and add the following code:
 ['https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png']
 ```
 
-Some models, like [methexis-inc/img2prompt](https://replicate.com/methexis-inc/img2prompt), receive images as inputs. To pass a file as an input, use a file handle or URL:
+Some models, like [andreasjansson/blip-2](https://replicate.com/andreasjansson/blip-2), have files as inputs.
+To run a model that takes a file input,
+pass a URL to a publicly accessible file.
+Or, for smaller files (<10MB), you can pass a file handle directly.
 
 ```python
 >>> output = replicate.run(
-        "salesforce/blip:2e1dddc8621f72155f24cf2e0adbde548458d3cab9f00c0139eea840d0ac4746",
-        input={"image": open("path/to/mystery.jpg", "rb")},
+        "andreasjansson/blip-2:f677695e5e89f8b236e52ecd1d3f01beb44c34606419bcc19345e046d8f786f9",
+        input={ "image": open("path/to/mystery.jpg") }
     )
 
 "an astronaut riding a horse"
@@ -78,28 +81,6 @@ Some models, like [methexis-inc/img2prompt](https://replicate.com/methexis-inc/i
 > results = await asyncio.gather(*tasks)
 > print(results)
 > ```
-
-To run a model that takes a file input, pass a URL to a publicly accessible file. Or, for smaller files (<10MB), you can convert file data into a base64-encoded data URI and pass that directly:
-
-```
-# Run andreasjansson/blip-2:f677695e by providing an image from local file system which is base64 encoded by files.py
-import replicate
-import base64
-
-# This reads an example image `gg_bridge.jpeg` from current working directory into a buffer and into the prediction request 
-with open("gg_bridge.jpeg", "rb") as image_file:
-    output = replicate.run(
-        "andreasjansson/blip-2:f677695e5e89f8b236e52ecd1d3f01beb44c34606419bcc19345e046d8f786f9",
-        input={
-            "image": image_file,
-            "caption": False,
-            "question": "what body of water does this bridge cross?",
-            "temperature": 1,
-            "use_nucleus_sampling": False
-        }
-    )
-    print(output)
-```
 
 ## Run a model and stream its output
 

--- a/README.md
+++ b/README.md
@@ -82,29 +82,23 @@ Some models, like [methexis-inc/img2prompt](https://replicate.com/methexis-inc/i
 To run a model that takes a file input, pass a URL to a publicly accessible file. Or, for smaller files (<10MB), you can convert file data into a base64-encoded data URI and pass that directly:
 
 ```
-# Run andreasjansson/blip-2:f677695e by providing a base64 encoded image from local file system
+# Run andreasjansson/blip-2:f677695e by providing an image from local file system which is base64 encoded by files.py
 import replicate
 import base64
 
-# Download `gg_bridge.jpeg` from https://replicate.delivery/pbxt/IJEPmgAlL2zNBNDoRRKFegTEcxnlRhoQxlNjPHSZEy0pSIKn/gg_bridge.jpeg
-# This reads example image `gg_bridge.jpeg` from current working directory into a buffer
+# This reads an example image `gg_bridge.jpeg` from current working directory into a buffer and into the prediction request 
 with open("gg_bridge.jpeg", "rb") as image_file:
-    # Then encodes the buffer into a base64 string
-    encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
-    # Finally, sets the MIME type and adds the data URI scheme to the encoded string
-    encoded_string = f"data:image/jpeg;base64,{encoded_string}"
-
-output = replicate.run(
-    "andreasjansson/blip-2:f677695e5e89f8b236e52ecd1d3f01beb44c34606419bcc19345e046d8f786f9",
-    input={
-        "image": encoded_string,
-        "caption": False,
-        "question": "what body of water does this bridge cross?",
-        "temperature": 1,
-        "use_nucleus_sampling": False
-    }
-)
-print(output)
+    output = replicate.run(
+        "andreasjansson/blip-2:f677695e5e89f8b236e52ecd1d3f01beb44c34606419bcc19345e046d8f786f9",
+        input={
+            "image": image_file,
+            "caption": False,
+            "question": "what body of water does this bridge cross?",
+            "temperature": 1,
+            "use_nucleus_sampling": False
+        }
+    )
+    print(output)
 ```
 
 ## Run a model and stream its output


### PR DESCRIPTION
### Context

Update sign-off prior commit in git history (https://github.com/replicate/replicate-python/commit/cd09db0691a96c3c299e1f9ac374d420bb4adbdd) + Add basic base64 example