### PR TITLE
Generate API reference 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    name: "Publish to PyPI"
+    name: "Publish to PyPI and update API documentation"
 
     steps:
       - uses: actions/checkout@v3
@@ -17,6 +17,17 @@ jobs:
           python-version: "3.10"
       - name: Install pypa/build
         run: python -m pip install build --user
+      - name: Install pdoc
+        run: pip install pdoc
+      - name: Generate API documentation
+        run: pdoc --output-dir docs --docformat markdown your_library_module
+      - name: Commit and push updated documentation
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add docs/
+          git commit -m "Update API documentation"
+          git push
       - name: Build a package
         run: python -m build
       - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,9 @@ jobs:
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Install pdoc
-        run: pip install pdoc
+        run: pip install pdoc3
       - name: Generate API documentation
-        run: pdoc --output-dir docs --docformat markdown your_library_module
+        run: pdoc --force  -o docs replicate
       - name: Commit and push updated documentation
         run: |
           git config --global user.email "actions@github.com"

--- a/docs/replicate/account.md
+++ b/docs/replicate/account.md
@@ -1,0 +1,54 @@
+Module replicate.account
+========================
+
+Classes
+-------
+
+`Account(**data: Any)`
+:   A user or organization account on Replicate.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `github_url: Optional[str]`
+    :   The GitHub URL of the account.
+
+    `name: str`
+    :   The name of the account.
+
+    `type: Literal['user', 'organization']`
+    :   The type of account.
+
+    `username: str`
+    :   The username of the account.
+
+`Accounts(client: Client)`
+:   Namespace for operations related to accounts.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Methods
+
+    `async_current(self) ‑> replicate.account.Account`
+    :   Get the current account.
+        
+        Returns:
+            Account: The current account.
+
+    `current(self) ‑> replicate.account.Account`
+    :   Get the current account.
+        
+        Returns:
+            Account: The current account.

--- a/docs/replicate/client.md
+++ b/docs/replicate/client.md
@@ -1,0 +1,106 @@
+Module replicate.client
+=======================
+
+Classes
+-------
+
+`Client(api_token: Optional[str] = None, *, base_url: Optional[str] = None, timeout: Optional[httpx.Timeout] = None, **kwargs)`
+:   A Replicate API client library
+
+    ### Instance variables
+
+    `accounts: replicate.account.Accounts`
+    :   Namespace for operations related to accounts.
+
+    `collections: replicate.collection.Collections`
+    :   Namespace for operations related to collections of models.
+
+    `deployments: replicate.deployment.Deployments`
+    :   Namespace for operations related to deployments.
+
+    `hardware: replicate.hardware.HardwareNamespace`
+    :   Namespace for operations related to hardware.
+
+    `models: replicate.model.Models`
+    :   Namespace for operations related to models.
+
+    `predictions: replicate.prediction.Predictions`
+    :   Namespace for operations related to predictions.
+
+    `trainings: replicate.training.Trainings`
+    :   Namespace for operations related to trainings.
+
+    ### Methods
+
+    `async_run(self, ref: str, input: Optional[Dict[str, Any]] = None, **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> Union[Any, AsyncIterator[Any]]`
+    :   Run a model and wait for its output asynchronously.
+
+    `async_stream(self, ref: str, input: Optional[Dict[str, Any]] = None, **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> AsyncIterator[ServerSentEvent]`
+    :   Stream a model's output asynchronously.
+
+    `run(self, ref: str, input: Optional[Dict[str, Any]] = None, **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> Union[Any, Iterator[Any]]`
+    :   Run a model and wait for its output.
+
+    `stream(self, ref: str, input: Optional[Dict[str, Any]] = None, **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> Iterator[ServerSentEvent]`
+    :   Stream a model's output.
+
+`RetryTransport(wrapped_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport], *, max_attempts: int = 10, max_backoff_wait: float = 60, backoff_factor: float = 0.1, jitter_ratio: float = 0.1, retryable_methods: Optional[Iterable[str]] = None, retry_status_codes: Optional[Iterable[int]] = None)`
+:   A custom HTTP transport that automatically retries requests using an exponential backoff strategy
+    for specific HTTP status codes and request methods.
+
+    ### Ancestors (in MRO)
+
+    * httpx.AsyncBaseTransport
+    * httpx.BaseTransport
+
+    ### Class variables
+
+    `MAX_BACKOFF_WAIT`
+    :
+
+    `RETRYABLE_METHODS`
+    :
+
+    `RETRYABLE_STATUS_CODES`
+    :
+
+    ### Methods
+
+    `aclose(self) ‑> None`
+    :
+
+    `close(self) ‑> None`
+    :
+
+    `handle_async_request(self, request: httpx.Request) ‑> httpx.Response`
+    :
+
+    `handle_request(self, request: httpx.Request) ‑> httpx.Response`
+    :   Send a single HTTP request and return a response.
+        
+        Developers shouldn't typically ever need to call into this API directly,
+        since the Client class provides all the higher level user-facing API
+        niceties.
+        
+        In order to properly release any network resources, the response
+        stream should *either* be consumed immediately, with a call to
+        `response.stream.read()`, or else the `handle_request` call should
+        be followed with a try/finally block to ensuring the stream is
+        always closed.
+        
+        Example usage:
+        
+            with httpx.HTTPTransport() as transport:
+                req = httpx.Request(
+                    method=b"GET",
+                    url=(b"https", b"www.example.com", 443, b"/"),
+                    headers=[(b"Host", b"www.example.com")],
+                )
+                resp = transport.handle_request(req)
+                body = resp.stream.read()
+                print(resp.status_code, resp.headers, body)
+        
+        
+        Takes a `Request` instance as the only argument.
+        
+        Returns a `Response` instance.

--- a/docs/replicate/collection.md
+++ b/docs/replicate/collection.md
@@ -1,0 +1,83 @@
+Module replicate.collection
+===========================
+
+Classes
+-------
+
+`Collection(**data: Any)`
+:   A collection of models on Replicate.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `description: str`
+    :   A description of the collection.
+
+    `models: Optional[List[replicate.model.Model]]`
+    :   The models in the collection.
+
+    `name: str`
+    :   The name of the collection.
+
+    `slug: str`
+    :   The slug used to identify the collection.
+
+    ### Instance variables
+
+    `id: str`
+    :   DEPRECATED: Use `slug` instead.
+
+`Collections(client: Client)`
+:   A namespace for operations related to collections of models.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Methods
+
+    `async_get(self, slug: str) ‑> replicate.collection.Collection`
+    :   Get a model by name.
+        
+        Args:
+            name: The name of the model, in the format `owner/model-name`.
+        Returns:
+            The model.
+
+    `async_list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.collection.Collection]`
+    :   List collections of models.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Collection]: A page of of model collections.
+        Raises:
+            ValueError: If `cursor` is `None`.
+
+    `get(self, slug: str) ‑> replicate.collection.Collection`
+    :   Get a model by name.
+        
+        Args:
+            name: The name of the model, in the format `owner/model-name`.
+        Returns:
+            The model.
+
+    `list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.collection.Collection]`
+    :   List collections of models.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Collection]: A page of of model collections.
+        Raises:
+            ValueError: If `cursor` is `None`.

--- a/docs/replicate/deployment.md
+++ b/docs/replicate/deployment.md
@@ -1,0 +1,163 @@
+Module replicate.deployment
+===========================
+
+Classes
+-------
+
+`Deployment(**data: Any)`
+:   A deployment of a model hosted on Replicate.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `Release`
+    :   A release of a deployment.
+
+    `current_release: Optional[replicate.deployment.Deployment.Release]`
+    :   The current release of the deployment.
+
+    `name: str`
+    :   The name of the deployment.
+
+    `owner: str`
+    :   The name of the user or organization that owns the deployment.
+
+    ### Instance variables
+
+    `id: str`
+    :   Return the qualified deployment name, in the format `owner/name`.
+
+    `predictions: replicate.deployment.DeploymentPredictions`
+    :   Get the predictions for this deployment.
+
+    `username: str`
+    :   The name of the user or organization that owns the deployment.
+        This attribute is deprecated and will be removed in future versions.
+
+`DeploymentPredictions(client: Client, deployment: replicate.deployment.Deployment)`
+:   Namespace for operations related to predictions in a deployment.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Methods
+
+    `async_create(self, input: Dict[str, Any], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction with the deployment.
+
+    `create(self, input: Dict[str, Any], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction with the deployment.
+
+`Deployments(client: Client)`
+:   Namespace for operations related to deployments.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Class variables
+
+    `CreateDeploymentParams`
+    :   Parameters for creating a new deployment.
+
+    `UpdateDeploymentParams`
+    :   Parameters for updating an existing deployment.
+
+    ### Instance variables
+
+    `predictions: replicate.deployment.DeploymentsPredictions`
+    :   Get predictions for deployments.
+
+    ### Methods
+
+    `async_create(self, **params: Unpack[replicate.deployment.Deployments.CreateDeploymentParams]) ‑> replicate.deployment.Deployment`
+    :   Create a new deployment.
+        
+        Args:
+            params: Configuration for the new deployment.
+        Returns:
+            The newly created Deployment.
+
+    `async_get(self, name: str) ‑> replicate.deployment.Deployment`
+    :   Get a deployment by name.
+        
+        Args:
+            name: The name of the deployment, in the format `owner/model-name`.
+        Returns:
+            The model.
+
+    `async_list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.deployment.Deployment]`
+    :   List all deployments.
+        
+        Returns:
+            A page of Deployments.
+
+    `async_update(self, deployment_owner: str, deployment_name: str, **params: Unpack[replicate.deployment.Deployments.UpdateDeploymentParams]) ‑> replicate.deployment.Deployment`
+    :   Update an existing deployment.
+        
+        Args:
+            deployment_owner: The owner of the deployment.
+            deployment_name: The name of the deployment.
+            params: Configuration updates for the deployment.
+        Returns:
+            The updated Deployment.
+
+    `create(self, **params: Unpack[replicate.deployment.Deployments.CreateDeploymentParams]) ‑> replicate.deployment.Deployment`
+    :   Create a new deployment.
+        
+        Args:
+            params: Configuration for the new deployment.
+        Returns:
+            The newly created Deployment.
+
+    `get(self, name: str) ‑> replicate.deployment.Deployment`
+    :   Get a deployment by name.
+        
+        Args:
+            name: The name of the deployment, in the format `owner/model-name`.
+        Returns:
+            The model.
+
+    `list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.deployment.Deployment]`
+    :   List all deployments.
+        
+        Returns:
+            A page of Deployments.
+
+    `update(self, deployment_owner: str, deployment_name: str, **params: Unpack[replicate.deployment.Deployments.UpdateDeploymentParams]) ‑> replicate.deployment.Deployment`
+    :   Update an existing deployment.
+        
+        Args:
+            deployment_owner: The owner of the deployment.
+            deployment_name: The name of the deployment.
+            params: Configuration updates for the deployment.
+        Returns:
+            The updated Deployment.
+
+`DeploymentsPredictions(client: Client)`
+:   Namespace for operations related to predictions in deployments.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Methods
+
+    `async_create(self, deployment: Union[str, Tuple[str, str], replicate.deployment.Deployment], input: Dict[str, Any], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction with the deployment.
+
+    `create(self, deployment: Union[str, Tuple[str, str], replicate.deployment.Deployment], input: Dict[str, Any], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction with the deployment.

--- a/docs/replicate/exceptions.md
+++ b/docs/replicate/exceptions.md
@@ -1,0 +1,65 @@
+Module replicate.exceptions
+===========================
+
+Classes
+-------
+
+`ModelError(*args, **kwargs)`
+:   An error from user's code in a model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.exceptions.ReplicateException
+    * builtins.Exception
+    * builtins.BaseException
+
+`ReplicateError(type: Optional[str] = None, title: Optional[str] = None, status: Optional[int] = None, detail: Optional[str] = None, instance: Optional[str] = None)`
+:   An error from Replicate's API.
+    
+    This class represents a problem details response as defined in RFC 7807.
+
+    ### Ancestors (in MRO)
+
+    * replicate.exceptions.ReplicateException
+    * builtins.Exception
+    * builtins.BaseException
+
+    ### Class variables
+
+    `detail: Optional[str]`
+    :   A human-readable explanation specific to this occurrence of the error.
+
+    `instance: Optional[str]`
+    :   A URI that identifies the specific occurrence of the error.
+
+    `status: Optional[int]`
+    :   The HTTP status code.
+
+    `title: Optional[str]`
+    :   A short, human-readable summary of the error.
+
+    `type: Optional[str]`
+    :   A URI that identifies the error type.
+
+    ### Static methods
+
+    `from_response(response: httpx.Response) ‑> replicate.exceptions.ReplicateError`
+    :   Create a ReplicateError from an HTTP response.
+
+    ### Methods
+
+    `to_dict(self) ‑> dict`
+    :   Get a dictionary representation of the error.
+
+`ReplicateException(*args, **kwargs)`
+:   A base class for all Replicate exceptions.
+
+    ### Ancestors (in MRO)
+
+    * builtins.Exception
+    * builtins.BaseException
+
+    ### Descendants
+
+    * replicate.exceptions.ModelError
+    * replicate.exceptions.ReplicateError

--- a/docs/replicate/files.md
+++ b/docs/replicate/files.md
@@ -1,0 +1,15 @@
+Module replicate.files
+======================
+
+Functions
+---------
+
+    
+`upload_file(file: io.IOBase, output_file_prefix: Optional[str] = None) ‑> str`
+:   Upload a file to the server.
+    
+    Args:
+        file: A file handle to upload.
+        output_file_prefix: A string to prepend to the output file name.
+    Returns:
+        str: A URL to the uploaded file.

--- a/docs/replicate/hardware.md
+++ b/docs/replicate/hardware.md
@@ -1,0 +1,53 @@
+Module replicate.hardware
+=========================
+
+Classes
+-------
+
+`Hardware(**data: Any)`
+:   Hardware for running a model on Replicate.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `name: str`
+    :   The name of the hardware.
+
+    `sku: str`
+    :   The SKU of the hardware.
+
+    ### Instance variables
+
+    `id: str`
+    :   DEPRECATED: Use `sku` instead.
+
+`HardwareNamespace(client: Client)`
+:   Namespace for operations related to hardware.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Methods
+
+    `async_list(self) ‑> List[replicate.hardware.Hardware]`
+    :   List all hardware available for you to run models on Replicate.
+        
+        Returns:
+            List[Hardware]: A list of hardware.
+
+    `list(self) ‑> List[replicate.hardware.Hardware]`
+    :   List all hardware available for you to run models on Replicate.
+        
+        Returns:
+            List[Hardware]: A list of hardware.

--- a/docs/replicate/identifier.md
+++ b/docs/replicate/identifier.md
@@ -1,0 +1,28 @@
+Module replicate.identifier
+===========================
+
+Classes
+-------
+
+`ModelVersionIdentifier(owner: str, name: str, version: Optional[str] = None)`
+:   A reference to a model version in the format owner/name or owner/name:version.
+
+    ### Ancestors (in MRO)
+
+    * builtins.tuple
+
+    ### Static methods
+
+    `parse(ref: str) ‑> replicate.identifier.ModelVersionIdentifier`
+    :   Split a reference in the format owner/name:version into its components.
+
+    ### Instance variables
+
+    `name: str`
+    :   Alias for field number 1
+
+    `owner: str`
+    :   Alias for field number 0
+
+    `version: Optional[str]`
+    :   Alias for field number 2

--- a/docs/replicate/index.md
+++ b/docs/replicate/index.md
@@ -1,0 +1,23 @@
+Module replicate
+================
+
+Sub-modules
+-----------
+* replicate.account
+* replicate.client
+* replicate.collection
+* replicate.deployment
+* replicate.exceptions
+* replicate.files
+* replicate.hardware
+* replicate.identifier
+* replicate.json
+* replicate.model
+* replicate.pagination
+* replicate.prediction
+* replicate.resource
+* replicate.run
+* replicate.schema
+* replicate.stream
+* replicate.training
+* replicate.version

--- a/docs/replicate/json.md
+++ b/docs/replicate/json.md
@@ -1,0 +1,9 @@
+Module replicate.json
+=====================
+
+Functions
+---------
+
+    
+`encode_json(obj: Any, upload_file: Callable[[io.IOBase], str]) ‑> Any`
+:   Return a JSON-compatible version of the object.

--- a/docs/replicate/model.md
+++ b/docs/replicate/model.md
@@ -1,0 +1,157 @@
+Module replicate.model
+======================
+
+Classes
+-------
+
+`Model(**data: Any)`
+:   A machine learning model hosted on Replicate.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `cover_image_url: Optional[str]`
+    :   The URL of the cover image for the model.
+
+    `default_example: Optional[replicate.prediction.Prediction]`
+    :   The default example of the model.
+
+    `description: Optional[str]`
+    :   The description of the model.
+
+    `github_url: Optional[str]`
+    :   The GitHub URL of the model.
+
+    `latest_version: Optional[replicate.version.Version]`
+    :   The latest version of the model.
+
+    `license_url: Optional[str]`
+    :   The URL of the license for the model.
+
+    `name: str`
+    :   The name of the model.
+
+    `owner: str`
+    :   The owner of the model.
+
+    `paper_url: Optional[str]`
+    :   The URL of the paper related to the model.
+
+    `run_count: int`
+    :   The number of runs of the model.
+
+    `url: str`
+    :   The URL of the model.
+
+    `visibility: Literal['public', 'private']`
+    :   The visibility of the model. Can be 'public' or 'private'.
+
+    ### Instance variables
+
+    `id: str`
+    :   Return the qualified model name, in the format `owner/name`.
+
+    `username: str`
+    :   The name of the user or organization that owns the model.
+        This attribute is deprecated and will be removed in future versions.
+
+    `versions: replicate.version.Versions`
+    :   Get the versions of this model.
+
+    ### Methods
+
+    `predict(self, *args, **kwargs) ‑> None`
+    :   DEPRECATED: Use `replicate.run()` instead.
+
+    `reload(self) ‑> None`
+    :   Load this object from the server.
+
+`Models(client: Client)`
+:   Namespace for operations related to models.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Class variables
+
+    `CreateModelParams`
+    :   Parameters for creating a model.
+
+    `model`
+    :   A machine learning model hosted on Replicate.
+
+    ### Instance variables
+
+    `predictions: replicate.model.ModelsPredictions`
+    :   Get a namespace for operations related to predictions on a model.
+
+    ### Methods
+
+    `async_create(self, owner: str, name: str, **params: Unpack[ForwardRef('Models.CreateModelParams')]) ‑> replicate.model.Model`
+    :   Create a model.
+
+    `async_get(self, key: str) ‑> replicate.model.Model`
+    :   Get a model by name.
+        
+        Args:
+            key: The qualified name of the model, in the format `owner/model-name`.
+        Returns:
+            The model.
+
+    `async_list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.model.Model]`
+    :   List all public models.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Model]: A page of of models.
+        Raises:
+            ValueError: If `cursor` is `None`.
+
+    `create(self, owner: str, name: str, **params: Unpack[ForwardRef('Models.CreateModelParams')]) ‑> replicate.model.Model`
+    :   Create a model.
+
+    `get(self, key: str) ‑> replicate.model.Model`
+    :   Get a model by name.
+        
+        Args:
+            key: The qualified name of the model, in the format `owner/model-name`.
+        Returns:
+            The model.
+
+    `list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.model.Model]`
+    :   List all public models.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Model]: A page of of models.
+        Raises:
+            ValueError: If `cursor` is `None`.
+
+`ModelsPredictions(client: Client)`
+:   Namespace for operations related to predictions in a deployment.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Methods
+
+    `async_create(self, model: Union[str, Tuple[str, str], ForwardRef('Model')], input: Dict[str, Any], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction with the deployment.
+
+    `create(self, model: Union[str, Tuple[str, str], ForwardRef('Model')], input: Dict[str, Any], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction with the deployment.

--- a/docs/replicate/pagination.md
+++ b/docs/replicate/pagination.md
@@ -1,0 +1,46 @@
+Module replicate.pagination
+===========================
+
+Functions
+---------
+
+    
+`async_paginate(list_method: Callable[[Union[str, ForwardRef('ellipsis'), ForwardRef(None)]], Awaitable[replicate.pagination.Page[~T]]]) ‑> AsyncGenerator[replicate.pagination.Page[~T], None]`
+:   Asynchronously iterate over all items using the provided list method.
+    
+    Args:
+        list_method: An async method that takes a cursor argument and returns a Page of items.
+
+    
+`paginate(list_method: Callable[[Union[str, ForwardRef('ellipsis'), ForwardRef(None)]], replicate.pagination.Page[~T]]) ‑> Generator[replicate.pagination.Page[~T], None, None]`
+:   Iterate over all items using the provided list method.
+    
+    Args:
+        list_method: A method that takes a cursor argument and returns a Page of items.
+
+Classes
+-------
+
+`Page(**data: Any)`
+:   A page of results from the API.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+    * typing.Generic
+
+    ### Class variables
+
+    `next: Optional[str]`
+    :   A pointer to the next page of results
+
+    `previous: Optional[str]`
+    :   A pointer to the previous page of results
+
+    `results: List[~T]`
+    :   The results on this page

--- a/docs/replicate/prediction.md
+++ b/docs/replicate/prediction.md
@@ -1,0 +1,182 @@
+Module replicate.prediction
+===========================
+
+Classes
+-------
+
+`Prediction(**data: Any)`
+:   A prediction made by a model hosted on Replicate.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `Progress`
+    :   The progress of a prediction.
+
+    `completed_at: Optional[str]`
+    :   When the prediction was completed, if finished.
+
+    `created_at: Optional[str]`
+    :   When the prediction was created.
+
+    `error: Optional[str]`
+    :   The error encountered during the prediction, if any.
+
+    `id: str`
+    :   The unique ID of the prediction.
+
+    `input: Optional[Dict[str, Any]]`
+    :   The input to the prediction.
+
+    `logs: Optional[str]`
+    :   The logs of the prediction.
+
+    `metrics: Optional[Dict[str, Any]]`
+    :   Metrics for the prediction.
+
+    `model: str`
+    :   An identifier for the model used to create the prediction, in the form `owner/name`.
+
+    `output: Optional[Any]`
+    :   The output of the prediction.
+
+    `started_at: Optional[str]`
+    :   When the prediction was started.
+
+    `status: Literal['starting', 'processing', 'succeeded', 'failed', 'canceled']`
+    :   The status of the prediction.
+
+    `urls: Optional[Dict[str, str]]`
+    :   URLs associated with the prediction.
+        
+        The following keys are available:
+        - `get`: A URL to fetch the prediction.
+        - `cancel`: A URL to cancel the prediction.
+
+    `version: str`
+    :   An identifier for the version of the model used to create the prediction.
+
+    ### Instance variables
+
+    `progress: Optional[replicate.prediction.Prediction.Progress]`
+    :   The progress of the prediction, if available.
+
+    ### Methods
+
+    `async_cancel(self) ‑> None`
+    :   Cancels a running prediction asynchronously.
+
+    `async_output_iterator(self) ‑> AsyncIterator[Any]`
+    :   Return an asynchronous iterator of the prediction output.
+
+    `async_reload(self) ‑> None`
+    :   Load this prediction from the server asynchronously.
+
+    `async_stream(self) ‑> AsyncIterator[ServerSentEvent]`
+    :   Stream the prediction output asynchronously.
+        
+        Raises:
+            ReplicateError: If the model does not support streaming.
+
+    `async_wait(self) ‑> None`
+    :   Wait for prediction to finish asynchronously.
+
+    `cancel(self) ‑> None`
+    :   Cancels a running prediction.
+
+    `output_iterator(self) ‑> Iterator[Any]`
+    :   Return an iterator of the prediction output.
+
+    `reload(self) ‑> None`
+    :   Load this prediction from the server.
+
+    `stream(self) ‑> Iterator[ServerSentEvent]`
+    :   Stream the prediction output.
+        
+        Raises:
+            ReplicateError: If the model does not support streaming.
+
+    `wait(self) ‑> None`
+    :   Wait for prediction to finish.
+
+`Predictions(client: Client)`
+:   Namespace for operations related to predictions.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Class variables
+
+    `CreatePredictionParams`
+    :   Parameters for creating a prediction.
+
+    ### Methods
+
+    `async_cancel(self, id: str) ‑> replicate.prediction.Prediction`
+    :   Cancel a prediction.
+        
+        Args:
+            id: The ID of the prediction to cancel.
+        Returns:
+            Prediction: The canceled prediction object.
+
+    `async_create(self, version: Union[replicate.version.Version, str], input: Optional[Dict[str, Any]], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction for the specified model version.
+
+    `async_get(self, id: str) ‑> replicate.prediction.Prediction`
+    :   Get a prediction by ID.
+        
+        Args:
+            id: The ID of the prediction.
+        Returns:
+            Prediction: The prediction object.
+
+    `async_list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.prediction.Prediction]`
+    :   List your predictions.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Prediction]: A page of of predictions.
+        Raises:
+            ValueError: If `cursor` is `None`.
+
+    `cancel(self, id: str) ‑> replicate.prediction.Prediction`
+    :   Cancel a prediction.
+        
+        Args:
+            id: The ID of the prediction to cancel.
+        Returns:
+            Prediction: The canceled prediction object.
+
+    `create(self, version: Union[replicate.version.Version, str], input: Optional[Dict[str, Any]], **params: Unpack[ForwardRef('Predictions.CreatePredictionParams')]) ‑> replicate.prediction.Prediction`
+    :   Create a new prediction for the specified model version.
+
+    `get(self, id: str) ‑> replicate.prediction.Prediction`
+    :   Get a prediction by ID.
+        
+        Args:
+            id: The ID of the prediction.
+        Returns:
+            Prediction: The prediction object.
+
+    `list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.prediction.Prediction]`
+    :   List your predictions.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Prediction]: A page of of predictions.
+        Raises:
+            ValueError: If `cursor` is `None`.

--- a/docs/replicate/resource.md
+++ b/docs/replicate/resource.md
@@ -1,0 +1,51 @@
+Module replicate.resource
+=========================
+
+Classes
+-------
+
+`Namespace(client: Client)`
+:   A base class for representing objects of a particular type on the server.
+
+    ### Ancestors (in MRO)
+
+    * abc.ABC
+
+    ### Descendants
+
+    * replicate.account.Accounts
+    * replicate.collection.Collections
+    * replicate.deployment.DeploymentPredictions
+    * replicate.deployment.Deployments
+    * replicate.deployment.DeploymentsPredictions
+    * replicate.hardware.HardwareNamespace
+    * replicate.model.Models
+    * replicate.model.ModelsPredictions
+    * replicate.prediction.Predictions
+    * replicate.training.Trainings
+    * replicate.version.Versions
+
+`Resource(**data: Any)`
+:   A base class for representing a single object on the server.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Descendants
+
+    * replicate.account.Account
+    * replicate.collection.Collection
+    * replicate.deployment.Deployment
+    * replicate.deployment.Deployment.Release
+    * replicate.deployment.Deployment.Release.Configuration
+    * replicate.hardware.Hardware
+    * replicate.model.Model
+    * replicate.prediction.Prediction
+    * replicate.training.Training
+    * replicate.version.Version

--- a/docs/replicate/run.md
+++ b/docs/replicate/run.md
@@ -1,0 +1,2 @@
+Module replicate.run
+====================

--- a/docs/replicate/schema.md
+++ b/docs/replicate/schema.md
@@ -1,0 +1,13 @@
+Module replicate.schema
+=======================
+
+Functions
+---------
+
+    
+`make_schema_backwards_compatible(schema: dict, cog_version: str) ‑> dict`
+:   A place to add backwards compatibility logic for our openapi schema
+
+    
+`version_has_no_array_type(cog_version: str) ‑> Optional[bool]`
+:   Iterators have x-cog-array-type=iterator in the schema from 0.3.9 onward

--- a/docs/replicate/stream.md
+++ b/docs/replicate/stream.md
@@ -1,0 +1,34 @@
+Module replicate.stream
+=======================
+
+Classes
+-------
+
+`ServerSentEvent(**data: Any)`
+:   A server-sent event.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `EventType`
+    :   A server-sent event type.
+
+    `data: str`
+    :
+
+    `event: replicate.stream.ServerSentEvent.EventType`
+    :
+
+    `id: str`
+    :
+
+    `retry: Optional[int]`
+    :

--- a/docs/replicate/training.md
+++ b/docs/replicate/training.md
@@ -1,0 +1,160 @@
+Module replicate.training
+=========================
+
+Classes
+-------
+
+`Training(**data: Any)`
+:   A training made for a model hosted on Replicate.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `completed_at: Optional[str]`
+    :   When the training was completed, if finished.
+
+    `created_at: Optional[str]`
+    :   When the training was created.
+
+    `destination: Optional[str]`
+    :   The model destination of the training.
+
+    `error: Optional[str]`
+    :   The error encountered during the training, if any.
+
+    `id: str`
+    :   The unique ID of the training.
+
+    `input: Optional[Dict[str, Any]]`
+    :   The input to the training.
+
+    `logs: Optional[str]`
+    :   The logs of the training.
+
+    `model: str`
+    :   An identifier for the model used to create the prediction, in the form `owner/name`.
+
+    `output: Optional[Any]`
+    :   The output of the training.
+
+    `started_at: Optional[str]`
+    :   When the training was started.
+
+    `status: Literal['starting', 'processing', 'succeeded', 'failed', 'canceled']`
+    :   The status of the training.
+
+    `urls: Optional[Dict[str, str]]`
+    :   URLs associated with the training.
+        
+        The following keys are available:
+        - `get`: A URL to fetch the training.
+        - `cancel`: A URL to cancel the training.
+
+    `version: Union[replicate.version.Version, str]`
+    :   The version of the model used to create the training.
+
+    ### Methods
+
+    `async_cancel(self) ‑> None`
+    :   Cancel a running training asynchronously.
+
+    `async_reload(self) ‑> None`
+    :   Load the training from the server asynchronously.
+
+    `cancel(self) ‑> None`
+    :   Cancel a running training.
+
+    `reload(self) ‑> None`
+    :   Load the training from the server.
+
+`Trainings(client: Client)`
+:   Namespace for operations related to trainings.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Class variables
+
+    `CreateTrainingParams`
+    :   Parameters for creating a training.
+
+    ### Methods
+
+    `async_cancel(self, id: str) ‑> replicate.training.Training`
+    :   Cancel a training.
+        
+        Args:
+            id: The ID of the training to cancel.
+        Returns:
+            Training: The canceled training object.
+
+    `async_create(self, model: Union[str, Tuple[str, str], ForwardRef('Model')], version: Union[replicate.version.Version, str], input: Dict[str, Any], **params: Unpack[ForwardRef('Trainings.CreateTrainingParams')]) ‑> replicate.training.Training`
+    :   Create a new training using the specified model version as a base.
+        
+        Args:
+            version: The ID of the base model version that you're using to train a new model version.
+            input: The input to the training.
+            destination: The desired model to push to in the format `{owner}/{model_name}`. This should be an existing model owned by the user or organization making the API request.
+            webhook: The URL to send a POST request to when the training is completed. Defaults to None.
+            webhook_completed: The URL to receive a POST request when the prediction is completed.
+            webhook_events_filter: The events to send to the webhook. Defaults to None.
+        Returns:
+            The training object.
+
+    `async_get(self, id: str) ‑> replicate.training.Training`
+    :   Get a training by ID.
+        
+        Args:
+            id: The ID of the training.
+        Returns:
+            Training: The training object.
+
+    `async_list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.training.Training]`
+    :   List your trainings.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Training]: A page of trainings.
+        Raises:
+            ValueError: If `cursor` is `None`.
+
+    `cancel(self, id: str) ‑> replicate.training.Training`
+    :   Cancel a training.
+        
+        Args:
+            id: The ID of the training to cancel.
+        Returns:
+            Training: The canceled training object.
+
+    `create(self, *args, model: Union[str, Tuple[str, str], ForwardRef('Model'), ForwardRef(None)] = None, version: Union[replicate.version.Version, str, ForwardRef(None)] = None, input: Optional[Dict[str, Any]] = None, **params: Unpack[ForwardRef('Trainings.CreateTrainingParams')]) ‑> replicate.training.Training`
+    :   Create a new training using the specified model version as a base.
+
+    `get(self, id: str) ‑> replicate.training.Training`
+    :   Get a training by ID.
+        
+        Args:
+            id: The ID of the training.
+        Returns:
+            Training: The training object.
+
+    `list(self, cursor: Union[str, ForwardRef('ellipsis'), ForwardRef(None)] = Ellipsis) ‑> replicate.pagination.Page[replicate.training.Training]`
+    :   List your trainings.
+        
+        Parameters:
+            cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
+        Returns:
+            Page[Training]: A page of trainings.
+        Raises:
+            ValueError: If `cursor` is `None`.

--- a/docs/replicate/version.md
+++ b/docs/replicate/version.md
@@ -1,0 +1,101 @@
+Module replicate.version
+========================
+
+Classes
+-------
+
+`Version(**data: Any)`
+:   A version of a model.
+    
+    Create a new model by parsing and validating input data from keyword arguments.
+    
+    Raises ValidationError if the input data cannot be parsed to form a valid model.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Resource
+    * pydantic.v1.main.BaseModel
+    * pydantic.v1.utils.Representation
+
+    ### Class variables
+
+    `cog_version: str`
+    :   The version of the Cog used to create the version.
+
+    `created_at: datetime.datetime`
+    :   When the version was created.
+
+    `id: str`
+    :   The unique ID of the version.
+
+    `openapi_schema: dict`
+    :   An OpenAPI description of the model inputs and outputs.
+
+`Versions(client: Client, model: Union[str, Tuple[str, str], ForwardRef('Model')])`
+:   Namespace for operations related to model versions.
+
+    ### Ancestors (in MRO)
+
+    * replicate.resource.Namespace
+    * abc.ABC
+
+    ### Class variables
+
+    `model: Tuple[str, str]`
+    :
+
+    ### Methods
+
+    `async_delete(self, id: str) ‑> bool`
+    :   Delete a model version and all associated predictions, including all output files.
+        
+        Model version deletion has some restrictions:
+        
+        * You can only delete versions from models you own.
+        * You can only delete versions from private models.
+        * You cannot delete a version if someone other than you
+          has run predictions with it.
+        
+        Args:
+            id: The version ID.
+
+    `async_get(self, id: str) ‑> replicate.version.Version`
+    :   Get a specific model version.
+        
+        Args:
+            id: The version ID.
+        Returns:
+            The model version.
+
+    `async_list(self) ‑> replicate.pagination.Page[replicate.version.Version]`
+    :   Return a list of all versions for a model.
+        
+        Returns:
+            List[Version]: A list of version objects.
+
+    `delete(self, id: str) ‑> bool`
+    :   Delete a model version and all associated predictions, including all output files.
+        
+        Model version deletion has some restrictions:
+        
+        * You can only delete versions from models you own.
+        * You can only delete versions from private models.
+        * You cannot delete a version if someone other than you
+          has run predictions with it.
+        
+        Args:
+            id: The version ID.
+
+    `get(self, id: str) ‑> replicate.version.Version`
+    :   Get a specific model version.
+        
+        Args:
+            id: The version ID.
+        Returns:
+            The model version.
+
+    `list(self) ‑> replicate.pagination.Page[replicate.version.Version]`
+    :   Return a list of all versions for a model.
+        
+        Returns:
+            List[Version]: A list of version objects.


### PR DESCRIPTION
This PR adds markdown API reference in the `docs` folder and updates the Release workflow to automatically generate and commit the docs. I am not a Github Actions adept so I'm not sure how to test that the action actually works without doing a release 😅 

Ultimately we'll want to integrate updated API reference into the main documentation site, but this seems like a worthwhile addition until/despite that. 