### PR TITLE
ci: pin GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,8 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,8 @@ jobs:
     name: "Publish to PyPI"
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.10"
       - name: Install pypa/build


### PR DESCRIPTION
## Summary

Pins all GitHub Actions in `ci.yaml` and `release.yaml` to full immutable commit SHAs instead of mutable version tags.

## Vulnerability

Using mutable tags (`@v3`, `@v4`, `@v5`) means the action code can change at any time — a compromised action repository could silently deliver malicious code in CI. The `release.yaml` workflow is especially sensitive as it publishes to PyPI using `secrets.PYPI_API_TOKEN`.

## Changes

| Workflow | Action | Before | After |
|---|---|---|---|
| `ci.yaml` | `actions/checkout` | `@v4` | `@34e1148` |
| `ci.yaml` | `astral-sh/setup-uv` | `@v5` | `@d4b2f3b` |
| `release.yaml` | `actions/checkout` | `@v3` | `@f43a0e5` |
| `release.yaml` | `actions/setup-python` | `@v3` | `@3542bca` |

All pins point to the exact same version as the current tags — no behaviour change.

## References
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- [tj-actions supply chain incident (2025)](https://www.bleepingcomputer.com/news/security/popular-github-action-tjactionschanged-files-compromised-in-supply-chain-attack/)