### PR TITLE
Document and fix behavior of custom client instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,33 @@ training = replicate.trainings.create(
 )
 ```
 
+## Customize client behavior
+
+The `replicate` package exports a default shared client.
+This client is initialized with an API token
+set by the `REPLICATE_API_TOKEN` environment variable.
+
+You can create your own client instance to
+pass a different API token value,
+add custom headers to requests,
+or control the behavior of the underlying [HTTPX client](https://www.python-httpx.org/api/#client):
+
+```python
+import os
+from replicate.client import Client
+
+replicate = Client(
+  api_token=os.environ["SOME_OTHER_REPLICATE_API_TOKEN"]
+  headers={
+    "User-Agent": "my-app/1.0
+  }
+)
+```
+
+> [!WARNING]
+> Never hardcode authentication credentials like API tokens into your code.
+> Instead, pass them as environment variables when running your program.
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -330,11 +330,11 @@ def _build_httpx_client(
     **kwargs,
 ) -> Union[httpx.Client, httpx.AsyncClient]:
     headers = kwargs.pop("headers", {})
-    headers["User-Agent"] = f"replicate-python/{__version__}"
-
-    if (
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = f"replicate-python/{__version__}"
+    if "Authorization" not in headers and (
         api_token := api_token or os.environ.get("REPLICATE_API_TOKEN")
-    ) and api_token != "":
+    ):
         headers["Authorization"] = f"Bearer {api_token}"
 
     base_url = (


### PR DESCRIPTION
In #268, we allowed custom headers to be passed to client instances. However, that didn't apply any custom `User-Agent` header. This is now fixed.

This PR also updates the README to document how to create a custom client instance, incorporating this new behavior. This PR is an alternative to #304.