### PR TITLE
asynchronously close of response

### DIFF
--- a/replicate/client.py
+++ b/replicate/client.py
@@ -305,7 +305,7 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
             ):
                 return response
 
-            response.close()
+            await response.aclose()
 
             sleep_for = self._calculate_sleep(attempts_made, response.headers)
             await asyncio.sleep(sleep_for)


### PR DESCRIPTION
The response is closed synchronously in the async path, unnecessarily blocking.
The PR closes the response asynchronously instead