### PR TITLE
Apply custom headers passed to client constructor

### DIFF
--- a/replicate/client.py
+++ b/replicate/client.py
@@ -329,9 +329,8 @@ def _build_httpx_client(
     timeout: Optional[httpx.Timeout] = None,
     **kwargs,
 ) -> Union[httpx.Client, httpx.AsyncClient]:
-    headers = {
-        "User-Agent": f"replicate-python/{__version__}",
-    }
+    headers = kwargs.pop("headers", {})
+    headers["User-Agent"] = f"replicate-python/{__version__}"
 
     if (
         api_token := api_token or os.environ.get("REPLICATE_API_TOKEN")


### PR DESCRIPTION
`Client.__init__`  takes a `**kwargs` argument that gets passed to the underlying httpx client constructor. However, the current implementation doesn't honor any custom headers that are passed. This PR fixes that.