### PR TITLE
docs: fix duplicate 'of' in pagination docstrings

### DIFF
--- a/replicate/collection.py
+++ b/replicate/collection.py
@@ -72,7 +72,7 @@ class Collections(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Collection]: A page of of model collections.
+            Page[Collection]: A page of model collections.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -99,7 +99,7 @@ class Collections(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Collection]: A page of of model collections.
+            Page[Collection]: A page of model collections.
         Raises:
             ValueError: If `cursor` is `None`.
         """

--- a/replicate/model.py
+++ b/replicate/model.py
@@ -163,7 +163,7 @@ class Models(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Model]: A page of of models.
+            Page[Model]: A page of models.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -190,7 +190,7 @@ class Models(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Model]: A page of of models.
+            Page[Model]: A page of models.
         Raises:
             ValueError: If `cursor` is `None`.
         """

--- a/replicate/prediction.py
+++ b/replicate/prediction.py
@@ -303,7 +303,7 @@ class Predictions(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Prediction]: A page of of predictions.
+            Page[Prediction]: A page of predictions.
         Raises:
             ValueError: If `cursor` is `None`.
         """
@@ -332,7 +332,7 @@ class Predictions(Namespace):
         Parameters:
             cursor: The cursor to use for pagination. Use the value of `Page.next` or `Page.previous`.
         Returns:
-            Page[Prediction]: A page of of predictions.
+            Page[Prediction]: A page of predictions.
         Raises:
             ValueError: If `cursor` is `None`.
         """


### PR DESCRIPTION
## Summary
- Removed a duplicated "of" in the `Returns:` docstrings of the sync and async `list()` methods across three resource namespaces (`Collections`, `Models`, `Predictions`).

## Change
- `replicate/collection.py`: "A page of of model collections." → "A page of model collections." (×2)
- `replicate/model.py`: "A page of of models." → "A page of models." (×2)
- `replicate/prediction.py`: "A page of of predictions." → "A page of predictions." (×2)

## Why this helps
- Fixes a clear documentation typo in the docstrings surfaced by `help()`/IDE tooling.
- Intentionally documentation-only, tiny (6 lines changed, all comment/docstring text).

## Test Plan
- [x] `python3 -m py_compile replicate/collection.py replicate/model.py replicate/prediction.py` passes
- [x] `git diff --check` clean
- [x] `grep -rn "page of of" replicate/` returns no matches
- [x] Commit signed off (`Signed-off-by`) per CONTRIBUTING.md
