### PR TITLE
Fix missing word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ background = Image.open("/tmp/out.png")
 
 ## List models
 
-You can the models you've created:
+You can list the models you've created:
 
 ```python
 replicate.models.list()


### PR DESCRIPTION
Add the missing verb 'list' to the sentence 'You can the models you've created' under the 'List models' section.