### PR TITLE
replicate: fix pagination docstrings

### DIFF
--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -72,7 +72,7 @@ class Collections(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Collection]: A page of of model collections.
+            Page[Collection]: A page of model collections.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -99,7 +99,7 @@ class Collections(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Collection]: A page of of model collections.
+            Page[Collection]: A page of model collections.
         Raises:
             ValueError: If `cursor` is `None`.
         """

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -163,7 +163,7 @@ class Models(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Model]: A page of of models.
+            Page[Model]: A page of models.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -190,7 +190,7 @@ class Models(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Model]: A page of of models.
+            Page[Model]: A page of models.
         Raises:
             ValueError: If `cursor` is `None`.
         """

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -303,7 +303,7 @@ class Predictions(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Prediction]: A page of of predictions.
+            Page[Prediction]: A page of predictions.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -332,7 +332,7 @@ class Predictions(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Prediction]: A page of of predictions.
+            Page[Prediction]: A page of predictions.
         Raises:
             ValueError: If `cursor` is `None`.
         """


### PR DESCRIPTION
## Summary
- Fix repeated-word typos in pagination return docstrings for collections, models, and predictions.

## Why this helps
- These docstrings are surfaced to readers and API tooling, so removing the duplicated "of" makes the generated/help text clearer without changing runtime behavior.

## Test Plan
- [x] `git diff --check`
- [x] `python3 -m py_compile replicate/collection.py replicate/model.py replicate/prediction.py`

## Notes
- Documentation-only change to Python docstrings.
- Commit includes DCO signoff.
