### PR TITLE
Fix typos in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,12 @@ Run the setup script to install uv and install the project's dependencies.
 ./script/setup
 ```
 
-You can run the `format`, `lint`, and `test` scripts before commiting
+You can run the `format`, `lint`, and `test` scripts before committing
 to validate your changes locally before going through CI.
 
 ### Environment variables
 
-- `REPLICATE_API_BASE_URL`: Defaults to `https://api.replicate.com` but can be overriden to point the client at a development host.
+- `REPLICATE_API_BASE_URL`: Defaults to `https://api.replicate.com` but can be overridden to point the client at a development host.
 - `REPLICATE_API_TOKEN`: Required. Find your token at https://replicate.com/#token
 
 ## Publishing releases


### PR DESCRIPTION
## Summary
- Fix two spelling errors in `CONTRIBUTING.md`: `commiting` → `committing` and `overriden` → `overridden`.

## Why this helps
- Keeps contributor-facing setup and environment variable documentation polished and clear.
- Documentation-only change; no runtime behavior changes.

## Test Plan
- `git diff --check`
- Manual review of the two-line documentation diff

## Notes
- Commit includes the required DCO sign-off.
