### PR TITLE
:bug: Remove call to removeprefix to fix python 3.8

### DIFF
--- a/replicate/stream.py
+++ b/replicate/stream.py
@@ -114,7 +114,7 @@ class EventSource:
                 return None
 
             fieldname, _, value = line.partition(":")
-            value = value.removeprefix(" ")
+            value = value[1:] if value.startswith(" ") else value
 
             if fieldname == "event":
                 if event := ServerSentEvent.EventType(value):


### PR DESCRIPTION
In `stream.py` we were using `removeprefix`, which was introduced in Python 3.9. This breaks compatibility with Python 3.8, which I believe we still want to support. This PR provides exact same functionality but without the call to that function.

Previously, we were `.lstrip()`-ing here, but I assume @mattt switched to `removeprefix` for a reason, so I didn't use that (as it would get rid of any and all whitespace, as opposed to a single space as we do here).