### PR TITLE
Add experimental `replicate.use()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,46 @@ for output in outputs:
     print(get_url_path(output)) # "https://replicate.delivery/xyz"
 ```
 
+### Async Mode
+
+By default `use()` will return a function instance with a sync interface. You can pass `use_async=True` to have it return an `AsyncFunction` that provides an async interface.
+
+```py
+import asyncio
+import replicate
+
+async def main():
+    flux_dev = replicate.use("black-forest-labs/flux-dev", use_async=True)
+    outputs = await flux_dev(prompt="a cat wearing an amusing hat")
+
+    for output in outputs:
+        print(Path(output))
+
+asyncio.run(main())
+```
+
+If the model returns an iterator an `AsyncIterator` implementation will be used:
+
+```py
+import asyncio
+import replicate
+
+async def main():
+    claude = replicate.use("anthropic/claude-3.5-haiku", use_async=True)
+    output = await claude(prompt="say hello")
+
+    # Stream the response as it comes in.
+    async for token in output:
+        print(token)
+
+    # Wait until model has completed. This will return either a `list` or a `str` depending
+    # on whether the model uses AsyncIterator or ConcatenateAsyncIterator. You can check this
+    # on the model schema by looking for `x-cog-display: concatenate`.
+    print(await output)
+
+asyncio.run(main())
+```
+
 ### Typing
 
 By default `use()` knows nothing about the interface of the model. To provide a better developer experience we provide two methods to add type annotations to the function returned by the `use()` helper.
@@ -666,11 +706,10 @@ In future we hope to provide tooling to generate and provide these models as pac
 
 There are several key things still outstanding:
 
- 1. Support for asyncio.
- 2. Support for streaming text when available (rather than polling)
- 3. Support for streaming files when available (rather than polling)
- 4. Support for cleaning up downloaded files.
- 5. Support for streaming logs using `OutputIterator`.
+ 1. Support for streaming text when available (rather than polling)
+ 2. Support for streaming files when available (rather than polling)
+ 3. Support for cleaning up downloaded files.
+ 4. Support for streaming logs using `OutputIterator`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -592,16 +592,49 @@ for output in outputs:
     print(get_url_path(output)) # "https://replicate.delivery/xyz"
 ```
 
+### Typing
+
+By default `use()` knows nothing about the interface of the model. To provide a better developer experience we provide two methods to add type annotations to the function returned by the `use()` helper.
+
+**1. Provide a function signature**
+
+The use method accepts a function signature as an additional `hint` keyword argument. When provided it will use this signature for the `model()` and `model.create()` functions.
+
+```py
+# Flux takes a required prompt string and optional image and seed.
+def hint(*, prompt: str, image: Path | None = None, seed: int | None = None) -> str: ...
+
+flux_dev = use("black-forest-labs/flux-dev", hint=hint)
+output1 = flux_dev() # will warn that `prompt` is missing
+output2 = flux_dev(prompt="str") # output2 will be typed as `str`
+```
+
+**2. Provide a class**
+
+The second method requires creating a callable class with a `name` field. The name will be used as the function reference when passed to `use()`.
+
+```py
+class FluxDev:
+    name = "black-forest-labs/flux-dev"
+
+    def __call__( self, *, prompt: str, image: Path | None = None, seed: int | None = None ) -> str: ...
+
+flux_dev = use(FluxDev)
+output1 = flux_dev() # will warn that `prompt` is missing
+output2 = flux_dev(prompt="str") # output2 will be typed as `str`
+```
+
+In future we hope to provide tooling to generate and provide these models as packages to make working with them easier. For now you may wish to create your own.
+
 ### TODO
 
 There are several key things still outstanding:
 
  1. Support for asyncio.
- 2. Support for typing the return value.
- 3. Support for streaming text when available (rather than polling)
- 4. Support for streaming files when available (rather than polling)
- 5. Support for cleaning up downloaded files.
- 6. Support for streaming logs using `OutputIterator`.
+ 2. Support for streaming text when available (rather than polling)
+ 3. Support for streaming files when available (rather than polling)
+ 4. Support for cleaning up downloaded files.
+ 5. Support for streaming logs using `OutputIterator`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -710,6 +710,153 @@ output2 = flux_dev(prompt="str") # output2 will be typed as `str`
 
 In future we hope to provide tooling to generate and provide these models as packages to make working with them easier. For now you may wish to create your own.
 
+### API Reference
+
+The Replicate Python Library provides several key classes and functions for working with models in pipelines:
+
+#### `use()` Function
+
+Creates a callable function wrapper for a Replicate model.
+
+```py
+def use(
+    ref: FunctionRef,
+    *,
+    streaming: bool = False,
+    use_async: bool = False
+) -> Function | AsyncFunction
+
+def use(
+    ref: str,
+    *,
+    hint: Callable | None = None,
+    streaming: bool = False,
+    use_async: bool = False
+) -> Function | AsyncFunction
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ref` | `str \| FunctionRef` | Required | Model reference (e.g., "owner/model" or "owner/model:version") |
+| `hint` | `Callable \| None` | `None` | Function signature for type hints |
+| `streaming` | `bool` | `False` | Return OutputIterator for streaming results |
+| `use_async` | `bool` | `False` | Return AsyncFunction instead of Function |
+
+**Returns:**
+- `Function` - Synchronous model wrapper (default)
+- `AsyncFunction` - Asynchronous model wrapper (when `use_async=True`)
+
+#### `Function` Class
+
+A synchronous wrapper for calling Replicate models.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `__call__()` | `(*args, **inputs) -> Output` | Execute the model and return final output |
+| `create()` | `(*args, **inputs) -> Run` | Start a prediction and return Run object |
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `openapi_schema` | `dict` | Model's OpenAPI schema for inputs/outputs |
+| `default_example` | `dict \| None` | Default example inputs (not yet implemented) |
+
+#### `AsyncFunction` Class
+
+An asynchronous wrapper for calling Replicate models.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `__call__()` | `async (*args, **inputs) -> Output` | Execute the model and return final output |
+| `create()` | `async (*args, **inputs) -> AsyncRun` | Start a prediction and return AsyncRun object |
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `openapi_schema()` | `async () -> dict` | Model's OpenAPI schema for inputs/outputs |
+| `default_example` | `dict \| None` | Default example inputs (not yet implemented) |
+
+#### `Run` Class
+
+Represents a running prediction with access to output and logs.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `output()` | `() -> Output` | Get prediction output (blocks until complete) |
+| `logs()` | `() -> str \| None` | Get current prediction logs |
+
+**Behavior:**
+- When `streaming=True`: Returns `OutputIterator` immediately
+- When `streaming=False`: Waits for completion and returns final result
+
+#### `AsyncRun` Class
+
+Asynchronous version of Run for async model calls.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `output()` | `async () -> Output` | Get prediction output (awaits completion) |
+| `logs()` | `async () -> str \| None` | Get current prediction logs |
+
+#### `OutputIterator` Class
+
+Iterator wrapper for streaming model outputs.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `__iter__()` | `() -> Iterator[T]` | Synchronous iteration over output chunks |
+| `__aiter__()` | `() -> AsyncIterator[T]` | Asynchronous iteration over output chunks |
+| `__str__()` | `() -> str` | Convert to string (concatenated or list representation) |
+| `__await__()` | `() -> List[T] \| str` | Await all results (string for concatenate, list otherwise) |
+
+#### `URLPath` Class
+
+A path-like object that downloads files on first access.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `__fspath__()` | `() -> str` | Get local file path (downloads if needed) |
+| `__str__()` | `() -> str` | String representation of local path |
+
+**Usage:**
+- Compatible with `open()`, `pathlib.Path()`, and most file operations
+- Downloads file automatically on first filesystem access
+- Cached locally in temporary directory
+
+#### `get_path_url()` Function
+
+Helper function to extract original URLs from `URLPath` objects.
+
+```py
+def get_path_url(path: Any) -> str | None
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | `Any` | Path object (typically `URLPath`) |
+
+**Returns:**
+- `str` - Original URL if path is a `URLPath`
+- `None` - If path is not a `URLPath` or has no URL
+
 ### TODO
 
 There are several key things still outstanding:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,6 @@ ignore = [
     "ANN001", # Missing type annotation for function argument
     "ANN002", # Missing type annotation for `*args`
     "ANN003", # Missing type annotation for `**kwargs`
-    "ANN101", # Missing type annotation for self in method
-    "ANN102", # Missing type annotation for cls in classmethod
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed in {name}
     "W191",   # Indentation contains tabs
     "UP037",  # Remove quotes from type annotation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev-dependencies = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "tests/"
 
 [tool.setuptools]

--- a/replicate/__init__.py
+++ b/replicate/__init__.py
@@ -1,6 +1,7 @@
 from replicate.client import Client
 from replicate.pagination import async_paginate as _async_paginate
 from replicate.pagination import paginate as _paginate
+from replicate.use import use
 
 default_client = Client()
 

--- a/replicate/__init__.py
+++ b/replicate/__init__.py
@@ -3,6 +3,26 @@ from replicate.pagination import async_paginate as _async_paginate
 from replicate.pagination import paginate as _paginate
 from replicate.use import use
 
+__all__ = [
+    "Client",
+    "use",
+    "run",
+    "async_run",
+    "stream",
+    "async_stream",
+    "paginate",
+    "async_paginate",
+    "collections",
+    "deployments",
+    "files",
+    "hardware",
+    "models",
+    "predictions",
+    "trainings",
+    "webhooks",
+    "default_client",
+]
+
 default_client = Client()
 
 run = default_client.run

--- a/replicate/__init__.py
+++ b/replicate/__init__.py
@@ -1,7 +1,7 @@
 from replicate.client import Client
 from replicate.pagination import async_paginate as _async_paginate
 from replicate.pagination import paginate as _paginate
-from replicate.use import use
+from replicate.use import get_path_url, use
 
 __all__ = [
     "Client",
@@ -21,6 +21,7 @@ __all__ = [
     "trainings",
     "webhooks",
     "default_client",
+    "get_path_url",
 ]
 
 default_client = Client()

--- a/replicate/client.py
+++ b/replicate/client.py
@@ -352,6 +352,11 @@ def _get_api_token_from_environment() -> Optional[str]:
     """Get API token from cog current scope if available, otherwise from environment."""
     try:
         import cog  # noqa: I001 # pyright: ignore [reportMissingImports]
+        import warnings
+
+        warnings.filterwarnings(
+            "ignore", message="current_scope", category=cog.ExperimentalFeatureWarning
+        )
 
         for key, value in cog.current_scope().context.items():
             if key.upper() == "REPLICATE_API_TOKEN":

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -248,6 +248,11 @@ class Prediction(Resource):
         """
         Return an iterator of the prediction output.
         """
+        if (
+            self.status in ["succeeded", "failed", "canceled"]
+            and self.output is not None
+        ):
+            yield from self.output
 
         # TODO: check output is list
         previous_output = self.output or []
@@ -270,6 +275,12 @@ class Prediction(Resource):
         """
         Return an asynchronous iterator of the prediction output.
         """
+        if (
+            self.status in ["succeeded", "failed", "canceled"]
+            and self.output is not None
+        ):
+            for item in self.output:
+                yield item
 
         # TODO: check output is list
         previous_output = self.output or []

--- a/replicate/schema.py
+++ b/replicate/schema.py
@@ -15,12 +15,12 @@ def version_has_no_array_type(cog_version: str) -> Optional[bool]:
 
 def make_schema_backwards_compatible(
     schema: dict,
-    cog_version: str,
+    cog_version: str | None,
 ) -> dict:
     """A place to add backwards compatibility logic for our openapi schema"""
 
     # If the top-level output is an array, assume it is an iterator in old versions which didn't have an array type
-    if version_has_no_array_type(cog_version):
+    if cog_version and version_has_no_array_type(cog_version):
         output = schema["components"]["schemas"]["Output"]
         if output.get("type") == "array":
             output["x-cog-array-type"] = "iterator"

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -154,7 +154,7 @@ def _process_output_with_schema(output: Any, openapi_schema: dict) -> Any:
     # Handle direct string with format=uri
     if output_schema.get("type") == "string" and output_schema.get("format") == "uri":
         if isinstance(output, str) and output.startswith(("http://", "https://")):
-            return _download_file(output)
+            return PathProxy(output)
         return output
 
     # Handle array of strings with format=uri
@@ -163,7 +163,7 @@ def _process_output_with_schema(output: Any, openapi_schema: dict) -> Any:
         if items.get("type") == "string" and items.get("format") == "uri":
             if isinstance(output, list):
                 return [
-                    _download_file(url)
+                    PathProxy(url)
                     if isinstance(url, str) and url.startswith(("http://", "https://"))
                     else url
                     for url in output
@@ -187,7 +187,7 @@ def _process_output_with_schema(output: Any, openapi_schema: dict) -> Any:
                     if isinstance(value, str) and value.startswith(
                         ("http://", "https://")
                     ):
-                        result[prop_name] = _download_file(value)
+                        result[prop_name] = PathProxy(value)
 
                 # Array of files property
                 elif prop_schema.get("type") == "array":
@@ -195,7 +195,7 @@ def _process_output_with_schema(output: Any, openapi_schema: dict) -> Any:
                     if items.get("type") == "string" and items.get("format") == "uri":
                         if isinstance(value, list):
                             result[prop_name] = [
-                                _download_file(url)
+                                PathProxy(url)
                                 if isinstance(url, str)
                                 and url.startswith(("http://", "https://"))
                                 else url

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -436,7 +436,9 @@ def use(ref: FunctionRef[Input, Output]) -> Function[Input, Output]: ...
 
 
 @overload
-def use(ref: str, *, hint: Callable[Input, Output]) -> Function[Input, Output]: ...
+def use(
+    ref: str, *, hint: Callable[Input, Output] | None = None
+) -> Function[Input, Output]: ...
 
 
 def use(

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -225,6 +225,10 @@ class PathProxy(Path):
         if name in ("__path__", "__target__"):
             return object.__getattribute__(self, name)
 
+        # TODO: We should cover other common properties on Path...
+        if name == "__class__":
+            return Path
+
         return getattr(object.__getattribute__(self, "__path__")(), name)
 
     def __setattr__(self, name, value) -> None:
@@ -332,11 +336,13 @@ class Function:
         """
         Start a prediction with the specified inputs.
         """
-        # Process inputs to convert concatenate OutputIterators to strings
+        # Process inputs to convert concatenate OutputIterators to strings and PathProxy to URLs
         processed_inputs = {}
         for key, value in inputs.items():
             if isinstance(value, OutputIterator) and value.is_concatenate:
                 processed_inputs[key] = str(value)
+            elif isinstance(value, PathProxy):
+                processed_inputs[key] = object.__getattribute__(value, "__target__")
             else:
                 processed_inputs[key] = value
 

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -368,11 +368,17 @@ class Run[O]:
                 ),
             )
 
-        # For non-iterator types, wait for completion and process output
+        # For non-streaming, wait for completion and process output
         self._prediction.wait()
 
         if self._prediction.status == "failed":
             raise ModelError(self._prediction)
+
+        # Handle concatenate iterators - return joined string
+        if _has_concatenate_iterator_output_type(self._schema):
+            if isinstance(self._prediction.output, list):
+                return "".join(str(item) for item in self._prediction.output)
+            return self._prediction.output
 
         # Process output for file downloads based on schema
         return _process_output_with_schema(self._prediction.output, self._schema)
@@ -529,11 +535,17 @@ class AsyncRun[O]:
                 ),
             )
 
-        # For non-iterator types, wait for completion and process output
+        # For non-streaming, wait for completion and process output
         await self._prediction.async_wait()
 
         if self._prediction.status == "failed":
             raise ModelError(self._prediction)
+
+        # Handle concatenate iterators - return joined string
+        if _has_concatenate_iterator_output_type(self._schema):
+            if isinstance(self._prediction.output, list):
+                return "".join(str(item) for item in self._prediction.output)
+            return self._prediction.output
 
         # Process output for file downloads based on schema
         return _process_output_with_schema(self._prediction.output, self._schema)

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -434,8 +434,11 @@ class Function(Generic[Input, Output]):
         # Process inputs to convert concatenate OutputIterators to strings and URLPath to URLs
         processed_inputs = {}
         for key, value in inputs.items():
-            if isinstance(value, OutputIterator) and value.is_concatenate:
-                processed_inputs[key] = str(value)
+            if isinstance(value, OutputIterator):
+                if value.is_concatenate:
+                    processed_inputs[key] = str(value)
+                else:
+                    processed_inputs[key] = list(value)
             elif url := get_path_url(value):
                 processed_inputs[key] = url
             else:
@@ -578,8 +581,8 @@ class AsyncFunction(Generic[Input, Output]):
         # Process inputs to convert concatenate OutputIterators to strings and URLPath to URLs
         processed_inputs = {}
         for key, value in inputs.items():
-            if isinstance(value, OutputIterator) and value.is_concatenate:
-                processed_inputs[key] = str(value)
+            if isinstance(value, OutputIterator):
+                processed_inputs[key] = await value
             elif url := get_path_url(value):
                 processed_inputs[key] = url
             else:

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -307,7 +307,7 @@ class URLPath(os.PathLike):
         return str(self.__path__)
 
     def __str__(self) -> str:
-        return str(self.__path__)
+        return self.__fspath__()
 
     def __repr__(self) -> str:
         return f"<URLPath url={self.__url__!r} path={self.__path__!r}>"

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -1,0 +1,198 @@
+# TODO
+# - [ ] Support downloading files and conversion into Path when schema is URL
+# - [ ] Support asyncio variant
+# - [ ] Support list outputs
+# - [ ] Support iterator outputs
+# - [ ] Support text streaming
+# - [ ] Support file streaming
+# - [ ] Support reusing output URL when passing to new method
+# - [ ] Support lazy downloading of files into Path
+# - [ ] Support helpers for working with ContatenateIterator
+import inspect
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Any, Dict, Optional, Tuple
+
+from replicate.client import Client
+from replicate.exceptions import ModelError, ReplicateError
+from replicate.identifier import ModelVersionIdentifier
+from replicate.model import Model
+from replicate.prediction import Prediction
+from replicate.run import make_schema_backwards_compatible
+from replicate.version import Version
+
+
+def _in_module_scope() -> bool:
+    """
+    Returns True when called from top level module scope.
+    """
+    import os
+    if os.getenv("REPLICATE_ALWAYS_ALLOW_USE"):
+        return True
+        
+    if frame := inspect.currentframe():
+        if caller := frame.f_back:
+            return caller.f_code.co_name == "<module>"
+    return False
+
+
+__all__ = ["use"]
+
+
+def _has_concatenate_iterator_output_type(openapi_schema: dict) -> bool:
+    """
+    Returns true if the model output type is ConcatenateIterator or
+    AsyncConcatenateIterator.
+    """
+    output = openapi_schema.get("components", {}).get("schemas", {}).get("Output", {})
+
+    if output.get("type") != "array":
+        return False
+
+    if output.get("items", {}).get("type") != "string":
+        return False
+
+    if output.get("x-cog-array-type") != "iterator":
+        return False
+
+    if output.get("x-cog-array-display") != "concatenate":
+        return False
+
+    return True
+
+
+@dataclass
+class Run:
+    """
+    Represents a running prediction with access to its version.
+    """
+
+    prediction: Prediction
+    schema: dict
+
+    def wait(self) -> Any:
+        """
+        Wait for the prediction to complete and return its output.
+        """
+        self.prediction.wait()
+
+        if self.prediction.status == "failed":
+            raise ModelError(self.prediction)
+
+        if _has_concatenate_iterator_output_type(self.schema):
+            return "".join(self.prediction.output)
+
+        return self.prediction.output
+
+    def logs(self) -> Optional[str]:
+        """
+        Fetch and return the logs from the prediction.
+        """
+        self.prediction.reload()
+
+        return self.prediction.logs
+
+
+@dataclass
+class Function:
+    """
+    A wrapper for a Replicate model that can be called as a function.
+    """
+
+    function_ref: str
+
+    def _client(self) -> Client:
+        return Client()
+
+    @cached_property
+    def _parsed_ref(self) -> Tuple[str, str, Optional[str]]:
+        return ModelVersionIdentifier.parse(self.function_ref)
+
+    @cached_property
+    def _model(self) -> Model:
+        client = self._client()
+        model_owner, model_name, _ = self._parsed_ref
+        return client.models.get(f"{model_owner}/{model_name}")
+
+    @cached_property
+    def _version(self) -> Version | None:
+        _, _, model_version = self._parsed_ref
+        model = self._model
+        try:
+            versions = model.versions.list()
+            if len(versions) == 0:
+                # if we got an empty list when getting model versions, this
+                # model is possibly a procedure instead and should be called via
+                # the versionless API
+                return None
+        except ReplicateError as e:
+            if e.status == 404:
+                # if we get a 404 when getting model versions, this is an official
+                # model and doesn't have addressable versions (despite what
+                # latest_version might tell us)
+                return None
+            raise
+
+        version = (
+            model.versions.get(model_version) if model_version else model.latest_version
+        )
+
+        return version
+
+    def __call__(self, **inputs: Dict[str, Any]) -> Any:
+        run = self.create(**inputs)
+        return run.wait()
+
+    def create(self, **inputs: Dict[str, Any]) -> Run:
+        """
+        Start a prediction with the specified inputs.
+        """
+        version = self._version
+
+        if version:
+            prediction = self._client().predictions.create(
+                version=version, input=inputs
+            )
+        else:
+            prediction = self._client().models.predictions.create(
+                model=self._model, input=inputs
+            )
+
+        return Run(prediction, self.openapi_schema)
+
+    @property
+    def default_example(self) -> Optional[Prediction]:
+        """
+        Get the default example for this model.
+        """
+        raise NotImplementedError("This property has not yet been implemented")
+
+    @cached_property
+    def openapi_schema(self) -> dict[Any, Any]:
+        """
+        Get the OpenAPI schema for this model version.
+        """
+        schema = self._model.latest_version.openapi_schema
+        if cog_version := self._model.latest_version.cog_version:
+            schema = make_schema_backwards_compatible(schema, cog_version)
+        return schema
+
+
+def use(function_ref: str) -> Function:
+    """
+    Use a Replicate model as a function.
+
+    This function can only be called at the top level of a module.
+
+    Example:
+
+        flux_dev = replicate.use("black-forest-labs/flux-dev")
+        output = flux_dev(prompt="make me a sandwich")
+
+    """
+    if not _in_module_scope():
+        raise RuntimeError(
+            "You may only call cog.ext.pipelines.include at the top level."
+        )
+
+    return Function(function_ref)

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -8,7 +8,7 @@ import tempfile
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, Iterator, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import httpx
@@ -333,11 +333,11 @@ class Function:
 
         return version
 
-    def __call__(self, **inputs: Dict[str, Any]) -> Any:
+    def __call__(self, **inputs: Any) -> Any:
         run = self.create(**inputs)
         return run.output()
 
-    def create(self, **inputs: Dict[str, Any]) -> Run:
+    def create(self, **inputs: Any) -> Run:
         """
         Start a prediction with the specified inputs.
         """

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -21,7 +21,6 @@ from replicate.prediction import Prediction
 from replicate.run import make_schema_backwards_compatible
 from replicate.version import Version
 
-
 __all__ = ["use", "get_path_url"]
 
 

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -377,7 +377,7 @@ class Run[O]:
         # Handle concatenate iterators - return joined string
         if _has_concatenate_iterator_output_type(self._schema):
             if isinstance(self._prediction.output, list):
-                return "".join(str(item) for item in self._prediction.output)
+                return cast(O, "".join(str(item) for item in self._prediction.output))
             return self._prediction.output
 
         # Process output for file downloads based on schema
@@ -544,7 +544,7 @@ class AsyncRun[O]:
         # Handle concatenate iterators - return joined string
         if _has_concatenate_iterator_output_type(self._schema):
             if isinstance(self._prediction.output, list):
-                return "".join(str(item) for item in self._prediction.output)
+                return cast(O, "".join(str(item) for item in self._prediction.output))
             return self._prediction.output
 
         # Process output for file downloads based on schema

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -119,6 +119,9 @@ def test_custom_headers_are_applied():
     mock_send_wrapper.assert_called_once()
 
 
+class ExperimentalFeatureWarning(Warning): ...
+
+
 class TestGetApiToken:
     """Test cases for _get_api_token_from_environment function covering all import paths."""
 
@@ -142,6 +145,7 @@ class TestGetApiToken:
     def test_cog_no_current_scope_method_falls_back_to_env(self):
         """Test fallback when cog exists but has no current_scope method."""
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         del mock_cog.current_scope  # Remove the method
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -152,6 +156,7 @@ class TestGetApiToken:
     def test_cog_current_scope_returns_none_falls_back_to_env(self):
         """Test fallback when current_scope() returns None."""
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = None
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -165,6 +170,7 @@ class TestGetApiToken:
         del mock_scope.context  # Remove the context attribute
 
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = mock_scope
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -178,6 +184,7 @@ class TestGetApiToken:
         mock_scope.context = "not a dict"
 
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = mock_scope
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -191,6 +198,7 @@ class TestGetApiToken:
         mock_scope.context = {"other_key": "other_value"}  # Missing replicate_api_token
 
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = mock_scope
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -204,6 +212,7 @@ class TestGetApiToken:
         mock_scope.context = {"REPLICATE_API_TOKEN": "cog-token"}
 
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = mock_scope
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -217,6 +226,7 @@ class TestGetApiToken:
         mock_scope.context = {"replicate_api_token": "cog-token"}
 
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = mock_scope
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -230,6 +240,7 @@ class TestGetApiToken:
         mock_scope.context = {"replicate_api_token": ""}  # Empty string
 
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = mock_scope
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -243,6 +254,7 @@ class TestGetApiToken:
         mock_scope.context = {"replicate_api_token": None}
 
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.return_value = mock_scope
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):
@@ -253,6 +265,7 @@ class TestGetApiToken:
     def test_cog_current_scope_raises_exception_falls_back_to_env(self):
         """Test fallback when current_scope() raises an exception."""
         mock_cog = mock.MagicMock()
+        mock_cog.ExperimentalFeatureWarning = ExperimentalFeatureWarning
         mock_cog.current_scope.side_effect = RuntimeError("Scope error")
 
         with mock.patch.dict(os.environ, {"REPLICATE_API_TOKEN": "env-token"}):

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,4 +1,6 @@
 import os
+import types
+from pathlib import Path
 
 import httpx
 import pytest
@@ -417,8 +419,11 @@ async def test_use_iterator_of_strings_output(use_async_client):
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
 
-    # Assert that output is returned as a list (iterators are returned as lists)
-    assert output == ["hello", "world", "test"]
+    # Assert that output is returned as an iterator
+    assert isinstance(output, types.GeneratorType)
+    # Convert to list to check contents
+    output_list = list(output)
+    assert output_list == ["hello", "world", "test"]
 
 
 @pytest.mark.asyncio
@@ -448,9 +453,6 @@ async def test_use_path_output(use_async_client):
 
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
-
-    # Assert that output is returned as a Path object
-    from pathlib import Path
 
     assert isinstance(output, Path)
     assert output.exists()
@@ -496,9 +498,6 @@ async def test_use_list_of_paths_output(use_async_client):
 
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
-
-    # Assert that output is returned as a list of Path objects
-    from pathlib import Path
 
     assert isinstance(output, list)
     assert len(output) == 2
@@ -549,15 +548,15 @@ async def test_use_iterator_of_paths_output(use_async_client):
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
 
-    # Assert that output is returned as a list of Path objects
-    from pathlib import Path
-
-    assert isinstance(output, list)
-    assert len(output) == 2
-    assert all(isinstance(path, Path) for path in output)
-    assert all(path.exists() for path in output)
-    assert output[0].read_bytes() == b"fake image 1 data"
-    assert output[1].read_bytes() == b"fake image 2 data"
+    # Assert that output is returned as an iterator of Path objects
+    assert isinstance(output, types.GeneratorType)
+    # Convert to list to check contents
+    output_list = list(output)
+    assert len(output_list) == 2
+    assert all(isinstance(path, Path) for path in output_list)
+    assert all(path.exists() for path in output_list)
+    assert output_list[0].read_bytes() == b"fake image 1 data"
+    assert output_list[1].read_bytes() == b"fake image 2 data"
 
 
 @pytest.mark.asyncio
@@ -681,9 +680,6 @@ async def test_use_object_output_with_file_properties(use_async_client):
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
 
-    # Assert that output is returned as an object with file downloaded
-    from pathlib import Path
-
     assert isinstance(output, dict)
     assert output["text"] == "Generated text"
     assert output["count"] == 42
@@ -741,9 +737,6 @@ async def test_use_object_output_with_file_list_property(use_async_client):
 
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
-
-    # Assert that output is returned as an object with files downloaded
-    from pathlib import Path
 
     assert isinstance(output, dict)
     assert output["text"] == "Generated text"

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,5 +1,6 @@
 import json
 import os
+from enum import Enum
 from pathlib import Path
 
 import httpx
@@ -7,6 +8,12 @@ import pytest
 import respx
 
 import replicate
+
+
+class ClientMode(str, Enum):
+    DEFAULT = "default"
+    ASYNC = "async"
+
 
 # Allow use() to be called in test context
 os.environ["REPLICATE_ALWAYS_ALLOW_USE"] = "1"
@@ -240,9 +247,9 @@ def mock_prediction_endpoints(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use(use_async_client):
+async def test_use(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints()
 
@@ -257,9 +264,9 @@ async def test_use(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_with_version_identifier(use_async_client):
+async def test_use_with_version_identifier(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints()
 
@@ -274,9 +281,9 @@ async def test_use_with_version_identifier(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_versionless_empty_versions_list(use_async_client):
+async def test_use_versionless_empty_versions_list(client_mode):
     mock_model_endpoints(has_no_versions=True, uses_versionless_api=True)
     mock_prediction_endpoints(uses_versionless_api=True)
 
@@ -291,9 +298,9 @@ async def test_use_versionless_empty_versions_list(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_versionless_404_versions_list(use_async_client):
+async def test_use_versionless_404_versions_list(client_mode):
     mock_model_endpoints(uses_versionless_api=True)
     mock_prediction_endpoints(uses_versionless_api=True)
 
@@ -308,9 +315,9 @@ async def test_use_versionless_404_versions_list(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_function_create_method(use_async_client):
+async def test_use_function_create_method(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints()
 
@@ -328,9 +335,9 @@ async def test_use_function_create_method(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_concatenate_iterator_output(use_async_client):
+async def test_use_concatenate_iterator_output(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {
@@ -406,9 +413,9 @@ async def test_use_concatenate_iterator_output(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_list_of_strings_output(use_async_client):
+async def test_use_list_of_strings_output(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {
@@ -437,9 +444,9 @@ async def test_use_list_of_strings_output(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_iterator_of_strings_output(use_async_client):
+async def test_use_iterator_of_strings_output(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {
@@ -474,9 +481,9 @@ async def test_use_iterator_of_strings_output(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_path_output(use_async_client):
+async def test_use_path_output(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {
@@ -507,9 +514,9 @@ async def test_use_path_output(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_list_of_paths_output(use_async_client):
+async def test_use_list_of_paths_output(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {
@@ -555,9 +562,9 @@ async def test_use_list_of_paths_output(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_iterator_of_paths_output(use_async_client):
+async def test_use_iterator_of_paths_output(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {
@@ -681,9 +688,9 @@ def test_get_path_url_with_empty_target():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_pathproxy_input_conversion(use_async_client):
+async def test_use_pathproxy_input_conversion(client_mode):
     """Test that PathProxy instances are converted to URLs when passed to create()."""
     mock_model_endpoints()
 
@@ -740,9 +747,9 @@ async def test_use_pathproxy_input_conversion(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_function_logs_method(use_async_client):
+async def test_use_function_logs_method(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints()
 
@@ -758,9 +765,9 @@ async def test_use_function_logs_method(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_function_logs_method_polling(use_async_client):
+async def test_use_function_logs_method_polling(client_mode):
     mock_model_endpoints()
 
     # Mock prediction endpoints with updated logs on polling
@@ -815,9 +822,9 @@ async def test_use_function_logs_method_polling(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_object_output_with_file_properties(use_async_client):
+async def test_use_object_output_with_file_properties(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {
@@ -869,9 +876,9 @@ async def test_use_object_output_with_file_properties(use_async_client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
-async def test_use_object_output_with_file_list_property(use_async_client):
+async def test_use_object_output_with_file_list_property(client_mode):
     mock_model_endpoints(
         version_overrides={
             "openapi_schema": {

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -398,7 +398,7 @@ async def test_use_concatenate_iterator_output(use_async_client):
     )
 
     # Pass the OutputIterator as input to create()
-    run = hotdog_detector.create(text_input=output)
+    hotdog_detector.create(text_input=output)
 
     # Verify the request body contains the stringified version
     parsed_body = json.loads(request_body)
@@ -610,7 +610,7 @@ async def test_use_iterator_of_paths_output(use_async_client):
 
 def test_get_path_url_with_pathproxy():
     """Test get_path_url returns the URL for PathProxy instances."""
-    from replicate.use import get_path_url, PathProxy
+    from replicate.use import PathProxy, get_path_url
 
     url = "https://example.com/test.jpg"
     path_proxy = PathProxy(url)
@@ -623,7 +623,7 @@ def test_get_path_url_with_regular_path():
     """Test get_path_url returns None for regular Path instances."""
     from replicate.use import get_path_url
 
-    regular_path = Path("/tmp/test.txt")
+    regular_path = Path("test.txt")
 
     result = get_path_url(regular_path)
     assert result is None
@@ -651,7 +651,7 @@ def test_get_path_url_with_object_with_target():
     from replicate.use import get_path_url
 
     class MockObjectWithTarget:
-        def __init__(self, target):
+        def __init__(self, target) -> None:
             object.__setattr__(self, "__replicate_target__", target)
 
     url = "https://example.com/mock.png"
@@ -666,7 +666,7 @@ def test_get_path_url_with_empty_target():
     from replicate.use import get_path_url
 
     class MockObjectWithEmptyTarget:
-        def __init__(self, target):
+        def __init__(self, target) -> None:
             object.__setattr__(self, "__replicate_target__", target)
 
     # Test with empty string
@@ -729,7 +729,7 @@ async def test_use_pathproxy_input_conversion(use_async_client):
 
     # Call use and create with PathProxy
     hotdog_detector = replicate.use("acme/hotdog-detector")
-    run = hotdog_detector.create(image=path_proxy)
+    hotdog_detector.create(image=path_proxy)
 
     # Verify the request body contains the URL, not the downloaded file
     parsed_body = json.loads(request_body)

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,0 +1,244 @@
+import asyncio
+import io
+import json
+import os
+import sys
+from email.message import EmailMessage
+from email.parser import BytesParser
+from email.policy import HTTP
+from typing import AsyncIterator, Iterator, Optional, cast
+
+import httpx
+import pytest
+import respx
+
+import replicate
+from replicate.client import Client
+from replicate.exceptions import ModelError, ReplicateError
+from replicate.helpers import FileOutput
+
+# Allow use() to be called in test context
+os.environ["REPLICATE_ALWAYS_ALLOW_USE"] = "1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use(use_async_client):
+    # Mock the model endpoint
+    respx.get("https://api.replicate.com/v1/models/acme/hotdog-detector").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "url": "https://replicate.com/acme/hotdog-detector",
+                "owner": "acme",
+                "name": "hotdog-detector",
+                "description": "A model to detect hotdogs",
+                "visibility": "public",
+                "github_url": "https://github.com/acme/hotdog-detector",
+                "paper_url": None,
+                "license_url": None,
+                "run_count": 42,
+                "cover_image_url": None,
+                "default_example": None,
+                "latest_version": {
+                    "id": "xyz123",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "cog_version": "0.8.0",
+                    "openapi_schema": {
+                        "openapi": "3.0.2",
+                        "info": {"title": "Cog", "version": "0.1.0"},
+                        "paths": {
+                            "/": {
+                                "post": {
+                                    "summary": "Make a prediction",
+                                    "requestBody": {
+                                        "content": {
+                                            "application/json": {
+                                                "schema": {"$ref": "#/components/schemas/PredictionRequest"}
+                                            }
+                                        }
+                                    },
+                                    "responses": {
+                                        "200": {
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {"$ref": "#/components/schemas/PredictionResponse"}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "components": {
+                            "schemas": {
+                                "Input": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prompt": {"type": "string", "title": "Prompt"}
+                                    },
+                                    "required": ["prompt"]
+                                },
+                                "Output": {
+                                    "type": "string",
+                                    "title": "Output"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+    )
+
+    # Mock the versions list endpoint
+    respx.get("https://api.replicate.com/v1/models/acme/hotdog-detector/versions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": "xyz123",
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "cog_version": "0.8.0",
+                        "openapi_schema": {
+                            "openapi": "3.0.2",
+                            "info": {"title": "Cog", "version": "0.1.0"},
+                            "paths": {
+                                "/": {
+                                    "post": {
+                                        "summary": "Make a prediction",
+                                        "requestBody": {
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {"$ref": "#/components/schemas/PredictionRequest"}
+                                                }
+                                            }
+                                        },
+                                        "responses": {
+                                            "200": {
+                                                "content": {
+                                                    "application/json": {
+                                                        "schema": {"$ref": "#/components/schemas/PredictionResponse"}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "components": {
+                                "schemas": {
+                                    "Input": {
+                                        "type": "object",
+                                        "properties": {
+                                            "prompt": {"type": "string", "title": "Prompt"}
+                                        },
+                                        "required": ["prompt"]
+                                    },
+                                    "Output": {
+                                        "type": "string",
+                                        "title": "Output"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        )
+    )
+
+    # Mock the prediction creation endpoint
+    respx.post("https://api.replicate.com/v1/predictions").mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "id": "pred123",
+                "model": "acme/hotdog-detector",
+                "version": "xyz123",
+                "urls": {
+                    "get": "https://api.replicate.com/v1/predictions/pred123",
+                    "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
+                },
+                "created_at": "2024-01-01T00:00:00Z",
+                "source": "api",
+                "status": "processing",
+                "input": {"prompt": "hello world"},
+                "output": None,
+                "error": None,
+                "logs": "",
+            }
+        )
+    )
+
+    # Mock the prediction polling endpoint - first call returns processing, second returns completed
+    prediction_responses = [
+        httpx.Response(
+            200,
+            json={
+                "id": "pred123",
+                "model": "acme/hotdog-detector", 
+                "version": "xyz123",
+                "urls": {
+                    "get": "https://api.replicate.com/v1/predictions/pred123",
+                    "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
+                },
+                "created_at": "2024-01-01T00:00:00Z",
+                "source": "api",
+                "status": "processing",
+                "input": {"prompt": "hello world"},
+                "output": None,
+                "error": None,
+                "logs": "Starting prediction...",
+            }
+        ),
+        httpx.Response(
+            200,
+            json={
+                "id": "pred123",
+                "model": "acme/hotdog-detector",
+                "version": "xyz123", 
+                "urls": {
+                    "get": "https://api.replicate.com/v1/predictions/pred123",
+                    "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
+                },
+                "created_at": "2024-01-01T00:00:00Z",
+                "source": "api",
+                "status": "succeeded",
+                "input": {"prompt": "hello world"},
+                "output": "not hotdog",
+                "error": None,
+                "logs": "Starting prediction...\nPrediction completed.",
+            }
+        )
+    ]
+    
+    respx.get("https://api.replicate.com/v1/predictions/pred123").mock(
+        side_effect=prediction_responses
+    )
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+    
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+    
+    # Assert that output is the completed output from the prediction request
+    assert output == "not hotdog"
+
+# TODO
+#
+# - [ ] Test a model with a version identifier acme/hotdog-detector:xyz
+# - [ ] Test a versionless model acme/hotdog-dectector when versions list is empty
+# - [ ] Test a versionless model acme/hotdog-dectector when versions list returns a 404
+# - [ ] Test a model that returns a list of strings
+# - [ ] Test a model that returns an Iterator of strings
+# - [ ] Test a model that returns a ConcatenateIterator of strings
+# - [ ] Test a model that returns a Path
+# - [ ] Test a model that returns a list of Path
+# - [ ] Test a model that returns an iterator of Path
+# - [ ] Test the `create` method on Function.
+# - [ ] Test the logs method on Function returns an iterator where the first iteration is the current value of logs
+# - [ ] Test the logs method on Function returns an iterator that polls for new logs

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -283,6 +283,27 @@ async def test_use_with_version_identifier(client_mode):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
 @respx.mock
+async def test_use_with_function_ref(client_mode):
+    mock_model_endpoints()
+    mock_prediction_endpoints()
+
+    class HotdogDetector:
+        name = "acme/hotdog-detector:xyz123"
+
+        def __call__(self, prompt: str) -> str: ...
+
+    hotdog_detector = replicate.use(HotdogDetector())
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is the completed output from the prediction request
+    assert output == "not hotdog"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@respx.mock
 async def test_use_versionless_empty_versions_list(client_mode):
     mock_model_endpoints(has_no_versions=True, uses_versionless_api=True)
     mock_prediction_endpoints(uses_versionless_api=True)

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -18,6 +18,7 @@ class ClientMode(str, Enum):
 
 # Allow use() to be called in test context
 os.environ["REPLICATE_ALWAYS_ALLOW_USE"] = "1"
+os.environ["REPLICATE_POLL_INTERVAL"] = "0"
 
 
 def _deep_merge(base, override):

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,5 +1,4 @@
 import os
-import types
 from pathlib import Path
 
 import httpx
@@ -356,8 +355,15 @@ async def test_use_concatenate_iterator_output(use_async_client):
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
 
-    # Assert that output is concatenated from the list
-    assert output == "Hello world!"
+    # Assert that output is an OutputIterator that concatenates when converted to string
+    from replicate.use import OutputIterator
+
+    assert isinstance(output, OutputIterator)
+    assert str(output) == "Hello world!"
+
+    # Also test that it's iterable
+    output_list = list(output)
+    assert output_list == ["Hello", " ", "world", "!"]
 
 
 @pytest.mark.asyncio
@@ -419,8 +425,10 @@ async def test_use_iterator_of_strings_output(use_async_client):
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
 
-    # Assert that output is returned as an iterator
-    assert isinstance(output, types.GeneratorType)
+    # Assert that output is returned as an OutputIterator
+    from replicate.use import OutputIterator
+
+    assert isinstance(output, OutputIterator)
     # Convert to list to check contents
     output_list = list(output)
     assert output_list == ["hello", "world", "test"]
@@ -548,8 +556,10 @@ async def test_use_iterator_of_paths_output(use_async_client):
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
 
-    # Assert that output is returned as an iterator of Path objects
-    assert isinstance(output, types.GeneratorType)
+    # Assert that output is returned as an OutputIterator of Path objects
+    from replicate.use import OutputIterator
+
+    assert isinstance(output, OutputIterator)
     # Convert to list to check contents
     output_list = list(output)
     assert len(output_list) == 2

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -9,6 +9,7 @@ import pytest
 import respx
 
 import replicate
+from replicate.use import PathProxy
 
 
 class ClientMode(str, Enum):
@@ -540,6 +541,7 @@ async def test_use_path_output(client_mode):
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
 
+    assert isinstance(output, PathProxy)
     assert isinstance(output, Path)
     assert output.exists()
     assert output.read_bytes() == b"fake image data"
@@ -598,6 +600,7 @@ async def test_use_list_of_paths_output(client_mode):
 
     assert isinstance(output, list)
     assert len(output) == 2
+    assert all(isinstance(path, PathProxy) for path in output)
     assert all(isinstance(path, Path) for path in output)
     assert all(path.exists() for path in output)
     assert output[0].read_bytes() == b"fake image 1 data"
@@ -663,6 +666,7 @@ async def test_use_iterator_of_paths_output(client_mode):
     # Convert to list to check contents
     output_list = list(output)
     assert len(output_list) == 2
+    assert all(isinstance(path, PathProxy) for path in output_list)
     assert all(isinstance(path, Path) for path in output_list)
     assert all(path.exists() for path in output_list)
     assert output_list[0].read_bytes() == b"fake image 1 data"

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -608,6 +608,78 @@ async def test_use_iterator_of_paths_output(use_async_client):
     assert output_list[1].read_bytes() == b"fake image 2 data"
 
 
+def test_get_path_url_with_pathproxy():
+    """Test get_path_url returns the URL for PathProxy instances."""
+    from replicate.use import get_path_url, PathProxy
+
+    url = "https://example.com/test.jpg"
+    path_proxy = PathProxy(url)
+
+    result = get_path_url(path_proxy)
+    assert result == url
+
+
+def test_get_path_url_with_regular_path():
+    """Test get_path_url returns None for regular Path instances."""
+    from replicate.use import get_path_url
+
+    regular_path = Path("/tmp/test.txt")
+
+    result = get_path_url(regular_path)
+    assert result is None
+
+
+def test_get_path_url_with_object_without_target():
+    """Test get_path_url returns None for objects without __replicate_target__."""
+    from replicate.use import get_path_url
+
+    # Test with a string
+    result = get_path_url("not a path")
+    assert result is None
+
+    # Test with a dict
+    result = get_path_url({"key": "value"})
+    assert result is None
+
+    # Test with None
+    result = get_path_url(None)
+    assert result is None
+
+
+def test_get_path_url_with_object_with_target():
+    """Test get_path_url returns URL for any object with __replicate_target__."""
+    from replicate.use import get_path_url
+
+    class MockObjectWithTarget:
+        def __init__(self, target):
+            object.__setattr__(self, "__replicate_target__", target)
+
+    url = "https://example.com/mock.png"
+    mock_obj = MockObjectWithTarget(url)
+
+    result = get_path_url(mock_obj)
+    assert result == url
+
+
+def test_get_path_url_with_empty_target():
+    """Test get_path_url with empty/falsy target values."""
+    from replicate.use import get_path_url
+
+    class MockObjectWithEmptyTarget:
+        def __init__(self, target):
+            object.__setattr__(self, "__replicate_target__", target)
+
+    # Test with empty string
+    mock_obj = MockObjectWithEmptyTarget("")
+    result = get_path_url(mock_obj)
+    assert result == ""
+
+    # Test with None
+    mock_obj = MockObjectWithEmptyTarget(None)
+    result = get_path_url(mock_obj)
+    assert result is None
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async_client", [False])
 @respx.mock

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,48 +1,99 @@
-import asyncio
-import io
-import json
 import os
-import sys
-from email.message import EmailMessage
-from email.parser import BytesParser
-from email.policy import HTTP
-from typing import AsyncIterator, Iterator, Optional, cast
 
 import httpx
 import pytest
 import respx
 
 import replicate
-from replicate.client import Client
-from replicate.exceptions import ModelError, ReplicateError
-from replicate.helpers import FileOutput
 
 # Allow use() to be called in test context
 os.environ["REPLICATE_ALWAYS_ALLOW_USE"] = "1"
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("use_async_client", [False])
-@respx.mock
-async def test_use(use_async_client):
+def mock_model_endpoints(
+    owner="acme",
+    name="hotdog-detector",
+    version_id="xyz123",
+    versions_response_status=200,
+    versions_results=None,
+    *,
+    include_specific_version=False,
+    output_schema=None,
+):
+    """Mock the model and versions endpoints."""
+    if output_schema is None:
+        output_schema = {"type": "string", "title": "Output"}
+
+    if versions_results is None:
+        versions_results = [
+            {
+                "id": version_id,
+                "created_at": "2024-01-01T00:00:00Z",
+                "cog_version": "0.8.0",
+                "openapi_schema": {
+                    "openapi": "3.0.2",
+                    "info": {"title": "Cog", "version": "0.1.0"},
+                    "paths": {
+                        "/": {
+                            "post": {
+                                "summary": "Make a prediction",
+                                "requestBody": {
+                                    "content": {
+                                        "application/json": {
+                                            "schema": {
+                                                "$ref": "#/components/schemas/PredictionRequest"
+                                            }
+                                        }
+                                    }
+                                },
+                                "responses": {
+                                    "200": {
+                                        "content": {
+                                            "application/json": {
+                                                "schema": {
+                                                    "$ref": "#/components/schemas/PredictionResponse"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                            }
+                        }
+                    },
+                    "components": {
+                        "schemas": {
+                            "Input": {
+                                "type": "object",
+                                "properties": {
+                                    "prompt": {"type": "string", "title": "Prompt"}
+                                },
+                                "required": ["prompt"],
+                            },
+                            "Output": output_schema,
+                        }
+                    },
+                },
+            }
+        ]
+
     # Mock the model endpoint
-    respx.get("https://api.replicate.com/v1/models/acme/hotdog-detector").mock(
+    respx.get(f"https://api.replicate.com/v1/models/{owner}/{name}").mock(
         return_value=httpx.Response(
             200,
             json={
-                "url": "https://replicate.com/acme/hotdog-detector",
-                "owner": "acme",
-                "name": "hotdog-detector",
+                "url": f"https://replicate.com/{owner}/{name}",
+                "owner": owner,
+                "name": name,
                 "description": "A model to detect hotdogs",
                 "visibility": "public",
-                "github_url": "https://github.com/acme/hotdog-detector",
+                "github_url": f"https://github.com/{owner}/{name}",
                 "paper_url": None,
                 "license_url": None,
                 "run_count": 42,
                 "cover_image_url": None,
                 "default_example": None,
                 "latest_version": {
-                    "id": "xyz123",
+                    "id": version_id,
                     "created_at": "2024-01-01T00:00:00Z",
                     "cog_version": "0.8.0",
                     "openapi_schema": {
@@ -55,7 +106,9 @@ async def test_use(use_async_client):
                                     "requestBody": {
                                         "content": {
                                             "application/json": {
-                                                "schema": {"$ref": "#/components/schemas/PredictionRequest"}
+                                                "schema": {
+                                                    "$ref": "#/components/schemas/PredictionRequest"
+                                                }
                                             }
                                         }
                                     },
@@ -63,11 +116,13 @@ async def test_use(use_async_client):
                                         "200": {
                                             "content": {
                                                 "application/json": {
-                                                    "schema": {"$ref": "#/components/schemas/PredictionResponse"}
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/PredictionResponse"
+                                                    }
                                                 }
                                             }
                                         }
-                                    }
+                                    },
                                 }
                             }
                         },
@@ -78,167 +133,459 @@ async def test_use(use_async_client):
                                     "properties": {
                                         "prompt": {"type": "string", "title": "Prompt"}
                                     },
-                                    "required": ["prompt"]
+                                    "required": ["prompt"],
                                 },
-                                "Output": {
-                                    "type": "string",
-                                    "title": "Output"
-                                }
+                                "Output": output_schema,
                             }
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         )
     )
 
     # Mock the versions list endpoint
-    respx.get("https://api.replicate.com/v1/models/acme/hotdog-detector/versions").mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "results": [
-                    {
-                        "id": "xyz123",
-                        "created_at": "2024-01-01T00:00:00Z",
-                        "cog_version": "0.8.0",
-                        "openapi_schema": {
-                            "openapi": "3.0.2",
-                            "info": {"title": "Cog", "version": "0.1.0"},
-                            "paths": {
-                                "/": {
-                                    "post": {
-                                        "summary": "Make a prediction",
-                                        "requestBody": {
-                                            "content": {
-                                                "application/json": {
-                                                    "schema": {"$ref": "#/components/schemas/PredictionRequest"}
-                                                }
-                                            }
-                                        },
-                                        "responses": {
-                                            "200": {
-                                                "content": {
-                                                    "application/json": {
-                                                        "schema": {"$ref": "#/components/schemas/PredictionResponse"}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "components": {
-                                "schemas": {
-                                    "Input": {
-                                        "type": "object",
-                                        "properties": {
-                                            "prompt": {"type": "string", "title": "Prompt"}
-                                        },
-                                        "required": ["prompt"]
-                                    },
-                                    "Output": {
-                                        "type": "string",
-                                        "title": "Output"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                ]
-            }
+    if versions_response_status == 404:
+        respx.get(f"https://api.replicate.com/v1/models/{owner}/{name}/versions").mock(
+            return_value=httpx.Response(404, json={"detail": "Not found"})
         )
-    )
+    else:
+        respx.get(f"https://api.replicate.com/v1/models/{owner}/{name}/versions").mock(
+            return_value=httpx.Response(
+                versions_response_status, json={"results": versions_results}
+            )
+        )
 
-    # Mock the prediction creation endpoint
-    respx.post("https://api.replicate.com/v1/predictions").mock(
-        return_value=httpx.Response(
-            201,
-            json={
-                "id": "pred123",
-                "model": "acme/hotdog-detector",
-                "version": "xyz123",
+    # Mock specific version endpoint if requested
+    if include_specific_version:
+        respx.get(
+            f"https://api.replicate.com/v1/models/{owner}/{name}/versions/{version_id}"
+        ).mock(
+            return_value=httpx.Response(
+                200, json=versions_results[0] if versions_results else {}
+            )
+        )
+
+
+def mock_prediction_endpoints(
+    owner="acme",
+    name="hotdog-detector",
+    version_id="xyz123",
+    prediction_id="pred123",
+    input_data=None,
+    output_data="not hotdog",
+    *,
+    use_versionless_api=False,
+    polling_responses=None,
+):
+    """Mock the prediction creation and polling endpoints."""
+    if input_data is None:
+        input_data = {"prompt": "hello world"}
+
+    if polling_responses is None:
+        polling_responses = [
+            {
+                "id": prediction_id,
+                "model": f"{owner}/{name}",
+                "version": "hidden" if use_versionless_api else version_id,
                 "urls": {
-                    "get": "https://api.replicate.com/v1/predictions/pred123",
-                    "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
+                    "get": f"https://api.replicate.com/v1/predictions/{prediction_id}",
+                    "cancel": f"https://api.replicate.com/v1/predictions/{prediction_id}/cancel",
                 },
                 "created_at": "2024-01-01T00:00:00Z",
                 "source": "api",
                 "status": "processing",
-                "input": {"prompt": "hello world"},
-                "output": None,
-                "error": None,
-                "logs": "",
-            }
-        )
-    )
-
-    # Mock the prediction polling endpoint - first call returns processing, second returns completed
-    prediction_responses = [
-        httpx.Response(
-            200,
-            json={
-                "id": "pred123",
-                "model": "acme/hotdog-detector", 
-                "version": "xyz123",
-                "urls": {
-                    "get": "https://api.replicate.com/v1/predictions/pred123",
-                    "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
-                },
-                "created_at": "2024-01-01T00:00:00Z",
-                "source": "api",
-                "status": "processing",
-                "input": {"prompt": "hello world"},
+                "input": input_data,
                 "output": None,
                 "error": None,
                 "logs": "Starting prediction...",
-            }
-        ),
-        httpx.Response(
-            200,
-            json={
-                "id": "pred123",
-                "model": "acme/hotdog-detector",
-                "version": "xyz123", 
+            },
+            {
+                "id": prediction_id,
+                "model": f"{owner}/{name}",
+                "version": "hidden" if use_versionless_api else version_id,
                 "urls": {
-                    "get": "https://api.replicate.com/v1/predictions/pred123",
-                    "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
+                    "get": f"https://api.replicate.com/v1/predictions/{prediction_id}",
+                    "cancel": f"https://api.replicate.com/v1/predictions/{prediction_id}/cancel",
                 },
                 "created_at": "2024-01-01T00:00:00Z",
                 "source": "api",
                 "status": "succeeded",
-                "input": {"prompt": "hello world"},
-                "output": "not hotdog",
+                "input": input_data,
+                "output": output_data,
                 "error": None,
                 "logs": "Starting prediction...\nPrediction completed.",
-            }
+            },
+        ]
+
+    # Mock the prediction creation endpoint
+    if use_versionless_api:
+        respx.post(
+            f"https://api.replicate.com/v1/models/{owner}/{name}/predictions"
+        ).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": prediction_id,
+                    "model": f"{owner}/{name}",
+                    "version": "hidden",
+                    "urls": {
+                        "get": f"https://api.replicate.com/v1/predictions/{prediction_id}",
+                        "cancel": f"https://api.replicate.com/v1/predictions/{prediction_id}/cancel",
+                    },
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "source": "api",
+                    "status": "processing",
+                    "input": input_data,
+                    "output": None,
+                    "error": None,
+                    "logs": "",
+                },
+            )
         )
-    ]
-    
-    respx.get("https://api.replicate.com/v1/predictions/pred123").mock(
-        side_effect=prediction_responses
+    else:
+        respx.post("https://api.replicate.com/v1/predictions").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": prediction_id,
+                    "model": f"{owner}/{name}",
+                    "version": version_id,
+                    "urls": {
+                        "get": f"https://api.replicate.com/v1/predictions/{prediction_id}",
+                        "cancel": f"https://api.replicate.com/v1/predictions/{prediction_id}/cancel",
+                    },
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "source": "api",
+                    "status": "processing",
+                    "input": input_data,
+                    "output": None,
+                    "error": None,
+                    "logs": "",
+                },
+            )
+        )
+
+    # Mock the prediction polling endpoint
+    respx.get(f"https://api.replicate.com/v1/predictions/{prediction_id}").mock(
+        side_effect=[
+            httpx.Response(200, json=response) for response in polling_responses
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use(use_async_client):
+    mock_model_endpoints()
+    mock_prediction_endpoints()
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is the completed output from the prediction request
+    assert output == "not hotdog"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_with_version_identifier(use_async_client):
+    mock_model_endpoints(include_specific_version=True)
+    mock_prediction_endpoints()
+
+    # Call use with version identifier "acme/hotdog-detector:xyz123"
+    hotdog_detector = replicate.use("acme/hotdog-detector:xyz123")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is the completed output from the prediction request
+    assert output == "not hotdog"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_versionless_empty_versions_list(use_async_client):
+    mock_model_endpoints(versions_results=[])
+    mock_prediction_endpoints(use_versionless_api=True)
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is the completed output from the prediction request
+    assert output == "not hotdog"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_versionless_404_versions_list(use_async_client):
+    mock_model_endpoints(versions_response_status=404)
+    mock_prediction_endpoints(use_versionless_api=True)
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is the completed output from the prediction request
+    assert output == "not hotdog"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_function_create_method(use_async_client):
+    mock_model_endpoints()
+    mock_prediction_endpoints()
+
+    # Call use and then create method
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+    run = hotdog_detector.create(prompt="hello world")
+
+    # Assert that run is a Run object with a prediction
+    from replicate.use import Run
+
+    assert isinstance(run, Run)
+    assert run.prediction.id == "pred123"
+    assert run.prediction.status == "processing"
+    assert run.prediction.input == {"prompt": "hello world"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_concatenate_iterator_output(use_async_client):
+    concatenate_iterator_output_schema = {
+        "type": "array",
+        "items": {"type": "string"},
+        "x-cog-array-type": "iterator",
+        "x-cog-array-display": "concatenate",
+        "title": "Output",
+    }
+
+    mock_model_endpoints(output_schema=concatenate_iterator_output_schema)
+    mock_prediction_endpoints(output_data=["Hello", " ", "world", "!"])
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is concatenated from the list
+    assert output == "Hello world!"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_list_of_strings_output(use_async_client):
+    list_of_strings_output_schema = {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Output",
+    }
+
+    mock_model_endpoints(output_schema=list_of_strings_output_schema)
+    mock_prediction_endpoints(output_data=["hello", "world", "test"])
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is returned as a list
+    assert output == ["hello", "world", "test"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_iterator_of_strings_output(use_async_client):
+    iterator_of_strings_output_schema = {
+        "type": "array",
+        "items": {"type": "string"},
+        "x-cog-array-type": "iterator",
+        "title": "Output",
+    }
+
+    mock_model_endpoints(output_schema=iterator_of_strings_output_schema)
+    mock_prediction_endpoints(output_data=["hello", "world", "test"])
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is returned as a list (iterators are returned as lists)
+    assert output == ["hello", "world", "test"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_path_output(use_async_client):
+    path_output_schema = {"type": "string", "format": "uri", "title": "Output"}
+
+    mock_model_endpoints(output_schema=path_output_schema)
+    mock_prediction_endpoints(output_data="https://example.com/output.jpg")
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is returned as a string URL
+    assert output == "https://example.com/output.jpg"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_list_of_paths_output(use_async_client):
+    list_of_paths_output_schema = {
+        "type": "array",
+        "items": {"type": "string", "format": "uri"},
+        "title": "Output",
+    }
+
+    mock_model_endpoints(output_schema=list_of_paths_output_schema)
+    mock_prediction_endpoints(
+        output_data=[
+            "https://example.com/output1.jpg",
+            "https://example.com/output2.jpg",
+        ]
     )
 
     # Call use with "acme/hotdog-detector"
     hotdog_detector = replicate.use("acme/hotdog-detector")
-    
+
     # Call function with prompt="hello world"
     output = hotdog_detector(prompt="hello world")
-    
-    # Assert that output is the completed output from the prediction request
-    assert output == "not hotdog"
 
-# TODO
-#
-# - [ ] Test a model with a version identifier acme/hotdog-detector:xyz
-# - [ ] Test a versionless model acme/hotdog-dectector when versions list is empty
-# - [ ] Test a versionless model acme/hotdog-dectector when versions list returns a 404
-# - [ ] Test a model that returns a list of strings
-# - [ ] Test a model that returns an Iterator of strings
-# - [ ] Test a model that returns a ConcatenateIterator of strings
-# - [ ] Test a model that returns a Path
-# - [ ] Test a model that returns a list of Path
-# - [ ] Test a model that returns an iterator of Path
-# - [ ] Test the `create` method on Function.
-# - [ ] Test the logs method on Function returns an iterator where the first iteration is the current value of logs
-# - [ ] Test the logs method on Function returns an iterator that polls for new logs
+    # Assert that output is returned as a list of URLs
+    assert output == [
+        "https://example.com/output1.jpg",
+        "https://example.com/output2.jpg",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_iterator_of_paths_output(use_async_client):
+    iterator_of_paths_output_schema = {
+        "type": "array",
+        "items": {"type": "string", "format": "uri"},
+        "x-cog-array-type": "iterator",
+        "title": "Output",
+    }
+
+    mock_model_endpoints(output_schema=iterator_of_paths_output_schema)
+    mock_prediction_endpoints(
+        output_data=[
+            "https://example.com/output1.jpg",
+            "https://example.com/output2.jpg",
+        ]
+    )
+
+    # Call use with "acme/hotdog-detector"
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+
+    # Call function with prompt="hello world"
+    output = hotdog_detector(prompt="hello world")
+
+    # Assert that output is returned as a list of URLs
+    assert output == [
+        "https://example.com/output1.jpg",
+        "https://example.com/output2.jpg",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_function_logs_method(use_async_client):
+    mock_model_endpoints()
+    mock_prediction_endpoints()
+
+    # Call use and then create method
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+    run = hotdog_detector.create(prompt="hello world")
+
+    # Call logs method to get current logs
+    logs = run.logs()
+
+    # Assert that logs returns the current log value
+    assert logs == "Starting prediction..."
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async_client", [False])
+@respx.mock
+async def test_use_function_logs_method_polling(use_async_client):
+    mock_model_endpoints()
+
+    # Mock prediction endpoints with updated logs on polling
+    polling_responses = [
+        {
+            "id": "pred123",
+            "model": "acme/hotdog-detector",
+            "version": "xyz123",
+            "urls": {
+                "get": "https://api.replicate.com/v1/predictions/pred123",
+                "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
+            },
+            "created_at": "2024-01-01T00:00:00Z",
+            "source": "api",
+            "status": "processing",
+            "input": {"prompt": "hello world"},
+            "output": None,
+            "error": None,
+            "logs": "Starting prediction...",
+        },
+        {
+            "id": "pred123",
+            "model": "acme/hotdog-detector",
+            "version": "xyz123",
+            "urls": {
+                "get": "https://api.replicate.com/v1/predictions/pred123",
+                "cancel": "https://api.replicate.com/v1/predictions/pred123/cancel",
+            },
+            "created_at": "2024-01-01T00:00:00Z",
+            "source": "api",
+            "status": "processing",
+            "input": {"prompt": "hello world"},
+            "output": None,
+            "error": None,
+            "logs": "Starting prediction...\nProcessing input...",
+        },
+    ]
+
+    mock_prediction_endpoints(polling_responses=polling_responses)
+
+    # Call use and then create method
+    hotdog_detector = replicate.use("acme/hotdog-detector")
+    run = hotdog_detector.create(prompt="hello world")
+
+    # Call logs method initially
+    initial_logs = run.logs()
+    assert initial_logs == "Starting prediction..."
+
+    # Call logs method again to get updated logs (simulates polling)
+    updated_logs = run.logs()
+    assert updated_logs == "Starting prediction...\nProcessing input..."

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -351,9 +351,9 @@ async def test_use_function_create_method(client_mode):
         assert isinstance(run, AsyncRun)
     else:
         assert isinstance(run, Run)
-    assert run.prediction.id == "pred123"
-    assert run.prediction.status == "processing"
-    assert run.prediction.input == {"prompt": "hello world"}
+    assert run._prediction.id == "pred123"
+    assert run._prediction.status == "processing"
+    assert run._prediction.input == {"prompt": "hello world"}
 
 
 @pytest.mark.asyncio
@@ -391,7 +391,9 @@ async def test_use_concatenate_iterator_output(client_mode):
 
     # Call use with "acme/hotdog-detector"
     hotdog_detector = replicate.use(
-        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+        "acme/hotdog-detector",
+        use_async=client_mode == ClientMode.ASYNC,
+        streaming=True,
     )
 
     # Call function with prompt="hello world"
@@ -561,7 +563,9 @@ async def test_async_function_concatenate_iterator_output():
     )
 
     # Call use with use_async=True
-    hotdog_detector = replicate.use("acme/hotdog-detector", use_async=True)
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=True, streaming=True
+    )
 
     # Call async function with prompt="hello world"
     run = await hotdog_detector.create(prompt="hello world")
@@ -660,7 +664,9 @@ async def test_iterator_output_returns_immediately(client_mode):
 
     # Call use with "acme/hotdog-detector"
     hotdog_detector = replicate.use(
-        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+        "acme/hotdog-detector",
+        use_async=client_mode == ClientMode.ASYNC,
+        streaming=True,
     )
 
     # Get the output iterator - this should return immediately even though prediction is processing
@@ -677,7 +683,7 @@ async def test_iterator_output_returns_immediately(client_mode):
     assert isinstance(output_iterator, OutputIterator)
 
     # Verify the prediction is still processing when we get the iterator
-    assert run.prediction.status == "processing"
+    assert run._prediction.status == "processing"
 
 
 @pytest.mark.asyncio
@@ -757,7 +763,9 @@ async def test_streaming_output_yields_incrementally(client_mode):
 
     # Call use with "acme/hotdog-detector"
     hotdog_detector = replicate.use(
-        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+        "acme/hotdog-detector",
+        use_async=client_mode == ClientMode.ASYNC,
+        streaming=True,
     )
 
     # Get the output iterator immediately
@@ -921,7 +929,9 @@ async def test_use_iterator_of_strings_output(client_mode):
 
     # Call use with "acme/hotdog-detector"
     hotdog_detector = replicate.use(
-        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+        "acme/hotdog-detector",
+        use_async=client_mode == ClientMode.ASYNC,
+        streaming=True,
     )
 
     # Call function with prompt="hello world"
@@ -1108,7 +1118,9 @@ async def test_use_iterator_of_paths_output(client_mode):
 
     # Call use with "acme/hotdog-detector"
     hotdog_detector = replicate.use(
-        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+        "acme/hotdog-detector",
+        use_async=client_mode == ClientMode.ASYNC,
+        streaming=True,
     )
 
     # Call function with prompt="hello world"

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -337,7 +337,6 @@ async def test_use_concatenate_iterator_output(client_mode):
                                     "items": {"type": "string"},
                                     "x-cog-array-type": "iterator",
                                     "x-cog-array-display": "concatenate",
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -348,7 +347,7 @@ async def test_use_concatenate_iterator_output(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {"status": "succeeded", "output": ["Hello", " ", "world", "!"]}
             ),
@@ -424,7 +423,6 @@ async def test_use_list_of_strings_output(client_mode):
                                 "Output": {
                                     "type": "array",
                                     "items": {"type": "string"},
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -435,7 +433,7 @@ async def test_use_list_of_strings_output(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {"status": "succeeded", "output": ["hello", "world", "test"]}
             ),
@@ -467,7 +465,6 @@ async def test_use_iterator_of_strings_output(client_mode):
                                     "type": "array",
                                     "items": {"type": "string"},
                                     "x-cog-array-type": "iterator",
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -478,7 +475,7 @@ async def test_use_iterator_of_strings_output(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {"status": "succeeded", "output": ["hello", "world", "test"]}
             ),
@@ -514,7 +511,6 @@ async def test_use_path_output(client_mode):
                                 "Output": {
                                     "type": "string",
                                     "format": "uri",
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -525,7 +521,7 @@ async def test_use_path_output(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {"status": "succeeded", "output": "https://example.com/output.jpg"}
             ),
@@ -562,7 +558,6 @@ async def test_use_list_of_paths_output(client_mode):
                                 "Output": {
                                     "type": "array",
                                     "items": {"type": "string", "format": "uri"},
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -573,7 +568,7 @@ async def test_use_list_of_paths_output(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {
                     "status": "succeeded",
@@ -623,7 +618,6 @@ async def test_use_iterator_of_paths_output(client_mode):
                                     "type": "array",
                                     "items": {"type": "string", "format": "uri"},
                                     "x-cog-array-type": "iterator",
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -634,7 +628,7 @@ async def test_use_iterator_of_paths_output(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {
                     "status": "succeeded",
@@ -810,17 +804,7 @@ async def test_use_pathproxy_input_conversion(client_mode):
 @respx.mock
 async def test_use_function_logs_method(client_mode):
     mock_model_endpoints()
-    mock_prediction_endpoints(
-        predictions=[
-            create_mock_prediction(
-                {
-                    "status": "processing",
-                    "output": None,
-                    "logs": "Starting prediction...",
-                },
-            ),
-        ]
-    )
+    mock_prediction_endpoints(predictions=[create_mock_prediction()])
 
     # Call use and then create method
     hotdog_detector = replicate.use("acme/hotdog-detector")
@@ -882,15 +866,13 @@ async def test_use_object_output_with_file_properties(client_mode):
                                 "Output": {
                                     "type": "object",
                                     "properties": {
-                                        "text": {"type": "string", "title": "Text"},
+                                        "text": {"type": "string"},
                                         "image": {
                                             "type": "string",
                                             "format": "uri",
-                                            "title": "Image",
                                         },
-                                        "count": {"type": "integer", "title": "Count"},
+                                        "count": {"type": "integer"},
                                     },
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -901,7 +883,7 @@ async def test_use_object_output_with_file_properties(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {
                     "status": "succeeded",
@@ -948,17 +930,15 @@ async def test_use_object_output_with_file_list_property(client_mode):
                                 "Output": {
                                     "type": "object",
                                     "properties": {
-                                        "text": {"type": "string", "title": "Text"},
+                                        "text": {"type": "string"},
                                         "images": {
                                             "type": "array",
                                             "items": {
                                                 "type": "string",
                                                 "format": "uri",
                                             },
-                                            "title": "Images",
                                         },
                                     },
-                                    "title": "Output",
                                 }
                             }
                         }
@@ -969,7 +949,7 @@ async def test_use_object_output_with_file_list_property(client_mode):
     )
     mock_prediction_endpoints(
         predictions=[
-            create_mock_prediction({"status": "processing", "output": None}),
+            create_mock_prediction(),
             create_mock_prediction(
                 {
                     "status": "succeeded",

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -215,41 +215,51 @@ def mock_prediction_endpoints(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints()
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is the completed output from the prediction request
     assert output == "not hotdog"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_with_version_identifier(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints()
 
     # Call use with version identifier "acme/hotdog-detector:xyz123"
-    hotdog_detector = replicate.use("acme/hotdog-detector:xyz123")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector:xyz123", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is the completed output from the prediction request
     assert output == "not hotdog"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_with_function_ref(client_mode):
     mock_model_endpoints()
@@ -260,71 +270,94 @@ async def test_use_with_function_ref(client_mode):
 
         def __call__(self, prompt: str) -> str: ...
 
-    hotdog_detector = replicate.use(HotdogDetector())
+    hotdog_detector = replicate.use(
+        HotdogDetector(), use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is the completed output from the prediction request
     assert output == "not hotdog"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_versionless_empty_versions_list(client_mode):
     mock_model_endpoints(uses_versionless_api="empty")
     mock_prediction_endpoints(uses_versionless_api="empty")
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is the completed output from the prediction request
     assert output == "not hotdog"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_versionless_404_versions_list(client_mode):
     mock_model_endpoints(uses_versionless_api="notfound")
     mock_prediction_endpoints(uses_versionless_api="notfound")
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is the completed output from the prediction request
     assert output == "not hotdog"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_function_create_method(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints()
 
     # Call use and then create method
-    hotdog_detector = replicate.use("acme/hotdog-detector")
-    run = hotdog_detector.create(prompt="hello world")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
+    if client_mode == ClientMode.ASYNC:
+        run = await hotdog_detector.create(prompt="hello world")
+    else:
+        run = hotdog_detector.create(prompt="hello world")
 
     # Assert that run is a Run object with a prediction
-    from replicate.use import Run
+    from replicate.use import Run, AsyncRun
 
-    assert isinstance(run, Run)
+    if client_mode == ClientMode.ASYNC:
+        assert isinstance(run, AsyncRun)
+    else:
+        assert isinstance(run, Run)
     assert run.prediction.id == "pred123"
     assert run.prediction.status == "processing"
     assert run.prediction.input == {"prompt": "hello world"}
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_concatenate_iterator_output(client_mode):
     mock_model_endpoints(
@@ -357,10 +390,15 @@ async def test_use_concatenate_iterator_output(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is an OutputIterator that concatenates when converted to string
     from replicate.use import OutputIterator
@@ -404,15 +442,187 @@ async def test_use_concatenate_iterator_output(client_mode):
     )
 
     # Pass the OutputIterator as input to create()
-    hotdog_detector.create(text_input=output)
+    if client_mode == ClientMode.ASYNC:
+        await hotdog_detector.create(text_input=output)
+    else:
+        hotdog_detector.create(text_input=output)
 
     # Verify the request body contains the stringified version
+    assert request_body
     parsed_body = json.loads(request_body)
     assert parsed_body["input"]["text_input"] == "Hello world!"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+async def test_output_iterator_async_iteration():
+    """Test OutputIterator async iteration capabilities."""
+    from replicate.use import OutputIterator
+
+    # Create mock sync and async iterators
+    def sync_iterator():
+        return iter(["Hello", " ", "world", "!"])
+
+    async def async_iterator():
+        for item in ["Hello", " ", "world", "!"]:
+            yield item
+
+    # Test concatenate iterator
+    concatenate_output = OutputIterator(
+        sync_iterator, async_iterator, {}, is_concatenate=True
+    )
+
+    # Test sync iteration
+    sync_result = list(concatenate_output)
+    assert sync_result == ["Hello", " ", "world", "!"]
+
+    # Test async iteration
+    async_result = []
+    async for item in concatenate_output:
+        async_result.append(item)
+    assert async_result == ["Hello", " ", "world", "!"]
+
+    # Test sync string conversion
+    assert str(concatenate_output) == "Hello world!"
+
+    # Test async await (should return joined string for concatenate)
+    async_result = await concatenate_output
+    assert async_result == "Hello world!"
+
+
+@pytest.mark.asyncio
+async def test_output_iterator_async_non_concatenate():
+    """Test OutputIterator async iteration for non-concatenate iterators."""
+    from replicate.use import OutputIterator
+
+    # Create mock sync and async iterators for non-concatenate case
+    test_items = ["item1", "item2", "item3"]
+
+    def sync_iterator():
+        return iter(test_items)
+
+    async def async_iterator():
+        for item in test_items:
+            yield item
+
+    # Test non-concatenate iterator
+    regular_output = OutputIterator(
+        sync_iterator, async_iterator, {}, is_concatenate=False
+    )
+
+    # Test sync iteration
+    sync_result = list(regular_output)
+    assert sync_result == test_items
+
+    # Test async iteration
+    async_result = []
+    async for item in regular_output:
+        async_result.append(item)
+    assert async_result == test_items
+
+    # Test sync string conversion
+    assert str(regular_output) == str(test_items)
+
+    # Test async await (should return list for non-concatenate)
+    async_result = await regular_output
+    assert async_result == test_items
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_function_concatenate_iterator_output():
+    """Test AsyncFunction with concatenate iterator output."""
+    mock_model_endpoints(
+        versions=[
+            create_mock_version(
+                {
+                    "openapi_schema": {
+                        "components": {
+                            "schemas": {
+                                "Output": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "x-cog-array-type": "iterator",
+                                    "x-cog-array-display": "concatenate",
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        ]
+    )
+    mock_prediction_endpoints(
+        predictions=[
+            create_mock_prediction(),
+            create_mock_prediction(
+                {"status": "succeeded", "output": ["Async", " ", "Hello", " ", "World"]}
+            ),
+        ]
+    )
+
+    # Call use with use_async=True
+    hotdog_detector = replicate.use("acme/hotdog-detector", use_async=True)
+
+    # Call async function with prompt="hello world"
+    run = await hotdog_detector.create(prompt="hello world")
+    output = await run.output()
+
+    # Assert that output is an OutputIterator that concatenates when converted to string
+    from replicate.use import OutputIterator
+
+    assert isinstance(output, OutputIterator)
+    assert str(output) == "Async Hello World"
+
+    # Test async await (should return joined string for concatenate)
+    async_result = await output
+    assert async_result == "Async Hello World"
+
+    # Test async iteration
+    async_result = []
+    async for item in output:
+        async_result.append(item)
+    assert async_result == ["Async", " ", "Hello", " ", "World"]
+
+    # Also test that it's still sync iterable
+    sync_result = list(output)
+    assert sync_result == ["Async", " ", "Hello", " ", "World"]
+
+
+@pytest.mark.asyncio
+async def test_output_iterator_await_syntax_demo():
+    """Demonstrate the clean await syntax for OutputIterator."""
+    from replicate.use import OutputIterator
+
+    # Create mock iterators
+    def sync_iterator():
+        return iter(["Hello", " ", "World"])
+
+    async def async_iterator():
+        for item in ["Hello", " ", "World"]:
+            yield item
+
+    # Test concatenate mode - await returns string
+    concatenate_output = OutputIterator(
+        sync_iterator, async_iterator, {}, is_concatenate=True
+    )
+
+    # This is the clean syntax we wanted: str(await iterator)
+    result = await concatenate_output
+    assert result == "Hello World"
+    assert str(result) == "Hello World"  # Can use str() on the result
+
+    # Test non-concatenate mode - await returns list
+    regular_output = OutputIterator(
+        sync_iterator, async_iterator, {}, is_concatenate=False
+    )
+
+    result = await regular_output
+    assert result == ["Hello", " ", "World"]
+    assert str(result) == "['Hello', ' ', 'World']"  # str() gives list representation
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_list_of_strings_output(client_mode):
     mock_model_endpoints(
@@ -443,17 +653,22 @@ async def test_use_list_of_strings_output(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is returned as a list
     assert output == ["hello", "world", "test"]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_iterator_of_strings_output(client_mode):
     mock_model_endpoints(
@@ -485,10 +700,15 @@ async def test_use_iterator_of_strings_output(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is returned as an OutputIterator
     from replicate.use import OutputIterator
@@ -500,7 +720,7 @@ async def test_use_iterator_of_strings_output(client_mode):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_path_output(client_mode):
     mock_model_endpoints(
@@ -536,10 +756,15 @@ async def test_use_path_output(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     assert isinstance(output, os.PathLike)
     assert get_path_url(output) == "https://example.com/output.jpg"
@@ -548,7 +773,7 @@ async def test_use_path_output(client_mode):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_list_of_paths_output(client_mode):
     mock_model_endpoints(
@@ -593,10 +818,15 @@ async def test_use_list_of_paths_output(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     assert isinstance(output, list)
     assert len(output) == 2
@@ -611,7 +841,7 @@ async def test_use_list_of_paths_output(client_mode):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_iterator_of_paths_output(client_mode):
     mock_model_endpoints(
@@ -657,10 +887,15 @@ async def test_use_iterator_of_paths_output(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     # Assert that output is returned as an OutputIterator of Path objects
     from replicate.use import OutputIterator
@@ -716,7 +951,7 @@ def test_get_path_url_with_object_without_target():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_pathproxy_input_conversion(client_mode):
     mock_model_endpoints()
@@ -762,8 +997,13 @@ async def test_use_pathproxy_input_conversion(client_mode):
     )
 
     # Call use and create with URLPath
-    hotdog_detector = replicate.use("acme/hotdog-detector")
-    hotdog_detector.create(image=urlpath)
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
+    if client_mode == ClientMode.ASYNC:
+        await hotdog_detector.create(image=urlpath)
+    else:
+        hotdog_detector.create(image=urlpath)
 
     # Verify the request body contains the URL, not the downloaded file
     assert request_body
@@ -775,25 +1015,33 @@ async def test_use_pathproxy_input_conversion(client_mode):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_function_logs_method(client_mode):
     mock_model_endpoints()
     mock_prediction_endpoints(predictions=[create_mock_prediction()])
 
     # Call use and then create method
-    hotdog_detector = replicate.use("acme/hotdog-detector")
-    run = hotdog_detector.create(prompt="hello world")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
+    if client_mode == ClientMode.ASYNC:
+        run = await hotdog_detector.create(prompt="hello world")
+    else:
+        run = hotdog_detector.create(prompt="hello world")
 
     # Call logs method to get current logs
-    logs = run.logs()
+    if client_mode == ClientMode.ASYNC:
+        logs = await run.logs()
+    else:
+        logs = run.logs()
 
     # Assert that logs returns the current log value
     assert logs == "Starting prediction..."
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_function_logs_method_polling(client_mode):
     mock_model_endpoints()
@@ -815,20 +1063,31 @@ async def test_use_function_logs_method_polling(client_mode):
     mock_prediction_endpoints(predictions=polling_responses)
 
     # Call use and then create method
-    hotdog_detector = replicate.use("acme/hotdog-detector")
-    run = hotdog_detector.create(prompt="hello world")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
+    if client_mode == ClientMode.ASYNC:
+        run = await hotdog_detector.create(prompt="hello world")
+    else:
+        run = hotdog_detector.create(prompt="hello world")
 
     # Call logs method initially
-    initial_logs = run.logs()
+    if client_mode == ClientMode.ASYNC:
+        initial_logs = await run.logs()
+    else:
+        initial_logs = run.logs()
     assert initial_logs == "Starting prediction..."
 
     # Call logs method again to get updated logs (simulates polling)
-    updated_logs = run.logs()
+    if client_mode == ClientMode.ASYNC:
+        updated_logs = await run.logs()
+    else:
+        updated_logs = run.logs()
     assert updated_logs == "Starting prediction...\nProcessing input..."
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_object_output_with_file_properties(client_mode):
     mock_model_endpoints(
@@ -878,10 +1137,15 @@ async def test_use_object_output_with_file_properties(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     assert isinstance(output, dict)
     assert output["text"] == "Generated text"
@@ -893,7 +1157,7 @@ async def test_use_object_output_with_file_properties(client_mode):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT])
+@pytest.mark.parametrize("client_mode", [ClientMode.DEFAULT, ClientMode.ASYNC])
 @respx.mock
 async def test_use_object_output_with_file_list_property(client_mode):
     mock_model_endpoints(
@@ -950,10 +1214,15 @@ async def test_use_object_output_with_file_list_property(client_mode):
     )
 
     # Call use with "acme/hotdog-detector"
-    hotdog_detector = replicate.use("acme/hotdog-detector")
+    hotdog_detector = replicate.use(
+        "acme/hotdog-detector", use_async=client_mode == ClientMode.ASYNC
+    )
 
     # Call function with prompt="hello world"
-    output = hotdog_detector(prompt="hello world")
+    if client_mode == ClientMode.ASYNC:
+        output = await hotdog_detector(prompt="hello world")
+    else:
+        output = hotdog_detector(prompt="hello world")
 
     assert isinstance(output, dict)
     assert output["text"] == "Generated text"


### PR DESCRIPTION
This PR introduces a new experimental `use()` function that is intended to make running a model closer to calling a function rather than an API request.

Some key differences to `replicate.run()`:

 1. You "import" the model using the `use()` syntax, after that you call the model like a function.
 2. The output type matches the model definition. i.e. if the model uses an iterator output will be an iterator.
 3. Files will be downloaded output as `Path` objects*.

> [!NOTE]

\* We've replaced the `FileOutput` implementation with `Path` objects. However to avoid unnecessary downloading of files until they are needed we've implemented a `PathProxy` class that will defer the download until the first time the object is used. If you need the underlying URL of the `Path` object you can use the `get_path_url(path: Path) -> str` helper.

### Examples

To use a model:

> [!IMPORTANT]
> For now `use()` MUST be called in the top level module scope. We may relax this in future.

```py
from replicate import use

flux_dev = use("black-forest-labs/flux-dev")
outputs = flux_dev(prompt="a cat wearing an amusing hat")

for output in outputs:
    print(output) # Path(/tmp/output.webp)
```

Models that implement iterators will return an iterator that yields partial output as the model does:


```py
claude = use("anthropic/claude-4-sonnet")

output = claude(prompt="Give me a recipe for tasty smashed avocado on sourdough toast that could feed all of California.")

for token in output:
    print(token) # "Here's a recipe"
```

You can call `str()` on a language model to get the complete output as a string rather than iterating over tokens:

```py
str(output) # "Here's a recipe to feed all of California (about 39 million people)! ..."
```

You can pass the results of one model directly into another, we'll do our best to make this work efficiently:

```py
from replicate import use

flux_dev = use("black-forest-labs/flux-dev")
claude = use("anthropic/claude-4-sonnet")

images = flux_dev(prompt="a cat wearing an amusing hat")

result = claude(prompt="describe this image for me", image=images[0])

print(str(result)) # "This shows an image of a cat wearing a hat ..."
```

To create a prediction, rather than just getting output, use the `create()` method:

```
claude = use("anthropic/claude-4-sonnet")

prediction = claude.create(prompt="Give me a recipe for tasty smashed avocado on sourdough toast that could feed all of California.")

prediction.logs() # get current logs (WIP)

prediction.output() # get the output
```

You can access the underlying URL for a Path object returned from a model call by using the `get_path_url()` helper.

```py
from replicate import use
from replicate.use import get_url_path

flux_dev = use("black-forest-labs/flux-dev")
outputs = flux_dev(prompt="a cat wearing an amusing hat")

for output in outputs:
    print(get_url_path(output)) # "https://replicate.delivery/xyz"
```

### TODO

There are several key things still outstanding:

 1. Support for asyncio.
 2. Support for typing the return value.
 3. Support for streaming text when available (rather than polling)
 4. Support for streaming files when available (rather than polling)
 5. Support for cleaning up downloaded files.
 6. Support for streaming logs using `OutputIterator`.
 7. Support for getting the prediction ID and status.
