### PR TITLE
Include `stream=True` in prediction stream snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ This is helpful when you want the ID of the prediction separate from its output.
 
 ```python
 version = "02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
-prediction = replicate.predictions.create(version=version, input={
-    "prompt": "Please write a haiku about llamas.",
-})
+prediction = replicate.predictions.create(
+    version=version,
+    input={"prompt": "Please write a haiku about llamas."},
+    stream=True,
+)
 
 for event in prediction.stream():
     print(str(event), end="")


### PR DESCRIPTION
Add missing `stream=True` in this snippet. Without it, you'll get error message about the model not supporting streaming.