### PR TITLE
Document how to set a custom token

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install replicate
 
 Before running any Python scripts that use the API, you need to set your Replicate API token in your environment.
 
-Grab your token from [replicate.com/account](https://replicate.com/account) and set it as an environment variable:
+Grab your token from [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens) and set it as an environment variable:
 
 ```
 export REPLICATE_API_TOKEN=<your token>

--- a/README.md
+++ b/README.md
@@ -360,6 +360,20 @@ training = replicate.trainings.create(
 )
 ```
 
+
+## Use a custom token
+
+The `REPLICATE_API_TOKEN` environment variable is used by default. If you want to specify a different token, use the `Client` factory method to create a custom client:
+
+```python
+import os
+from replicate.client import Client
+
+replicate = Client(
+  api_token=os.environ["SOME_OTHER_REPLICATE_API_TOKEN"]
+)
+```
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds a section to the README documenting how to use a differently named env var to create a client.

## Why?

I am using the `replicate` Python client in an application where `REPLICATE_API_TOKEN` is not an adequately descriptive name for the environment variable.

I know I could do something like this:

```
os.environ["REPLICATE_API_TOKEN"] = os.environ["SOME_CUSTOM_REPLICATE_API_TOKEN"]
import replicate
```

... but I don't want to pollute the environment with a var that could break other things or confuse teammates.