### PR TITLE
Fix `Deployment` model definition

### DIFF
--- a/replicate/deployment.py
+++ b/replicate/deployment.py
@@ -79,24 +79,14 @@ class Deployment(Resource):
             The SKU for the hardware used to run the model.
             """
 
-            class Scaling(Resource):
-                """
-                A scaling configuration for a deployment.
-                """
-
-                min_instances: int
-                """
-                The minimum number of instances for scaling.
-                """
-
-                max_instances: int
-                """
-                The maximum number of instances for scaling.
-                """
-
-            scaling: Scaling
+            min_instances: int
             """
-            The scaling configuration for the deployment.
+            The minimum number of instances for scaling.
+            """
+
+            max_instances: int
+            """
+            The maximum number of instances for scaling.
             """
 
         configuration: Configuration

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -31,7 +31,8 @@ router.route(
                 },
                 "configuration": {
                     "hardware": "gpu-t4",
-                    "scaling": {"min_instances": 1, "max_instances": 5},
+                    "min_instances": 1,
+                    "max_instances": 5,
                 },
             },
         },
@@ -86,7 +87,8 @@ router.route(
                         },
                         "configuration": {
                             "hardware": "gpu-t4",
-                            "scaling": {"min_instances": 1, "max_instances": 5},
+                            "min_instances": 1,
+                            "max_instances": 5,
                         },
                     },
                 },
@@ -105,7 +107,8 @@ router.route(
                         },
                         "configuration": {
                             "hardware": "cpu",
-                            "scaling": {"min_instances": 2, "max_instances": 10},
+                            "min_instances": 2,
+                            "max_instances": 10,
                         },
                     },
                 },
@@ -136,7 +139,8 @@ router.route(
                 },
                 "configuration": {
                     "hardware": "gpu-t4",
-                    "scaling": {"min_instances": 1, "max_instances": 5},
+                    "min_instances": 1,
+                    "max_instances": 5,
                 },
             },
         },
@@ -166,7 +170,8 @@ router.route(
                 },
                 "configuration": {
                     "hardware": "gpu-v100",
-                    "scaling": {"min_instances": 2, "max_instances": 10},
+                    "min_instances": 2,
+                    "max_instances": 10,
                 },
             },
         },
@@ -352,8 +357,8 @@ async def test_create_deployment(async_flag):
     assert deployment.current_release.created_by.username == "acme"
     assert deployment.current_release.created_by.name == "Acme, Inc."
     assert deployment.current_release.configuration.hardware == "gpu-t4"
-    assert deployment.current_release.configuration.scaling.min_instances == 1
-    assert deployment.current_release.configuration.scaling.max_instances == 5
+    assert deployment.current_release.configuration.min_instances == 1
+    assert deployment.current_release.configuration.max_instances == 5
 
 
 @respx.mock
@@ -392,5 +397,5 @@ async def test_update_deployment(async_flag):
     assert updated_deployment.current_release.model == "acme/esrgan-updated"
     assert updated_deployment.current_release.version == "new-version-id"
     assert updated_deployment.current_release.configuration.hardware == "gpu-v100"
-    assert updated_deployment.current_release.configuration.scaling.min_instances == 2
-    assert updated_deployment.current_release.configuration.scaling.max_instances == 10
+    assert updated_deployment.current_release.configuration.min_instances == 2
+    assert updated_deployment.current_release.configuration.max_instances == 10


### PR DESCRIPTION
#258 added fields to the `Deployment` model provided by the new `deployments.{get,list,update}` endpoints. However, those were implemented against a version of the OpenAPI specification that disagreed with the actual API responses. Specifically, the `min_instances` and `max_instances` properties were listed as subproperties of a `scaling` object rather than direct fields. The result — as reported in #270 — was Pydantic validation errors like this:

```
raise validation_error
pydantic.v1.error_wrappers.ValidationError: 1 validation error for Deployment
current_release -> configuration -> scaling
field required (type=value_error.missing)"
```

This PR updates the `Deployment` model to correctly locate `min_instances` and `max_instances` as properties of `current_release.configuration`.