### PR TITLE
Fix dereferencing in Function and AsyncFunction

### DIFF
--- a/replicate/use.py
+++ b/replicate/use.py
@@ -190,7 +190,17 @@ def _dereference_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
     result = _resolve_ref(dereferenced)
 
-    # Filter out any references that have now been referenced.
+    # Remove "paths" as these aren't relevant to models.
+    result["paths"] = {}
+
+    # Retain Input and Output schemas as these are important.
+    dereferenced_refs.discard("Input")
+    dereferenced_refs.discard("Output")
+
+    dereferenced_refs.discard("TrainingInput")
+    dereferenced_refs.discard("TrainingOutput")
+
+    # Filter out any remaining references that have been inlined.
     result["components"]["schemas"] = {
         k: v
         for k, v in result["components"]["schemas"].items()

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "replicate"
-version = "1.1.0b1"
+version = "1.1.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
We were accidentally stripping out all components in the schemas due to
the Input/Output being referenced by PredictionRequest and
PredictionResponse and those in turn being referenced by the various
`path` entries. This commit ensures we retain Input and Output and
cleans up the object to only contain relevant fields.