### PR TITLE
Correctly pass filename to file creation call

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,31 +1,12 @@
 {
   "editor.formatOnSave": true,
-  "editor.formatOnType": true,
-  "editor.formatOnPaste": true,
-  "editor.renderControlCharacters": true,
-  "editor.suggest.localityBonus": true,
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
-    "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll": "explicit",
-      "source.organizeImports": "explicit"
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
     }
-  },
-  "python.languageServer": "Pylance",
-  "python.analysis.typeCheckingMode": "basic",
-  "python.testing.pytestArgs": [
-    "-vvv",
-    "python"
-  ],
-  "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true,
-  "ruff.lint.args": [
-    "--config=pyproject.toml"
-  ],
-  "ruff.format.args": [
-    "--config=pyproject.toml"
-  ],
+  }
 }

--- a/replicate/file.py
+++ b/replicate/file.py
@@ -71,6 +71,8 @@ class Files(Namespace):
         """
 
         if isinstance(file, (str, pathlib.Path)):
+            file_path = pathlib.Path(file)
+            params["filename"] = file_path.name
             with open(file, "rb") as f:
                 return self.create(f, **params)
         elif not isinstance(file, (io.IOBase, BinaryIO)):
@@ -92,7 +94,9 @@ class Files(Namespace):
         """Upload a file asynchronously that can be passed as an input when running a model."""
 
         if isinstance(file, (str, pathlib.Path)):
-            with open(file, "rb") as f:
+            file_path = pathlib.Path(file)
+            params["filename"] = file_path.name
+            with open(file_path, "rb") as f:
                 return await self.async_create(f, **params)
         elif not isinstance(file, (io.IOBase, BinaryIO)):
             raise ValueError(

--- a/replicate/file.py
+++ b/replicate/file.py
@@ -93,7 +93,7 @@ class Files(Namespace):
 
         if isinstance(file, (str, pathlib.Path)):
             with open(file, "rb") as f:
-                return self.create(f, **params)
+                return await self.async_create(f, **params)
         elif not isinstance(file, (io.IOBase, BinaryIO)):
             raise ValueError(
                 "Unsupported file type. Must be a file path or file-like object."


### PR DESCRIPTION
Resolves #338 

Follow up to #226 

Filenames from open file handles were not being passed correctly in `create` / `async_create`. This PR fixes that and adds some test coverage.