### PR TITLE
Use Bearer authorization scheme

### DIFF
--- a/replicate/client.py
+++ b/replicate/client.py
@@ -335,7 +335,7 @@ def _build_httpx_client(
     if (
         api_token := api_token or os.environ.get("REPLICATE_API_TOKEN")
     ) and api_token != "":
-        headers["Authorization"] = f"Token {api_token}"
+        headers["Authorization"] = f"Bearer {api_token}"
 
     base_url = (
         base_url or os.environ.get("REPLICATE_BASE_URL") or "https://api.replicate.com"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ async def test_authorization_when_setting_environ_after_import():
     router.route(
         method="GET",
         url="https://api.replicate.com/",
-        headers={"Authorization": "Token test-set-after-import"},
+        headers={"Authorization": "Bearer test-set-after-import"},
     ).mock(
         return_value=httpx.Response(
             200,
@@ -42,7 +42,7 @@ async def test_client_error_handling():
     router.route(
         method="GET",
         url="https://api.replicate.com/",
-        headers={"Authorization": "Token test-client-error"},
+        headers={"Authorization": "Bearer test-client-error"},
     ).mock(
         return_value=httpx.Response(
             400,
@@ -69,7 +69,7 @@ async def test_server_error_handling():
     router.route(
         method="GET",
         url="https://api.replicate.com/",
-        headers={"Authorization": "Token test-server-error"},
+        headers={"Authorization": "Bearer test-server-error"},
     ).mock(
         return_value=httpx.Response(
             500,


### PR DESCRIPTION
Replicate's API now supports the standard [Bearer authentication scheme](https://swagger.io/docs/specification/authentication/bearer-authentication/). 

https://replicate.com/changelog/2024-04-03-bearer-tokens

For compatibility with existing clients, the existing `Token` scheme will be supported indefinitely. But going forward, the new `Bearer` scheme is preferred.