### PR TITLE
fix(stream): EventSource ignores use_file_output=False

### DIFF
--- a/replicate/stream.py
+++ b/replicate/stream.py
@@ -76,7 +76,7 @@ class EventSource:
     ) -> None:
         self.client = client
         self.response = response
-        self.use_file_output = use_file_output or True
+        self.use_file_output = use_file_output if use_file_output is not None else True
         content_type, _, _ = response.headers["content-type"].partition(";")
         if content_type != "text/event-stream":
             raise ValueError(


### PR DESCRIPTION
## What's broken

`EventSource` silently ignores `use_file_output=False`. The constructor assigns the flag with `use_file_output or True`, but `False or True` evaluates to `True` in Python, so the caller's intent is lost:

```python
source = EventSource(client, response, use_file_output=False)
print(source.use_file_output)  # True — should be False
```

Output tokens are still run through `transform_output` even when the caller explicitly opted out.

## Why it happens

The line `self.use_file_output = use_file_output or True` is meant to default to `True` when `None` is passed, but it clobbers a deliberate `False` as well since Python's `or` operator returns the right-hand side for any falsy left-hand side.

## Fix

Replace the boolean-or default with an explicit `None` check:

```python
self.use_file_output = use_file_output if use_file_output is not None else True
```