### PR TITLE
docs: fix duplicate words in pagination docstrings

### DIFF
--- a/replicate/model.py
+++ b/replicate/model.py
@@ -163,7 +163,7 @@ class Models(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Model]: A page of of models.
+            Page[Model]: A page of models.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -190,7 +190,7 @@ class Models(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Model]: A page of of models.
+            Page[Model]: A page of models.
         Raises:
             ValueError: If `cursor` is `None`.
         """

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -303,7 +303,7 @@ class Predictions(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Prediction]: A page of of predictions.
+            Page[Prediction]: A page of predictions.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -332,7 +332,7 @@ class Predictions(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Prediction]: A page of of predictions.
+            Page[Prediction]: A page of predictions.
         Raises:
             ValueError: If `cursor` is `None`.
         """


### PR DESCRIPTION
## Summary
- Fix duplicate “of” words in pagination return docstrings for models and predictions.

## Why this helps
- These docstrings are surfaced to readers and generated/API documentation, so removing the duplicated word makes the descriptions clearer without changing behavior.

## Test Plan
- [x] `git diff --check`
- [x] `python3 -m compileall -q replicate/model.py replicate/prediction.py`

Signed-off-by: Lichao Chen <lichao_chen@outlook.com>
