### PR TITLE
Add `prediction` field to `ModelError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ or a handle to a file on your local device.
 "an astronaut riding a horse"
 ```
 
+`replicate.run` raises `ModelError` if the prediction fails.
+You can access the exception's `prediction` property 
+to get more information about the failure.
+
+```python
+import replicate
+from replicate.exceptions import ModelError
+
+try:
+  output = replicate.run("stability-ai/stable-diffusion-3", { "prompt": "An astronaut riding a rainbow unicorn" })
+except ModelError as e
+  if "(some known issue)" in e.logs:
+    pass
+
+  print("Failed prediction: " + e.prediction.id)
+```
+
+
 ## Run a model and stream its output
 
 Replicate’s API supports server-sent event streams (SSEs) for language models. 

--- a/replicate/exceptions.py
+++ b/replicate/exceptions.py
@@ -1,6 +1,9 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import httpx
+
+if TYPE_CHECKING:
+    from replicate.prediction import Prediction
 
 
 class ReplicateException(Exception):
@@ -10,11 +13,11 @@ class ReplicateException(Exception):
 class ModelError(ReplicateException):
     """An error from user's code in a model."""
 
-    prediction_id: str
+    prediction: "Prediction"
 
-    def __init__(self, error: Optional[str], prediction_id: str) -> None:
-        self.prediction_id = prediction_id
-        super().__init__(error)
+    def __init__(self, prediction: "Prediction") -> None:
+        self.prediction = prediction
+        super().__init__(prediction.error)
 
 
 class ReplicateError(ReplicateException):

--- a/replicate/exceptions.py
+++ b/replicate/exceptions.py
@@ -10,6 +10,12 @@ class ReplicateException(Exception):
 class ModelError(ReplicateException):
     """An error from user's code in a model."""
 
+    prediction_id: str
+
+    def __init__(self, error: Optional[str], prediction_id: str) -> None:
+        self.prediction_id = prediction_id
+        super().__init__(error)
+
 
 class ReplicateError(ReplicateException):
     """

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -249,7 +249,7 @@ class Prediction(Resource):
             self.reload()
 
         if self.status == "failed":
-            raise ModelError(self.error)
+            raise ModelError(self.error, self.id)
 
         output = self.output or []
         new_output = output[len(previous_output) :]
@@ -272,7 +272,7 @@ class Prediction(Resource):
             await self.async_reload()
 
         if self.status == "failed":
-            raise ModelError(self.error)
+            raise ModelError(self.error, self.id)
 
         output = self.output or []
         new_output = output[len(previous_output) :]

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -249,7 +249,7 @@ class Prediction(Resource):
             self.reload()
 
         if self.status == "failed":
-            raise ModelError(self.error, self.id)
+            raise ModelError(self)
 
         output = self.output or []
         new_output = output[len(previous_output) :]
@@ -272,7 +272,7 @@ class Prediction(Resource):
             await self.async_reload()
 
         if self.status == "failed":
-            raise ModelError(self.error, self.id)
+            raise ModelError(self)
 
         output = self.output or []
         new_output = output[len(previous_output) :]

--- a/replicate/run.py
+++ b/replicate/run.py
@@ -58,7 +58,7 @@ def run(
     prediction.wait()
 
     if prediction.status == "failed":
-        raise ModelError(prediction.error, prediction.id)
+        raise ModelError(prediction)
 
     return prediction.output
 
@@ -97,7 +97,7 @@ async def async_run(
     await prediction.async_wait()
 
     if prediction.status == "failed":
-        raise ModelError(prediction.error, prediction.id)
+        raise ModelError(prediction)
 
     return prediction.output
 

--- a/replicate/run.py
+++ b/replicate/run.py
@@ -58,7 +58,7 @@ def run(
     prediction.wait()
 
     if prediction.status == "failed":
-        raise ModelError(prediction.error)
+        raise ModelError(prediction.error, prediction.id)
 
     return prediction.output
 
@@ -97,7 +97,7 @@ async def async_run(
     await prediction.async_wait()
 
     if prediction.status == "failed":
-        raise ModelError(prediction.error)
+        raise ModelError(prediction.error, prediction.id)
 
     return prediction.output
 


### PR DESCRIPTION
This PR extends #325 to add the prediction object itself to `ModelError`, as opposed to just its ID. This makes it convenient to introspect logs and other information to determine how to handle the failure.

```python
import replicate
from replicate.exceptions import ModelError

try:
  output = replicate.run("stability-ai/stable-diffusion-3", { "prompt": "..." })
except ModelError as e
  if "(some known issue)" in e.logs:
    pass

  print("Failed prediction: " + e.prediction.id)
```