### PR TITLE
DP-498: Log Prediction URLs

### DIFF
--- a/replicate/use.py
+++ b/replicate/use.py
@@ -3,7 +3,6 @@
 # - [ ] Support file streaming
 import copy
 import hashlib
-import logging
 import os
 import tempfile
 from functools import cached_property
@@ -214,7 +213,7 @@ def _dereference_schema(schema: dict[str, Any]) -> dict[str, Any]:
 def _log_prediction_url(id: str) -> None:
     if os.environ.get("R8_LOG_PREDICTION_URL") != "1":
         return
-    logging.info("Running prediction https://replicate.com/p/%s", id)
+    print("Running prediction https://replicate.com/p/%s", id)
 
 
 T = TypeVar("T")

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -213,7 +213,7 @@ def _dereference_schema(schema: dict[str, Any]) -> dict[str, Any]:
 def _log_prediction_url(id: str) -> None:
     if os.environ.get("R8_LOG_PREDICTION_URL") != "1":
         return
-    print("Running prediction https://replicate.com/p/%s", id)
+    print(f"Running prediction https://replicate.com/p/{id}")
 
 
 T = TypeVar("T")

--- a/replicate/use.py
+++ b/replicate/use.py
@@ -3,6 +3,7 @@
 # - [ ] Support file streaming
 import copy
 import hashlib
+import logging
 import os
 import tempfile
 from functools import cached_property
@@ -208,6 +209,12 @@ def _dereference_schema(schema: dict[str, Any]) -> dict[str, Any]:
     }
 
     return result
+
+
+def _log_prediction_url(id: str) -> None:
+    if os.environ.get("R8_LOG_PREDICTION_URL") != "1":
+        return
+    logging.info("Running prediction https://replicate.com/p/%s", id)
 
 
 T = TypeVar("T")
@@ -436,6 +443,8 @@ class Function(Generic[Input, Output]):
                 model=self._model, input=processed_inputs
             )
 
+        _log_prediction_url(prediction.id)
+
         return Run(
             prediction=prediction,
             schema=self.openapi_schema(),
@@ -648,6 +657,8 @@ class AsyncFunction(Generic[Input, Output]):
             prediction = await self._client().models.predictions.async_create(
                 model=model, input=processed_inputs
             )
+
+        _log_prediction_url(prediction.id)
 
         return AsyncRun(
             prediction=prediction,


### PR DESCRIPTION
* Logs prediction URLs after prediction creation if the environment variable `R8_LOG_PREDICTION_URL` is set to `1`

https://linear.app/replicate/issue/DP-498/log-prediction-urls-in-terminal-for-easier-access-during-local