### PR TITLE
Improve ergonomics of streaming predictions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ jobs:
 
     name: "Test Python ${{ matrix.python-version }}"
 
+    env:
+      REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+
     timeout-minutes: 10
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ for event in replicate.stream(
     print(str(event), end="")
 ```
 
+You can also stream the output of a prediction you create.
+This is helpful when you want the ID of the prediction separate from its output.
+
+```python
+version = "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3
+prediction = replicate.predictions.create(version=version, input={
+    "prompt": "Please write a haiku about llamas.",
+})
+
+for event in prediction.stream():
+    print(str(event), end="")
+```
+
 For more information, see
 ["Streaming output"](https://replicate.com/docs/streaming) in Replicate's docs.
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,55 +1,62 @@
 import pytest
 
 import replicate
+from replicate.stream import ServerSentEvent
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("async_flag", [True, False])
 async def test_stream(async_flag, record_mode):
-    if record_mode == "none":
-        return
+    # if record_mode == "none":
+    #     return
 
-    version = "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
-
+    model = "replicate/canary:30e22229542eb3f79d4f945dacb58d32001b02cc313ae6f54eef27904edf3272"
     input = {
-        "prompt": "Please write a haiku about llamas.",
+        "text": "Hello",
     }
 
     events = []
 
     if async_flag:
         async for event in await replicate.async_stream(
-            f"meta/llama-2-70b-chat:{version}",
+            model,
             input=input,
         ):
             events.append(event)
     else:
         for event in replicate.stream(
-            f"meta/llama-2-70b-chat:{version}",
+            model,
             input=input,
         ):
             events.append(event)
 
     assert len(events) > 0
-    assert events[0].event == "output"
+    assert any(event.event == ServerSentEvent.EventType.OUTPUT for event in events)
+    assert any(event.event == ServerSentEvent.EventType.DONE for event in events)
 
 
 @pytest.mark.asyncio
-async def test_stream_prediction(record_mode):
-    if record_mode == "none":
-        return
+@pytest.mark.parametrize("async_flag", [True, False])
+async def test_stream_prediction(async_flag, record_mode):
+    # if record_mode == "none":
+    #     return
 
-    version = "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
-
+    version = "30e22229542eb3f79d4f945dacb58d32001b02cc313ae6f54eef27904edf3272"
     input = {
-        "prompt": "Please write a haiku about llamas.",
+        "text": "Hello",
     }
 
-    prediction = replicate.predictions.create(version=version, input=input)
-
     events = []
-    for event in prediction.stream():
-        events.append(event)
+
+    if async_flag:
+        async for event in replicate.predictions.create(
+            version=version, input=input, stream=True
+        ).async_stream():
+            events.append(event)
+    else:
+        for event in replicate.predictions.create(
+            version=version, input=input, stream=True
+        ).stream():
+            events.append(event)
 
     assert len(events) > 0
-    assert events[0].event == "output"

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -7,9 +7,6 @@ from replicate.stream import ServerSentEvent
 @pytest.mark.asyncio
 @pytest.mark.parametrize("async_flag", [True, False])
 async def test_stream(async_flag, record_mode):
-    # if record_mode == "none":
-    #     return
-
     model = "replicate/canary:30e22229542eb3f79d4f945dacb58d32001b02cc313ae6f54eef27904edf3272"
     input = {
         "text": "Hello",
@@ -38,9 +35,6 @@ async def test_stream(async_flag, record_mode):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("async_flag", [True, False])
 async def test_stream_prediction(async_flag, record_mode):
-    # if record_mode == "none":
-    #     return
-
     version = "30e22229542eb3f79d4f945dacb58d32001b02cc313ae6f54eef27904edf3272"
     input = {
         "text": "Hello",


### PR DESCRIPTION
A few folks have expressed confusion about how to stream output from a prediction. This PR updates the README with documentation and adds a missing `async_stream` instance method on `prediction`.