### PR TITLE
Fix(prediction): add missing "aborted" status to Prediction model

### DIFF
--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -55,7 +55,7 @@ class Prediction(Resource):
     version: str
     """An identifier for the version of the model used to create the prediction."""
 
-    status: Literal["starting", "processing", "succeeded", "failed", "canceled"]
+    status: Literal["starting", "processing", "succeeded", "failed", "canceled", "aborted"]
     """The status of the prediction."""
 
     input: Optional[Dict[str, Any]]


### PR DESCRIPTION
The Replicate API sometimes returns a "status": "aborted" value for predictions that were interrupted before completion. The current pydantic model does not include this status, which causes a ValidationError:

    pydantic.v1.error_wrappers.ValidationError:
    unexpected value; permitted: 'starting', 'processing', 'succeeded', 'failed', 'canceled' (type=value_error.const; given=aborted; permitted=('starting', 'processing', 'succeeded', 'failed', 'canceled'))

This commit updates the `Prediction.status` Literal to include "aborted" to match the current API behavior.