### PR TITLE
DP-130: Embellish the exception message on model error

### DIFF
--- a/replicate/exceptions.py
+++ b/replicate/exceptions.py
@@ -17,7 +17,9 @@ class ModelError(ReplicateException):
 
     def __init__(self, prediction: "Prediction") -> None:
         self.prediction = prediction
-        super().__init__(prediction.error)
+        super().__init__(
+            f"Prediction {prediction.id} {prediction.status}: {prediction.error}"
+        )
 
 
 class ReplicateError(ReplicateException):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -581,7 +581,7 @@ async def test_run_with_model_error(mock_replicate_api_token):
             },
         )
 
-    assert str(excinfo.value) == "OOM"
+    assert str(excinfo.value) == "Prediction p1 failed: OOM"
     assert excinfo.value.prediction.error == "OOM"
     assert excinfo.value.prediction.status == "failed"
 


### PR DESCRIPTION
* Tell us the prediction ID and status in the error message

https://linear.app/replicate/issue/DP-130/make-sure-we-raise-a-useful-exported-error-when-a-child-prediction