### PR TITLE
Read REPLICATE_API_TOKEN from cog context

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ export REPLICATE_API_TOKEN=<your token>
 
 We recommend not adding the token directly to your source code, because you don't want to put your credentials in source control. If anyone used your API key, their usage would be charged to your account.
 
+<details>
+
+<summary>Alternative authentication</summary>
+
+As of [replicate 1.0.5](https://github.com/replicate/replicate-python/releases/tag/1.0.5) and [cog 0.14.11](https://github.com/replicate/cog/releases/tag/v0.14.11) it is possible to pass a `REPLICATE_API_TOKEN` via the `context` as part of a prediction request.
+
+The `Replicate()` constructor will now use this context when available. This grants cog models the ability to use the Replicate client libraries, scoped to a user on a per request basis.
+
+</details>
+
 ## Run a model
 
 Create a new Python file and add the following code, replacing the model identifier and input with your own:

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -351,7 +351,7 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
 def _get_api_token_from_environment() -> Optional[str]:
     """Get API token from cog current scope if available, otherwise from environment."""
     try:
-        import cog
+        import cog  # noqa: I001 # pyright: ignore [reportMissingImports]
 
         for key, value in cog.current_scope().context.items():
             if key.upper() == "REPLICATE_API_TOKEN":

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -355,10 +355,11 @@ def _get_api_token_from_environment() -> Optional[str]:
 
         if hasattr(cog, "current_scope"):
             scope = cog.current_scope()
-            if scope and hasattr(scope, "content") and isinstance(scope.content, dict):
-                if "replicate_api_token" in scope.content:
-                    return scope.content["replicate_api_token"]
-    except (ImportError, AttributeError, Exception):
+            if scope and hasattr(scope, "context") and isinstance(scope.context, dict):
+                for key, value in scope.context.items():
+                    if key.upper() == "REPLICATE_API_TOKEN":
+                        return scope.context[key]
+    except:  # noqa: S110,E722,BLE001 we don't want this code to cause clients to fail
         pass
 
     return os.environ.get("REPLICATE_API_TOKEN")

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -353,12 +353,9 @@ def _get_api_token_from_environment() -> Optional[str]:
     try:
         import cog
 
-        if hasattr(cog, "current_scope"):
-            scope = cog.current_scope()
-            if scope and hasattr(scope, "context") and isinstance(scope.context, dict):
-                for key, value in scope.context.items():
-                    if key.upper() == "REPLICATE_API_TOKEN":
-                        return scope.context[key]
+        for key, value in cog.current_scope().context.items():
+            if key.upper() == "REPLICATE_API_TOKEN":
+                return value
     except:  # noqa: S110,E722,BLE001 we don't want this code to cause clients to fail
         pass
 

--- a/replicate/helpers.py
+++ b/replicate/helpers.py
@@ -44,8 +44,7 @@ def encode_json(
     if isinstance(obj, io.IOBase):
         if file_encoding_strategy == "base64":
             return base64_encode_file(obj)
-        else:
-            return client.files.create(obj).urls["get"]
+        return client.files.create(obj).urls["get"]
     if HAS_NUMPY:
         if isinstance(obj, np.integer):  # type: ignore
             return int(obj)
@@ -82,8 +81,7 @@ async def async_encode_json(
         if file_encoding_strategy == "base64":
             # TODO: This should ideally use an async based file reader path.
             return base64_encode_file(obj)
-        else:
-            return (await client.files.async_create(obj)).urls["get"]
+        return (await client.files.async_create(obj)).urls["get"]
     if HAS_NUMPY:
         if isinstance(obj, np.integer):  # type: ignore
             return int(obj)
@@ -183,9 +181,9 @@ def transform_output(value: Any, client: "Client") -> Any:
     def transform(obj: Any) -> Any:
         if isinstance(obj, Mapping):
             return {k: transform(v) for k, v in obj.items()}
-        elif isinstance(obj, Sequence) and not isinstance(obj, str):
+        if isinstance(obj, Sequence) and not isinstance(obj, str):
             return [transform(item) for item in obj]
-        elif isinstance(obj, str) and (
+        if isinstance(obj, str) and (
             obj.startswith("https:") or obj.startswith("data:")
         ):
             return FileOutput(obj, client)

--- a/replicate/run.py
+++ b/replicate/run.py
@@ -38,7 +38,7 @@ def run(
 
     if "wait" not in params:
         params["wait"] = True
-    is_blocking = params["wait"] != False  # noqa: E712
+    is_blocking = params["wait"] is not False
 
     version, owner, name, version_id = identifier._resolve(ref)
 
@@ -108,7 +108,7 @@ async def async_run(
 
     if "wait" not in params:
         params["wait"] = True
-    is_blocking = params["wait"] != False  # noqa: E712
+    is_blocking = params["wait"] is not False
 
     version, owner, name, version_id = identifier._resolve(ref)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -127,7 +127,7 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": None}):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
     def test_cog_import_error_falls_back_to_env(self):
         """Test fallback to environment when cog import raises exception."""
@@ -137,7 +137,7 @@ class TestGetApiToken:
                 side_effect=ModuleNotFoundError("No module named 'cog'"),
             ):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
     def test_cog_no_current_scope_method_falls_back_to_env(self):
         """Test fallback when cog exists but has no current_scope method."""
@@ -147,7 +147,7 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": mock_cog}):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
     def test_cog_current_scope_returns_none_falls_back_to_env(self):
         """Test fallback when current_scope() returns None."""
@@ -157,12 +157,12 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": mock_cog}):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
-    def test_cog_scope_no_content_attr_falls_back_to_env(self):
-        """Test fallback when scope has no content attribute."""
+    def test_cog_scope_no_context_attr_falls_back_to_env(self):
+        """Test fallback when scope has no context attribute."""
         mock_scope = mock.MagicMock()
-        del mock_scope.content  # Remove the content attribute
+        del mock_scope.context  # Remove the context attribute
 
         mock_cog = mock.MagicMock()
         mock_cog.current_scope.return_value = mock_scope
@@ -170,12 +170,12 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": mock_cog}):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
-    def test_cog_scope_content_not_dict_falls_back_to_env(self):
-        """Test fallback when scope.content is not a dictionary."""
+    def test_cog_scope_context_not_dict_falls_back_to_env(self):
+        """Test fallback when scope.context is not a dictionary."""
         mock_scope = mock.MagicMock()
-        mock_scope.content = "not a dict"
+        mock_scope.context = "not a dict"
 
         mock_cog = mock.MagicMock()
         mock_cog.current_scope.return_value = mock_scope
@@ -183,12 +183,12 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": mock_cog}):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
     def test_cog_scope_no_replicate_api_token_key_falls_back_to_env(self):
-        """Test fallback when replicate_api_token key is missing from content."""
+        """Test fallback when replicate_api_token key is missing from context."""
         mock_scope = mock.MagicMock()
-        mock_scope.content = {"other_key": "other_value"}  # Missing replicate_api_token
+        mock_scope.context = {"other_key": "other_value"}  # Missing replicate_api_token
 
         mock_cog = mock.MagicMock()
         mock_cog.current_scope.return_value = mock_scope
@@ -196,12 +196,12 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": mock_cog}):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
     def test_cog_scope_replicate_api_token_valid_string(self):
         """Test successful retrieval of non-empty token from cog."""
         mock_scope = mock.MagicMock()
-        mock_scope.content = {"replicate_api_token": "cog-token"}
+        mock_scope.context = {"REPLICATE_API_TOKEN": "cog-token"}
 
         mock_cog = mock.MagicMock()
         mock_cog.current_scope.return_value = mock_scope
@@ -209,12 +209,25 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": mock_cog}):
                 token = _get_api_token_from_environment()
-                assert token == "cog-token"
+                assert token == "cog-token"  # noqa: S105
+
+    def test_cog_scope_replicate_api_token_case_insensitive(self):
+        """Test successful retrieval of non-empty token from cog ignoring case."""
+        mock_scope = mock.MagicMock()
+        mock_scope.context = {"replicate_api_token": "cog-token"}
+
+        mock_cog = mock.MagicMock()
+        mock_cog.current_scope.return_value = mock_scope
+
+        with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
+            with mock.patch.dict(sys.modules, {"cog": mock_cog}):
+                token = _get_api_token_from_environment()
+                assert token == "cog-token"  # noqa: S105
 
     def test_cog_scope_replicate_api_token_empty_string(self):
         """Test that empty string from cog is returned (not falling back to env)."""
         mock_scope = mock.MagicMock()
-        mock_scope.content = {"replicate_api_token": ""}  # Empty string
+        mock_scope.context = {"replicate_api_token": ""}  # Empty string
 
         mock_cog = mock.MagicMock()
         mock_cog.current_scope.return_value = mock_scope
@@ -227,7 +240,7 @@ class TestGetApiToken:
     def test_cog_scope_replicate_api_token_none(self):
         """Test that None from cog is returned (not falling back to env)."""
         mock_scope = mock.MagicMock()
-        mock_scope.content = {"replicate_api_token": None}
+        mock_scope.context = {"replicate_api_token": None}
 
         mock_cog = mock.MagicMock()
         mock_cog.current_scope.return_value = mock_scope
@@ -245,7 +258,7 @@ class TestGetApiToken:
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
             with mock.patch.dict(sys.modules, {"cog": mock_cog}):
                 token = _get_api_token_from_environment()
-                assert token == "env-token"
+                assert token == "env-token"  # noqa: S105
 
     def test_no_env_token_returns_none(self):
         """Test that None is returned when no environment token is set and cog unavailable."""


### PR DESCRIPTION
This PR introduces support for the cog context introduced in 0.14.11 into the Replicate SDK. The `current_scope` helper now makes per-prediction context available via the `current_scope().context` dict.

A cog model can then provide a `REPLICATE_API_TOKEN` on a per-prediction basis to be used by the model.

```
curl -X POST http://localhost/predictions -H 'Content-Type: application/json' -d '{
    "inputs": { "prompt": "make me a sandwich" },
    "context": { "REPLICATE_API_TOKEN": "r8_xyz..." }
}'
```

```py
def predict(prompt: str) -> str:
    # create a Replicate client using the token provided in the request
    replicate = Replicate()
    output = replicate.run("anthropic/claude-3.5-haiku", {input:
{"prompt": "prompt"}})
    return output
```
